### PR TITLE
Add error handling response in API

### DIFF
--- a/service-api/module/Application/config/module.config.php
+++ b/service-api/module/Application/config/module.config.php
@@ -88,6 +88,11 @@ return [
     ],
 
     'view_manager' => [
+        'template_map'             => [
+            'layout/layout'           => __DIR__ . '/../view/layout/layout.phtml',
+            '404'                     => __DIR__ . '/../view/error/error.json',
+            'error'                   => __DIR__ . '/../view/error/error.json',
+        ],
         'strategies' => [
             'ViewJsonStrategy',
         ],

--- a/service-api/module/Application/src/Module.php
+++ b/service-api/module/Application/src/Module.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application;
 
+use Laminas\Http\Response;
 use Laminas\Mvc\MvcEvent;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -24,18 +25,37 @@ class Module
     public function onBootstrap(MvcEvent $event): void
     {
         $eventManager = $event->getApplication()->getEventManager();
-        $eventManager->attach(MvcEvent::EVENT_FINISH, [$this, 'onFinish']);
+        $eventManager->attach(MvcEvent::EVENT_FINISH, [$this, 'onFinish'], 1000000);
     }
 
     public function onFinish(MvcEvent $event): void
     {
-        // If an exception was thrown, log it
-        $exception = $event->getParam('exception');
-        if ($exception instanceof Throwable) {
-            $serviceManager = $event->getApplication()->getServiceManager();
-            $logger = $serviceManager->get(LoggerInterface::class);
+        /** @var Response */
+        $response = $event->getResponse();
 
-            $logger->error("an unexpected error occurred", ['exception' => $exception]);
+        if ($response->getStatusCode() >= 400) {
+            $exception = $event->getParam('exception');
+            $problem = [
+                'status' => $response->getStatusCode(),
+            ];
+
+            if ($exception instanceof Throwable) {
+                $serviceManager = $event->getApplication()->getServiceManager();
+                $logger = $serviceManager->get(LoggerInterface::class);
+
+                $logger->error("an unexpected error occurred", ['exception' => $exception]);
+
+                $problem['type'] = 'UnexpectedError';
+                $problem['title'] = "An unexpected error occurred";
+                $problem['detail'] = $exception->getMessage();
+                $problem['exception'] = $exception::class;
+            } else {
+                $problem['type'] = 'HTTP' . $response->getStatusCode();
+                $problem['title'] = $response->getReasonPhrase();
+            }
+
+            $response->getHeaders()->addHeaderLine('content-type', 'application/json');
+            $response->setContent(json_encode($problem));
         }
     }
 }

--- a/service-api/module/Application/view/error/error.json
+++ b/service-api/module/Application/view/error/error.json
@@ -1,0 +1,1 @@
+{"type": "UnexpectedError", "title": "An unexpected error occurred", "status": 500, "detail": "<?= $this->message ?>"}

--- a/service-api/module/Application/view/layout/layout.phtml
+++ b/service-api/module/Application/view/layout/layout.phtml
@@ -1,0 +1,1 @@
+<?= $this->content;


### PR DESCRIPTION
# Purpose

Ensure we show proper JSON responses for API errors.

#minor

## Approach

Laminas needs a template to fall back to, so we set up a basic JSON response as a final backstop.

Also adapt the logic in `Module.php` so that it catches unsuccessful responses and returns a proper JSON error with more information.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
