### PR TITLE
Run front PHPUnit tests in CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
             test_command: "make api-unit-test"
           - service_name: "front"
             image_app_name: "paper-identity/front"
-            test_command: "ls -l"
+            test_command: "make front-unit-test"
     # we use these a few times, so its easier to generate them once and env
     # vars are visible in the output, so helps with debug
     env:

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ down: ## Stop application
 
 api-unit-test:
 	docker compose run --rm api-test vendor/bin/phpunit
+
+front-unit-test:
+	docker compose run --rm front-test vendor/bin/phpunit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,19 @@ services:
       - ./service-front/config/development.config.php.dist:/var/www/config/development.config.php
       - static-content:/var/www/public
 
+  front-test:
+    image: paper-identity/front-test
+    build:
+      context: service-front
+      dockerfile: Dockerfile
+      target: development
+    healthcheck:
+      test: SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:8000
+      interval: 15s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
   api-web:
       build: nginx
       depends_on: [api]

--- a/service-front/Dockerfile
+++ b/service-front/Dockerfile
@@ -65,7 +65,8 @@ USER "www-data"
 RUN composer install --prefer-dist --no-interaction --no-scripts &&\
 composer dumpautoload -o
 
-COPY tests tests
-COPY phpstan.neon phpstan.neon
+COPY phpcs.xml phpcs.xml
+COPY phpunit.xml.dist phpunit.xml
+COPY psalm.xml psalm.xml
 
 FROM app AS production


### PR DESCRIPTION
# Purpose

To ensure tests are run and protect against regressions.

#minor

Fixes ID-49

## Approach

Create a `front-test` image, copy the right files onto it, and run PHPUnit in the pipeline

## Checklist

* [x] I have performed a self-review of my own code
