### PR TITLE
Add logger, auto-log response exceptions

### DIFF
--- a/service-api/composer.json
+++ b/service-api/composer.json
@@ -19,7 +19,8 @@
         "laminas/laminas-component-installer": "^3.4.0",
         "laminas/laminas-development-mode": "^3.12.0",
         "laminas/laminas-mvc": "^3.7.0",
-        "laminas/laminas-skeleton-installer": "^1.3.0"
+        "laminas/laminas-skeleton-installer": "^1.3.0",
+        "monolog/monolog": "^3.5"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",

--- a/service-api/composer.lock
+++ b/service-api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "098b24e437aee9c9baff9862ccacbd2f",
+    "content-hash": "e1fcd7a46675b9ea86d03a815f9db5ec",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -1381,6 +1381,107 @@
             "time": "2023-11-24T13:56:19+00:00"
         },
         {
+            "name": "monolog/monolog",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "c915e2634718dbc8a4a15c61b0e62e7a44e14448"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c915e2634718dbc8a4a15c61b0e62e7a44e14448",
+                "reference": "c915e2634718dbc8a4a15c61b0e62e7a44e14448",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "predis/predis": "^1.1 || ^2",
+                "ruflin/elastica": "^7",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-10-27T15:32:31+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v4.18.0",
             "source": {
@@ -1536,6 +1637,56 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
+            },
+            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "webimpress/safe-writer",
@@ -3437,56 +3588,6 @@
                 "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.18.4"
             },
             "time": "2022-12-03T07:47:07+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
-            },
-            "time": "2021-07-14T16:46:02+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/service-api/module/Application/config/module.config.php
+++ b/service-api/module/Application/config/module.config.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Application;
 
+use Application\Factories\LoggerFactory;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Segment;
 use Laminas\ServiceManager\Factory\InvokableFactory;
+use Psr\Log\LoggerInterface;
 
 return [
     'router' => [
@@ -77,6 +79,11 @@ return [
         'factories' => [
             Controller\IndexController::class => InvokableFactory::class,
             Controller\IdentityController::class => InvokableFactory::class
+        ],
+    ],
+    'service_manager' => [
+        'factories' => [
+            LoggerInterface::class => LoggerFactory::class,
         ],
     ],
 

--- a/service-api/module/Application/src/Factories/LoggerFactory.php
+++ b/service-api/module/Application/src/Factories/LoggerFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Factories;
+
+use Application\Services\Logging\OpgFormatter;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+class LoggerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string                          $requestedName
+     * @param array<mixed>|null               $options
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LoggerInterface
+    {
+        $streamHandler = new StreamHandler('php://stderr', LogLevel::INFO);
+        $streamHandler->setFormatter(new OpgFormatter());
+
+        return new Logger('opg-paper-identity/api', [$streamHandler]);
+    }
+}

--- a/service-api/module/Application/src/Module.php
+++ b/service-api/module/Application/src/Module.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Application;
 
 use Laminas\Mvc\MvcEvent;
+use Psr\Log\LoggerInterface;
+use Throwable;
 
 class Module
 {
@@ -13,5 +15,27 @@ class Module
         /** @var array $config */
         $config = include __DIR__ . '/../config/module.config.php';
         return $config;
+    }
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod
+     * This is called auto-magically by the Laminas framework
+     */
+    public function onBootstrap(MvcEvent $event): void
+    {
+        $eventManager = $event->getApplication()->getEventManager();
+        $eventManager->attach(MvcEvent::EVENT_FINISH, [$this, 'onFinish']);
+    }
+
+    public function onFinish(MvcEvent $event): void
+    {
+        // If an exception was thrown, log it
+        $exception = $event->getParam('exception');
+        if ($exception instanceof Throwable) {
+            $serviceManager = $event->getApplication()->getServiceManager();
+            $logger = $serviceManager->get(LoggerInterface::class);
+
+            $logger->error("an unexpected error occurred", ['exception' => $exception]);
+        }
     }
 }

--- a/service-api/module/Application/src/Services/Logging/OpgFormatter.php
+++ b/service-api/module/Application/src/Services/Logging/OpgFormatter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Services\Logging;
+
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\LogRecord;
+
+class OpgFormatter extends NormalizerFormatter
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function format(LogRecord $record): string
+    {
+        $original = parent::format($record);
+
+        $record = [
+            'time' => $original['datetime'],
+            'level' => $original['level_name'],
+            'msg' => $original['message'],
+            'service_name' => $original['channel'],
+        ];
+
+        unset($original['datetime']);
+        unset($original['level_name']);
+        unset($original['message']);
+        unset($original['channel']);
+
+        return $this->toJson(array_filter($record + $original)) . "\n";
+    }
+}

--- a/service-api/psalm.xml
+++ b/service-api/psalm.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    errorLevel="1"
+    errorLevel="2"
     findUnusedPsalmSuppress="true"
     findUnusedCode="true"
     findUnusedBaselineEntry="true"

--- a/service-front/composer.json
+++ b/service-front/composer.json
@@ -24,6 +24,7 @@
         "laminas/laminas-mvc-plugins": "^1.2.0",
         "laminas/laminas-session": "^2.16.0",
         "laminas/laminas-skeleton-installer": "^1.3.0",
+        "monolog/monolog": "^3.5",
         "oxcom/zend-twig": "^1.1"
     },
     "require-dev": {

--- a/service-front/composer.lock
+++ b/service-front/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68898ef66cf3b75e5f9ab272edd2eb81",
+    "content-hash": "aa267084941c1d545a27d867ba3b0403",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -3245,6 +3245,107 @@
                 }
             ],
             "time": "2024-01-25T11:26:39+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "c915e2634718dbc8a4a15c61b0e62e7a44e14448"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/c915e2634718dbc8a4a15c61b0e62e7a44e14448",
+                "reference": "c915e2634718dbc8a4a15c61b0e62e7a44e14448",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "phpstan/phpstan": "^1.9",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.4",
+                "phpunit/phpunit": "^10.1",
+                "predis/predis": "^1.1 || ^2",
+                "ruflin/elastica": "^7",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-10-27T15:32:31+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/service-front/module/Application/config/module.config.php
+++ b/service-front/module/Application/config/module.config.php
@@ -6,6 +6,7 @@ namespace Application;
 
 use Application\Auth\Listener as AuthListener;
 use Application\Auth\ListenerFactory as AuthListenerFactory;
+use Application\Factories\LoggerFactory;
 use Application\Factories\OpgApiServiceFactory;
 use Application\Factories\SiriusApiServiceFactory;
 use Application\Services\OpgApiService;
@@ -14,6 +15,7 @@ use Application\Views\TwigExtension;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Segment;
 use Laminas\Mvc\Controller\LazyControllerAbstractFactory;
+use Psr\Log\LoggerInterface;
 
 return [
     'router' => [
@@ -95,6 +97,7 @@ return [
             AuthListener::class => AuthListenerFactory::class,
             OpgApiService::class => OpgApiServiceFactory::class,
             SiriusApiService::class => SiriusApiServiceFactory::class,
+            LoggerInterface::class => LoggerFactory::class,
         ],
     ],
     'zend_twig'       => [

--- a/service-front/module/Application/src/Factories/LoggerFactory.php
+++ b/service-front/module/Application/src/Factories/LoggerFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Factories;
+
+use Application\Services\Logging\OpgFormatter;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+
+class LoggerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string                          $requestedName
+     * @param array<mixed>|null               $options
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LoggerInterface
+    {
+        $streamHandler = new StreamHandler('php://stderr', LogLevel::INFO);
+        $streamHandler->setFormatter(new OpgFormatter());
+
+        return new Logger('opg-paper-identity/front', [$streamHandler]);
+    }
+}

--- a/service-front/module/Application/src/Module.php
+++ b/service-front/module/Application/src/Module.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Application;
 
+use Laminas\Mvc\MvcEvent;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
 class Module
 {
     public function getConfig(): array
@@ -11,5 +15,27 @@ class Module
         /** @var array $config */
         $config = include __DIR__ . '/../config/module.config.php';
         return $config;
+    }
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod
+     * This is called auto-magically by the Laminas framework
+     */
+    public function onBootstrap(MvcEvent $event): void
+    {
+        $eventManager = $event->getApplication()->getEventManager();
+        $eventManager->attach(MvcEvent::EVENT_FINISH, [$this, 'onFinish']);
+    }
+
+    public function onFinish(MvcEvent $event): void
+    {
+        // If an exception was thrown, log it
+        $exception = $event->getParam('exception');
+        if ($exception instanceof Throwable) {
+            $serviceManager = $event->getApplication()->getServiceManager();
+            $logger = $serviceManager->get(LoggerInterface::class);
+
+            $logger->error("an unexpected error occurred", ['exception' => $exception]);
+        }
     }
 }

--- a/service-front/module/Application/src/Services/Logging/OpgFormatter.php
+++ b/service-front/module/Application/src/Services/Logging/OpgFormatter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Services\Logging;
+
+use Monolog\Formatter\NormalizerFormatter;
+use Monolog\LogRecord;
+
+class OpgFormatter extends NormalizerFormatter
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function format(LogRecord $record): string
+    {
+        $original = parent::format($record);
+
+        $record = [
+            'time' => $original['datetime'],
+            'level' => $original['level_name'],
+            'msg' => $original['message'],
+            'service_name' => $original['channel'],
+        ];
+
+        unset($original['datetime']);
+        unset($original['level_name']);
+        unset($original['message']);
+        unset($original['channel']);
+
+        return $this->toJson(array_filter($record + $original)) . "\n";
+    }
+}


### PR DESCRIPTION
# Purpose

If an exception is thrown in the controller it is absorbed and an error template is shown. Since we don't want to show the details of the error in the user-facing template, we need to explicitly log it during the EVENT_FINISH event.

Fixes ID-65 #minor

## Approach

Sets up monolog with standard OPG logging output under the hood, but can just be fetched as LoggerInterface anywhere in code.

Duplication due to setting this up in both API and Frontend.

## Learning

I didn't realise Laminas so aggressively swallowed errors.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * N/A
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
