### PR TITLE
Refer to correct containers in startup/dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build: ## Build containers
 	docker compose build --parallel api front api-test
 
 up: ## Start application
-	docker compose up -d front
+	docker compose up -d front-web
 
 down: ## Stop application
 	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       context: service-front
       dockerfile: Dockerfile
     depends_on:
-      - api
+      - api-web
     healthcheck:
       test: SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:8000
       interval: 15s


### PR DESCRIPTION
In both cases, the `-web` container is needed because they need to be interactable over HTTP.

#patch
