### PR TITLE
Add nginx container in front of frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,20 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+
+  # front-web:
+  #   build: nginx
+  #   depends_on: [front]
+  #   environment:
+  #     APP_HOST: front
+  #     APP_NAME: front
+  #     APP_PORT: 9000
+  #     NGINX_LOG_LEVEL: info
+  #   ports:
+  #     - 8000:80
+  #   healthcheck:
+  #     test: curl -f http://localhost/nginx-health || exit 1
+  #     interval: 15s
+  #     timeout: 10s
+  #     retries: 3
+  #     start_period: 30s

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:alpine
+
+COPY default.conf.template /etc/nginx/templates/default.conf.template
+COPY nginx.conf /etc/nginx/nginx.conf
+
+ENV TIMEOUT=20
+RUN mkdir -p /var/www/public
+VOLUME ["/var/www/public"]

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -1,0 +1,68 @@
+server {
+    listen 80 default_server;
+    server_name ${APP_NAME};
+    root /var/www/public;
+    client_body_timeout 60s;
+    client_body_buffer_size 64M;
+    client_max_body_size 64M;
+    chunked_transfer_encoding off;
+    server_tokens off;
+
+    access_log  /dev/stdout  main;
+    error_log   /dev/stderr ${NGINX_LOG_LEVEL};
+
+    add_header Referrer-Policy same-origin;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
+    add_header X-Frame-Options "SAMEORIGIN";
+    add_header X-XSS-Protection "1; mode=block";
+    add_header X-Content-Type-Options nosniff;
+
+    # Simple health check for nginx containers
+    location /nginx-health {
+        return 200 "healthy\n";
+    }
+
+    location /clear-secret-cache {
+        try_files $uri /index.php$is_args$args;
+
+        allow 127.0.0.1;
+        deny all;
+    }
+
+    location / {
+        rewrite ^ /index.php last;
+    }
+
+    location ~ "\.(js|css|png|svg|ico)$" {
+        # try to serve file directly, fallback to index.php
+        try_files $uri /index.php$is_args$args;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    location ~ \.php$ {
+        fastcgi_pass   ${APP_HOST}:${APP_PORT};
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        include fastcgi_params;
+
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+        # set X-Request-Id header for fastcqi
+        fastcgi_param   HTTP_X_REQUEST_ID  $http_x_request_id;
+
+        # hide php version
+        fastcgi_hide_header "X-Powered-By";
+    }
+
+    if ($http_x_request_id = '') {
+        set $http_x_request_id $request_id;
+    }
+
+    # Comply with https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/#implementing-securitytxt
+    rewrite ^/.well_known/security.txt$ https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt permanent;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,50 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format main escape=json '{'
+                             '"timestamp_msec": "$msec", '
+                             '"remote_addr": "$remote_addr", '
+                             '"real_ip": "$http_x_real_ip", '
+                             '"real_forwarded_for": "$http_x_forwarded_for", '
+                             '"real_forwarded_proto": "$http_x_forwarded_proto", '
+                             '"request_id": "$http_x_request_id", '
+                             '"remote_user": "$remote_user", '
+                             '"request_time": $request_time, '
+                             '"request_uri": "$request_uri", '
+                             '"status": $status, '
+                             '"request": "$request", '
+                             '"request_method": "$request_method", '
+                             '"http_referrer": "$http_referer", '
+                             '"http_user_agent": "$http_user_agent", '
+                             '"bytes_sent": $bytes_sent, '
+                             '"http_host": "$host", '
+                             '"sent_http_location": "$sent_http_location", '
+                             '"server_name": "$server_name", '
+                             '"server_port": "$server_port", '
+                             '"upstream_addr": "$upstream_addr", '
+                             '"upstream_response_length": "$upstream_response_length", '
+                             '"upstream_response_time": "$upstream_response_time", '
+                             '"upstream_status": "$upstream_status" '
+                             '}';
+
+    access_log  /var/log/nginx/access.log  main;
+    server_tokens off;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
# Purpose

Provides a nginx container so that PHP containers can run on FPM.

## Approach

Config copied across from opg-sirius: a reusable nginx image with sensible security headers and logging built in, which is mapped to port 8000.

We should probably switch to the shared `311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/nginx` image at some point.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * N/A
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
