### PR TITLE
Add auth listener to front end

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,18 @@
 version: "3.7"
 
 services:
+  sirius-mock:
+    image: stoplight/prism:5
+    command: mock -h 0.0.0.0 -p 4010 -d /tmp/openapi.yml
+    healthcheck:
+      test: wget -O /dev/null -S 'http://localhost:4010/health-check' 2>&1 | grep 'HTTP/1.1 200 OK' || exit 1
+      interval: 15s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    volumes:
+      - ./docker/sirius/openapi.yml:/tmp/openapi.yml
+
   api:
     image: paper-identity/api
     build:
@@ -45,6 +57,11 @@ services:
       dockerfile: Dockerfile
     depends_on:
       - api-web
+      - sirius-mock
+    environment:
+      - API_BASE_URI=http://api-web
+      - SIRIUS_BASE_URL=http://sirius-mock:4010 # http://host.docker.internal:8080 for real Sirius
+      - SIRIUS_LOGIN_URL=http://localhost:8080
     healthcheck:
       test: SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:8000
       interval: 15s
@@ -55,8 +72,6 @@ services:
       - ./service-front:/var/www
       - ./service-front/config/development.config.php.dist:/var/www/config/development.config.php
       - static-content:/var/www/public
-    environment:
-      - SIRIUS_BASE_URI=http://api-web
 
   front-test:
     image: paper-identity/front-test

--- a/docker/sirius/openapi.yml
+++ b/docker/sirius/openapi.yml
@@ -1,0 +1,27 @@
+openapi: 3.0.0
+info:
+  title: Notifications API
+  description: Backwards engineered and limited to what we need to mock; deprecate if notifications provide an api spec
+  version: 0.1.0
+servers:
+  - url: http://localhost:4010
+    description: Local Prism server
+paths:
+  /api/v1/users/current:
+    get:
+      summary: Get current user
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '401':
+          description: Error
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id: int

--- a/docs/architecture/decisions/0002-authentication-via-sirius.md
+++ b/docs/architecture/decisions/0002-authentication-via-sirius.md
@@ -1,0 +1,19 @@
+# 1. Authentication via Sirius
+
+Date: 2024-03-13
+
+## Status
+
+Accepted
+
+## Context
+
+Users need to authenticate to access this service, using the same authentication requirements as they do for [Sirius](https://github.com/ministryofjustice/opg-sirius/). Authentication should be transparent: by clicking through to the Paper ID service from Sirius, they will immediately be logged in. If not authenticated with Sirius, or their authentication expires, they will not be able to access the Paper ID service.
+
+## Decision
+
+The Paper ID service will be hosted on the same domain as Sirius, so will have access to the authentication cookie that Sirius sets. The Paper ID service will use that cookie to make a request to the Sirius API to check that it returns a 200 response.
+
+## Consequences
+
+This puts a strict dependency on the Sirius API in order to access Paper ID. It will also result in lots of calls to the Sirius API: if this becomes a high load we could cache a successful authentication in session so it's confirmed less frequently.

--- a/service-front/module/Application/config/module.config.php
+++ b/service-front/module/Application/config/module.config.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace Application;
 
+use Application\Auth\Listener as AuthListener;
+use Application\Auth\ListenerFactory as AuthListenerFactory;
 use Application\Factories\OpgApiServiceFactory;
+use Application\Factories\SiriusApiServiceFactory;
 use Application\Services\OpgApiService;
+use Application\Services\SiriusApiService;
 use Application\Views\TwigExtension;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Segment;
@@ -61,6 +65,9 @@ return [
             Controller\IndexController::class => LazyControllerAbstractFactory::class,
         ],
     ],
+    'listeners' => [
+        AuthListener::class
+    ],
     'view_manager' => [
         'display_not_found_reason' => true,
         'display_exceptions'       => true,
@@ -85,7 +92,9 @@ return [
             TwigExtension::class => TwigExtension::class,
         ],
         'factories' => [
+            AuthListener::class => AuthListenerFactory::class,
             OpgApiService::class => OpgApiServiceFactory::class,
+            SiriusApiService::class => SiriusApiServiceFactory::class,
         ],
     ],
     'zend_twig'       => [

--- a/service-front/module/Application/src/Auth/Listener.php
+++ b/service-front/module/Application/src/Auth/Listener.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Auth;
+
+use Application\Services\SiriusApiService;
+use Laminas\EventManager\AbstractListenerAggregate;
+use Laminas\EventManager\EventManagerInterface;
+use Laminas\Http\Response;
+use Laminas\Mvc\MvcEvent;
+
+class Listener extends AbstractListenerAggregate
+{
+    public function __construct(
+        private readonly SiriusApiService $siriusApi,
+        private readonly string $loginUrl,
+    ) {
+    }
+
+    /**
+     * @param int $priority
+     */
+    public function attach(EventManagerInterface $events, $priority = -200): void
+    {
+        if (getenv('DISABLE_AUTH_LISTENER') === "1") {
+            return;
+        }
+
+        $this->listeners[] = $events->attach(
+            MvcEvent::EVENT_ROUTE,
+            [$this, 'checkAuth'],
+            $priority
+        );
+    }
+
+    public function checkAuth(MvcEvent $e): ?Response
+    {
+        /** @var Response $response */
+        $response = $e->getResponse();
+
+        if (! $this->siriusApi->checkAuth($e->getRequest())) {
+            $response->setContent('unauthorised, please login at ' . $this->loginUrl);
+            $response->getHeaders()->addHeaderLine("Location: " . $this->loginUrl);
+            $response->setStatusCode(Response::STATUS_CODE_302);
+            return $response;
+        }
+
+        return null;
+    }
+}

--- a/service-front/module/Application/src/Auth/ListenerFactory.php
+++ b/service-front/module/Application/src/Auth/ListenerFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Auth;
+
+use Application\Services\SiriusApiService;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+
+class ListenerFactory implements FactoryInterface
+{
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        array $options = null
+    ) {
+        $siriusLoginUrl = getenv("SIRIUS_LOGIN_URL");
+
+        return new Listener(
+            $container->get(SiriusApiService::class),
+            $siriusLoginUrl === false ? "" : $siriusLoginUrl,
+        );
+    }
+}

--- a/service-front/module/Application/src/Factories/SiriusApiServiceFactory.php
+++ b/service-front/module/Application/src/Factories/SiriusApiServiceFactory.php
@@ -4,28 +4,30 @@ declare(strict_types=1);
 
 namespace Application\Factories;
 
+use Application\Services\SiriusApiService;
 use GuzzleHttp\Client;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
-use Application\Services\OpgApiService;
 use RuntimeException;
 
-class OpgApiServiceFactory implements FactoryInterface
+class SiriusApiServiceFactory implements FactoryInterface
 {
     /**
      * @param ContainerInterface $container
      * @param string                          $requestedName
      * @param array<mixed>|null               $options
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): OpgApiService
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): SiriusApiService
     {
-        $baseUri = getenv("API_BASE_URI");
+        $baseUri = getenv("SIRIUS_BASE_URL");
         if (! is_string($baseUri) || empty($baseUri)) {
-            throw new RuntimeException("API_BASE_URI is empty");
+            throw new RuntimeException("SIRIUS_BASE_URL is empty");
         }
 
-        $guzzleClient = new Client(['base_uri' => $baseUri]);
+        $client = new Client(['base_uri' => $baseUri]);
 
-        return new OpgApiService($guzzleClient);
+        return new SiriusApiService(
+            $client
+        );
     }
 }

--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Laminas\Http\Header\Cookie;
+use Laminas\Http\Request;
+use Laminas\Stdlib\RequestInterface;
+
+class SiriusApiService
+{
+    public function __construct(
+        public readonly Client $client
+    ) {
+    }
+
+    public function checkAuth(RequestInterface $request): bool
+    {
+        if (! ($request instanceof Request)) {
+            return false;
+        }
+
+        $cookieHeader = $request->getHeader('Cookie');
+
+        if (! ($cookieHeader instanceof Cookie)) {
+            return false;
+        }
+
+        try {
+            $this->client->get('/api/v1/users/current', [
+                'headers' => [
+                    'Cookie' => $cookieHeader->getFieldValue(),
+                ],
+            ]);
+        } catch (GuzzleException $e) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/service-front/module/Application/test/Auth/ListenerTest.php
+++ b/service-front/module/Application/test/Auth/ListenerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Auth;
+
+use Application\Auth\Listener;
+use Application\Services\SiriusApiService;
+use Laminas\Http\Header\Location;
+use Laminas\Http\Request;
+use Laminas\Http\Response;
+use Laminas\Mvc\MvcEvent;
+use Laminas\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
+
+class ListenerTest extends AbstractHttpControllerTestCase
+{
+    public function testCheckAuthSuccess(): void
+    {
+        $siriusApiMock = $this->createMock(SiriusApiService::class);
+
+        $sut = new Listener($siriusApiMock, "login-url");
+
+        $event = $this->createMock(MvcEvent::class);
+
+        $request = new Request();
+
+        $event->expects($this->once())->method("getRequest")->willReturn($request);
+
+        $siriusApiMock->expects($this->once())
+            ->method("checkAuth")
+            ->with($request)
+            ->willReturn(true);
+
+        $ret = $sut->checkAuth($event);
+
+        $this->assertNull($ret);
+    }
+
+    public function testCheckAuthFailure(): void
+    {
+        $siriusApiMock = $this->createMock(SiriusApiService::class);
+
+        $sut = new Listener($siriusApiMock, "http://login-url");
+
+        $event = $this->createMock(MvcEvent::class);
+
+        $request = new Request();
+        $event->expects($this->once())->method("getRequest")->willReturn($request);
+
+        $event->expects($this->once())->method("getResponse")->willReturn(new Response());
+
+        $siriusApiMock->expects($this->once())
+            ->method("checkAuth")
+            ->with($request)
+            ->willReturn(false);
+
+        $response = $sut->checkAuth($event);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(302, $response->getStatusCode());
+        $location = $response->getHeaders()->get('Location');
+        assert($location instanceof Location);
+        $this->assertEquals("http://login-url", $location->getFieldValue());
+    }
+}

--- a/service-front/module/Application/test/Services/SiriusApiServiceTest.php
+++ b/service-front/module/Application/test/Services/SiriusApiServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Services;
+
+use GuzzleHttp\Client;
+use Application\Services\SiriusApiService;
+use GuzzleHttp\Exception\GuzzleException;
+use Laminas\Http\Headers;
+use Laminas\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @psalm-suppress DeprecatedMethod
+ * False positive with `GuzzleHttp\Client::__call` being deprecated
+ * Supression can be removed when Guzzle 8 is released as it removes the method
+ */
+class SiriusApiServiceTest extends TestCase
+{
+    public function testCheckAuthSuccess(): void
+    {
+        $clientMock = $this->createMock(Client::class);
+
+        $sut = new SiriusApiService($clientMock);
+
+        $request = new Request();
+        $headers = $request->getHeaders();
+        assert($headers instanceof Headers);
+        $headers->addHeaderLine("cookie", "mycookie=1");
+
+        $clientMock
+            ->expects($this->once())
+            ->method("get")
+            ->with("/api/v1/users/current", ['headers' => ['Cookie' => 'mycookie=1']]);
+
+        $ret = $sut->checkAuth($request);
+        $this->assertTrue($ret);
+    }
+
+    public function testCheckAuthFailureNoCookie(): void
+    {
+        $clientMock = $this->createMock(Client::class);
+
+        $sut = new SiriusApiService($clientMock);
+
+        $request = new Request();
+        $headers = $request->getHeaders();
+        assert($headers instanceof Headers);
+
+        $ret = $sut->checkAuth($request);
+        $this->assertFalse($ret);
+    }
+
+    public function testCheckAuthFailureNotAuthed(): void
+    {
+        $clientMock = $this->createMock(Client::class);
+
+        $sut = new SiriusApiService($clientMock);
+
+        $request = new Request();
+        $headers = $request->getHeaders();
+        assert($headers instanceof Headers);
+        $headers->addHeaderLine("cookie", "mycookie=1");
+
+        $exception = $this->createMock(GuzzleException::class);
+
+        $clientMock
+            ->expects($this->once())
+            ->method("get")
+            ->with("/api/v1/users/current", ['headers' => ['Cookie' => 'mycookie=1']])
+            ->willThrowException($exception);
+
+        $ret = $sut->checkAuth($request);
+        $this->assertFalse($ret);
+    }
+}

--- a/service-front/phpunit.xml
+++ b/service-front/phpunit.xml
@@ -23,4 +23,11 @@
             <directory>./module/*/test</directory>
         </testsuite>
     </testsuites>
+
+    <php>
+        <env name="API_BASE_URI" value="API_BASE_URI" />
+        <env name="SIRIUS_BASE_URL" value="SIRIUS_BASE_URL" />
+        <env name="SIRIUS_LOGIN_URL" value="SIRIUS_LOGIN_URL" />
+        <env name="DISABLE_AUTH_LISTENER" value="1"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
# Purpose

Ensures user is authenticated with Sirius on each request.

Fixes ID-31 #minor

## Approach

In local development, Sirius is replaced by a mock server that always returns 200.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
