### PR TITLE
Update Sirius mock API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,30 +1,30 @@
 ---
-version: "3.7"
 
 services:
   sirius-mock:
-    image: outofcoffee/imposter
+    image: stoplight/prism:5
+    command: mock -h 0.0.0.0 -p 4010 -d /tmp/openapi.yml
     restart: unless-stopped
     healthcheck:
-      test: wget -O /dev/null -S 'http://localhost:8080/api/v1/users/current' 2>&1 | grep 'HTTP/1.1 200 OK' || exit 1
+      test: wget -O /dev/null -S 'http://0.0.0.0:4010/api/v1/users/current' 2>&1 | grep 'HTTP/1.1 200 OK' || exit 1
       interval: 15s
       timeout: 10s
       retries: 3
-      start_period: 30s
     volumes:
-      - ./docker/sirius:/opt/imposter/config
+      - "./docker/sirius/openapi.yml:/tmp/openapi.yml"
 
   yoti-mock:
     image: outofcoffee/imposter
     restart: unless-stopped
     healthcheck:
-      test: wget -O /dev/null -S 'http://localhost:8002/idverify/v1/sessions/X' 2>&1 | grep 'HTTP/1.1 200 OK' || exit 1
+      test: ["CMD", "imposter", "list", "-x"]
       interval: 15s
       timeout: 10s
       retries: 3
-      start_period: 30s
     volumes:
       - ./docker/yoti:/opt/imposter/config
+    ports:
+      - 8334:8080
 
   api:
     image: paper-identity/api
@@ -42,7 +42,6 @@ services:
       interval: 15s
       timeout: 10s
       retries: 3
-      start_period: 30s
     volumes:
       - ./service-api:/var/www
       - ./service-api/config/development.config.php.dist:/var/www/config/development.config.php
@@ -82,7 +81,7 @@ services:
       - sirius-mock
     environment:
       - API_BASE_URI=http://api-web
-      - SIRIUS_BASE_URL=http://sirius-mock:8080 # http://host.docker.internal:8080 for real Sirius
+      - SIRIUS_BASE_URL=http://sirius-mock:4010 # http://host.docker.internal:8080 for real Sirius
       - SIRIUS_LOGIN_URL=http://localhost:8080
     healthcheck:
       test: SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:8000

--- a/docker/sirius/openapi.yml
+++ b/docker/sirius/openapi.yml
@@ -36,13 +36,13 @@ paths:
     get:
       summary: Get an LPA
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CombinedLpa'
-        '401':
+                $ref: "#/components/schemas/CombinedLpa"
+        "401":
           description: Error
 components:
   schemas:
@@ -62,7 +62,9 @@ components:
           $ref: "#/components/schemas/DigitalLpa"
         opg.poas.lpastore:
           oneOf:
-            - $ref: https://raw.githubusercontent.com/ministryofjustice/opg-data-lpa-store/main/docs/schemas/2024-04/lpa.json
+            - allOf:
+                - $ref: https://raw.githubusercontent.com/ministryofjustice/opg-data-lpa-store/main/docs/schemas/2024-10/lpa.json
+                - $ref: "#/components/schemas/LpaWithPostcodes"
             - null
       additionalProperties: false
     DigitalLpa:
@@ -77,3 +79,20 @@ components:
           type: string
           pattern: "M(-[0-9A-Z]{4}){3}"
           example: M-789Q-P4DF-4UX3
+    LpaWithPostcodes:
+      type: object
+      properties:
+        donor:
+          type: object
+          properties:
+            address:
+              type: object
+              required:
+                - postcode
+        certificateProvider:
+          type: object
+          properties:
+            address:
+              type: object
+              required:
+                - postcode


### PR DESCRIPTION
# Purpose

- Use Prism so that it can pull in mocks properly
- Point to 2024-10 version of LPA spec
- Force mock LPA responses to return postcodes (for ID-103)
- Fix the healthcheck for the Yoti mock (it doesn't have wget)

#patch

## Approach

As above. Some changes taken from #73 

## Learning

I didn't realise imposter didn't have access to wget, but their CLI command is quite helpful.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
