### PR TITLE
Show a 404 error page if the case isn't found

### DIFF
--- a/service-api/module/Application/src/Controller/IdentityController.php
+++ b/service-api/module/Application/src/Controller/IdentityController.php
@@ -84,7 +84,8 @@ class IdentityController extends AbstractActionController
             return new JsonModel($data[0]);
         }
 
-        return new JsonModel(['error' => 'Invalid uuid']);
+        $this->getResponse()->setStatusCode(Response::STATUS_CODE_404);
+        return new JsonModel(['error' => 'Case not found']);
     }
 
     public function findByNameAction(): JsonModel

--- a/service-api/module/Application/test/Controller/IdentityControllerTest.php
+++ b/service-api/module/Application/test/Controller/IdentityControllerTest.php
@@ -70,8 +70,25 @@ class IdentityControllerTest extends TestCase
 
     public function testDetailsWithUUID(): void
     {
+        $this->dataQueryHandlerMock
+            ->expects($this->once())->method('getCaseByUUID')
+            ->with('2b45a8c1-dd35-47ef-a00e-c7b6264bf1cc')
+            ->willReturn([
+                ['id' => '2b45a8c1-dd35-47ef-a00e-c7b6264bf1cc', 'personType' => 'donor'],
+            ]);
+
         $this->dispatch('/identity/details?uuid=2b45a8c1-dd35-47ef-a00e-c7b6264bf1cc', 'GET');
         $this->assertResponseStatusCode(200);
+        $this->assertModuleName('application');
+        $this->assertControllerName(IdentityController::class);
+        $this->assertControllerClass('IdentityController');
+        $this->assertMatchedRouteName('details');
+    }
+
+    public function testDetailsWithNonexistentUUID(): void
+    {
+        $this->dispatch('/identity/details?uuid=2b45a8c1-dd35-47ef-a00e-c7b6264bf1cc', 'GET');
+        $this->assertResponseStatusCode(404);
         $this->assertModuleName('application');
         $this->assertControllerName(IdentityController::class);
         $this->assertControllerClass('IdentityController');

--- a/service-front/module/Application/src/Exceptions/HttpException.php
+++ b/service-front/module/Application/src/Exceptions/HttpException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Exceptions;
+
+use Exception;
+use Throwable;
+
+class HttpException extends Exception
+{
+    public function __construct(
+        private int $statusCode,
+        string $message = '',
+        ?Throwable $previous = null,
+        int $code = 0,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+}

--- a/service-front/module/Application/src/Module.php
+++ b/service-front/module/Application/src/Module.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Application;
 
+use Application\Exceptions\HttpException;
+use Laminas\Http\Response;
 use Laminas\Mvc\MvcEvent;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -29,9 +31,16 @@ class Module
 
     public function onFinish(MvcEvent $event): void
     {
-        // If an exception was thrown, log it
         $exception = $event->getParam('exception');
-        if ($exception instanceof Throwable) {
+
+        if ($exception instanceof HttpException) {
+            // If an HttpException was thrown, use its status code
+            /** @var Response $response */
+            $response = $event->getResponse();
+
+            $response->setStatusCode($exception->getStatusCode());
+        } elseif ($exception instanceof Throwable) {
+            // If any other exception was thrown, log it
             $serviceManager = $event->getApplication()->getServiceManager();
             $logger = $serviceManager->get(LoggerInterface::class);
 

--- a/service-front/module/Application/src/Views/TwigExtension.php
+++ b/service-front/module/Application/src/Views/TwigExtension.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Application\Views;
 
 use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;
 
-class TwigExtension extends AbstractExtension
+class TwigExtension extends AbstractExtension implements GlobalsInterface
 {
     public function getFilters()
     {
@@ -18,6 +19,13 @@ class TwigExtension extends AbstractExtension
 
         return [
             new TwigFilter('basepath', fn (string $str) => $prefix . $str),
+        ];
+    }
+
+    public function getGlobals(): array
+    {
+        return [
+            'SIRIUS_PUBLIC_URL' => getenv("SIRIUS_PUBLIC_URL"),
         ];
     }
 }

--- a/service-front/module/Application/view/error/index.twig
+++ b/service-front/module/Application/view/error/index.twig
@@ -1,4 +1,15 @@
-<h1 class="govuk-heading-l">
-  An error occurred
+{% if exception.statusCode == 404 %}
+  <h1 class="govuk-heading-l">Page not found</h1>
+  <p class="govuk-body">
+    If you typed the web address, check it is correct.
+  </p>
+  <p class="govuk-body">
+    If you pasted the web address, check you copied the entire address.
+  </p>
+  <p class="govuk-body">
+    Please use your browser to go back to the previous page, or return to the <a class="govuk-link" href="{{ SIRIUS_PUBLIC_URL }}">Sirius homepage</a>.
+  </p>
+{% else %}
+  <h1 class="govuk-heading-l">An error occurred</h1>
   <span class="govuk-caption-l">{{ message }}</span>
-</h1>
+{% endif %}


### PR DESCRIPTION
# Purpose

When a case isn't found, the user should get a clear 404 page rather than a half-filled 200 or a generic 500.

Fixes ID-143 #minor

## Approach

This introduces the start of a framework around error handling:

Controllers and services can throw a `HttpException` to immediately jettison the request with a particular status code.

The Application module listener will intercept these to set the correct status code. The error template can also use this to show a custom error message.

When throwing OpgApiException, attach the Guzzle exception as previous, so that any code catching it can check the underlying error.

Then bring that all together so that `OpgApiService->getDetailsData()` can intercept Guzzle 404s and turn them into a `HttpException`.

Also fix an issue in API where it wasn't setting the correct status code.

## Learning

Laminas doesn't have a good way of managing this. I thought [laminas-mvc-middleware](https://docs.laminas.dev/laminas-mvc-middleware/) might help, but it doesn't work alongside controllers (only with `PipeSpec` response types).

I had a lot of mental back-and-forth about how exceptions should be declared, I think this is a good balance between flexibility (you can `throw new HttpException` anywhere) and explicitness (**all** other exceptions are treated as actual application errors).

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A