### PR TITLE
Alter JUnit files to support annotations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ permissions:
   contents: write
   security-events: write
   checks: write
-  pull-requests: write
 
 jobs:
   test:
@@ -39,11 +38,15 @@ jobs:
       - name: Run Tests
         run: |
           make ${{ matrix.service }}-${{ matrix.suite }}
+      - name: Clean JUnit output
+        if: always()
+        run: |
+          make -i clean-junit-output
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           comment_mode: off
           files: service-${{ matrix.service }}/build/*.xml
-          test_file_prefix: +service-${{ matrix.service }}
+          test_file_prefix: +service-${{ matrix.service }}/
           check_name: ${{ matrix.service }} ${{ matrix.suite }} tests

--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,11 @@ api-test:
 
 front-test:
 	@${MAKE} front-psalm front-phpcs front-unit-test -j 3
+
+clean-junit-output:
+	sed -i 's/file="\/var\/www\//file="/g' ./service-api/build/phpunit-junit.xml
+	sed -i 's/file="\/var\/www\//file="/g' ./service-front/build/phpunit-junit.xml
+	sed -i -E 's/testcase name="(.*?)\/var\/www\/([^ ]+?)( \(([0-9]+):[0-9]+\))?"/& file="\2" line="\4"/g' ./service-api/build/phpcs-junit.xml
+	sed -i -E 's/testcase name="(.*?)\/var\/www\/([^ ]+?)( \(([0-9]+):[0-9]+\))?"/& file="\2" line="\4"/g' ./service-front/build/phpcs-junit.xml
+	sed -i -E 's/testcase name="(.*?):([0-9]+)"/& file="\1" line="\2"/g' ./service-api/build/psalm-junit.xml
+	sed -i -E 's/testcase name="(.*?):([0-9]+)"/& file="\1" line="\2"/g' ./service-front/build/psalm-junit.xml


### PR DESCRIPTION
# Purpose

Each of our JUnit files uses a difference output format for the file name and line, none of which match the `EnricoMi/publish-unit-test-result-action` action we use to publish the results of tests.

Fixes ID-67 #patch

<details>
<summary>Demo</summary>

![Code changes in pull request, with annotations where linting has failed](https://github.com/ministryofjustice/opg-paper-identity/assets/100852/2e66cf80-90d3-4f7e-9318-6e6b3cb65fa9)

</details>

## Approach

Add some quick `sed` scripts to manipulate the files and get them into the correct format.

See #50 for an example of annotations in action

## Learning

I was surprised JUnit was more standardised for this!
