### PR TITLE
Include a backlink when redirecting to auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     environment:
       - API_BASE_URI=http://api-web
       - SIRIUS_BASE_URL=http://sirius-mock:4010 # http://host.docker.internal:8080 for real Sirius
-      - SIRIUS_LOGIN_URL=http://localhost:8080
+      - SIRIUS_PUBLIC_URL=http://localhost:8080
     healthcheck:
       test: SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000
       interval: 15s

--- a/service-front/module/Application/src/Auth/Listener.php
+++ b/service-front/module/Application/src/Auth/Listener.php
@@ -7,8 +7,10 @@ namespace Application\Auth;
 use Application\Services\SiriusApiService;
 use Laminas\EventManager\AbstractListenerAggregate;
 use Laminas\EventManager\EventManagerInterface;
+use Laminas\Http\Request;
 use Laminas\Http\Response;
 use Laminas\Mvc\MvcEvent;
+use Laminas\Uri\Uri;
 
 class Listener extends AbstractListenerAggregate
 {
@@ -39,13 +41,34 @@ class Listener extends AbstractListenerAggregate
         /** @var Response $response */
         $response = $e->getResponse();
 
-        if (! $this->siriusApi->checkAuth($e->getRequest())) {
+        /** @var Request $request */
+        $request = $e->getRequest();
+
+        if (! $this->siriusApi->checkAuth($request)) {
+            $redirect = $this->getRedirect($request);
+            $location = sprintf("Location: %s/auth?redirect=%s", $this->loginUrl, urlencode($redirect));
+
             $response->setContent('unauthorised, please login at ' . $this->loginUrl);
-            $response->getHeaders()->addHeaderLine("Location: " . $this->loginUrl);
+            $response->getHeaders()->addHeaderLine($location);
             $response->setStatusCode(Response::STATUS_CODE_302);
             return $response;
         }
 
         return null;
+    }
+
+    private function getRedirect(Request $request): string
+    {
+        $path = $request->getUri()->getPath();
+        if ($path === null) {
+            return '';
+        }
+
+        $query = $request->getUri()->getQuery();
+        if ($query === null) {
+            return $path;
+        }
+
+        return $path . '?' . Uri::encodeQueryFragment($query);
     }
 }

--- a/service-front/module/Application/src/Auth/ListenerFactory.php
+++ b/service-front/module/Application/src/Auth/ListenerFactory.php
@@ -15,7 +15,7 @@ class ListenerFactory implements FactoryInterface
         $requestedName,
         array $options = null
     ) {
-        $siriusLoginUrl = getenv("SIRIUS_LOGIN_URL");
+        $siriusLoginUrl = getenv("SIRIUS_PUBLIC_URL");
 
         return new Listener(
             $container->get(SiriusApiService::class),

--- a/service-front/module/Application/test/Auth/ListenerTest.php
+++ b/service-front/module/Application/test/Auth/ListenerTest.php
@@ -45,6 +45,7 @@ class ListenerTest extends AbstractHttpControllerTestCase
         $event = $this->createMock(MvcEvent::class);
 
         $request = new Request();
+        $request->setUri('http://somehost/my/page?type=somevalue');
         $event->expects($this->once())->method("getRequest")->willReturn($request);
 
         $event->expects($this->once())->method("getResponse")->willReturn(new Response());
@@ -60,6 +61,8 @@ class ListenerTest extends AbstractHttpControllerTestCase
         $this->assertEquals(302, $response->getStatusCode());
         $location = $response->getHeaders()->get('Location');
         assert($location instanceof Location);
-        $this->assertEquals("http://login-url", $location->getFieldValue());
+
+        $expectedUrl = "http://login-url/auth?redirect=%2Fmy%2Fpage%3Ftype%3Dsomevalue";
+        $this->assertEquals($expectedUrl, $location->getFieldValue());
     }
 }

--- a/service-front/phpunit.xml
+++ b/service-front/phpunit.xml
@@ -27,7 +27,7 @@
     <php>
         <env name="API_BASE_URI" value="API_BASE_URI" />
         <env name="SIRIUS_BASE_URL" value="SIRIUS_BASE_URL" />
-        <env name="SIRIUS_LOGIN_URL" value="SIRIUS_LOGIN_URL" />
+        <env name="SIRIUS_PUBLIC_URL" value="SIRIUS_PUBLIC_URL" />
         <env name="DISABLE_AUTH_LISTENER" value="1"/>
     </php>
 </phpunit>


### PR DESCRIPTION
# Purpose

Tells Sirius where to redirect back to if the authentication attempt is successful.

This ensures unauthed users will be taken to the page they navigated to, rather than being taken to the Sirius home page.

Fixes ID-142 #minor

## Approach

This is already built in to Sirius, so we just need to provide a `redirect` query parameter.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
