### PR TITLE
Fallback to Sirius data

### DIFF
--- a/docker/sirius/openapi.yml
+++ b/docker/sirius/openapi.yml
@@ -15,13 +15,13 @@ paths:
     get:
       summary: Get current user
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
-        '401':
+                $ref: "#/components/schemas/User"
+        "401":
           description: Error
   /api/v1/digital-lpas/{uid}:
     parameters:
@@ -51,8 +51,6 @@ components:
       properties:
         id: int
     CombinedLpa:
-      allOf:
-        - $ref: "#/components/schemas/DigitalLpa"
       type: object
       required:
         - opg.poas.sirius
@@ -70,7 +68,9 @@ components:
     DigitalLpa:
       type: object
       required:
+        - id
         - uId
+        - donor
       properties:
         id:
           type: integer
@@ -79,6 +79,21 @@ components:
           type: string
           pattern: "M(-[0-9A-Z]{4}){3}"
           example: M-789Q-P4DF-4UX3
+        donor:
+          required: [firstname, surname, dob, address]
+          type: object
+          properties:
+            firstname:
+              type: string
+              x-faker: name.firstName
+            surname:
+              type: string
+              x-faker: name.lastName
+            dob:
+              type: string
+              format: date
+            address:
+              $ref: "#/components/schemas/Address"
     LpaWithPostcodes:
       type: object
       properties:
@@ -96,3 +111,31 @@ components:
               type: object
               required:
                 - postcode
+    Address:
+      type: object
+      required:
+        - line1
+        - country
+      properties:
+        line1:
+          type: string
+          x-faker: address.streetAddress
+        line2:
+          type: string
+          x-faker: address.streetName
+        line3:
+          type: string
+          x-faker: address.cityName
+        town:
+          type: string
+          x-faker: address.cityName
+        postcode:
+          type: string
+          x-faker:
+            helpers.replaceSymbols: "??# #??"
+        country:
+          type: string
+          format: ISO-3166-1
+          minLength: 2
+          maxLength: 2
+          x-faker: address.countryCode

--- a/service-front/module/Application/src/Controller/IndexController.php
+++ b/service-front/module/Application/src/Controller/IndexController.php
@@ -5,19 +5,19 @@ declare(strict_types=1);
 namespace Application\Controller;
 
 use Application\Contracts\OpgApiServiceInterface;
-use Application\Exceptions\OpgApiException;
-use Application\Forms\DrivingLicenceNumber;
-use Application\Forms\IdQuestions;
-use Application\Forms\PassportNumber;
-use Application\Forms\PassportDate;
-use Application\Services\FormProcessorService;
+use Application\Exceptions\HttpException;
 use Application\Services\SiriusApiService;
+use DateTime;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\Mvc\Controller\Plugin\Redirect;
 use Laminas\View\Model\ViewModel;
-use Laminas\Form\Annotation\AttributeBuilder;
-use Application\Forms\NationalInsuranceNumber;
+
+/**
+ * @psalm-import-type Lpa from SiriusApiService
+ * @psalm-import-type Address from SiriusApiService
+ *
+ * @psalm-type Identity array{first_name: string, last_name: string, dob: string, address: string[]}
+ */
 
 class IndexController extends AbstractActionController
 {
@@ -36,23 +36,20 @@ class IndexController extends AbstractActionController
 
     public function startAction(): Response
     {
+        /** @var string[] $lpasQuery */
         $lpasQuery = $this->params()->fromQuery("lpas");
         $lpas = [];
         foreach ($lpasQuery as $lpaUid) {
             $data = $this->siriusApiService->getLpaByUid($lpaUid, $this->getRequest());
-            $lpas[] = $data['opg.poas.lpastore'];
+            $lpas[] = $data;
         }
 
+        /** @var string $type */
         $type = $this->params()->fromQuery("personType");
         /**
          * @psalm-suppress PossiblyUndefinedArrayOffset
          */
         $detailsData = $this->processLpaResponse($type, $lpas[0]);
-        // Find the details of the actor (donor or certificate provider, based on URL) that we need to ID check them
-
-        // Create a case in the API with the LPA UID and the actors' details
-
-        // Redirect to the "select which ID to use" page for this case
 
         $case = $this->opgApiService->createCase(
             $detailsData['first_name'],
@@ -63,35 +60,63 @@ class IndexController extends AbstractActionController
             $detailsData['address']
         );
 
-//        die(json_encode($case));
-
         return $type === 'donor' ?
             $this->redirect()->toRoute('root/how_donor_confirms', ['uuid' => $case['uuid']]) :
             $this->redirect()->toRoute('root/cp_how_cp_confirms', ['uuid' => $case['uuid']]);
     }
 
+    /**
+     * @param Lpa $data
+     * @return Identity
+     */
     private function processLpaResponse(string $type, array $data): array
     {
-        $parsedIdentity = [];
-
         if ($type === 'donor') {
-            $address = $this->processAddress($type, $data['donor']['address']);
-            $parsedIdentity['first_name'] = $data['donor']['firstNames'];
-            $parsedIdentity['last_name'] = $data['donor']['lastName'];
-            $parsedIdentity['dob'] = (new \DateTime($data['donor']['dateOfBirth']))->format("Y-m-d");
-            $parsedIdentity['address'] = $address;
-        } else {
-            $address = $this->processAddress($type, $data['certificateProvider']['address']);
-            $parsedIdentity['first_name'] = $data['certificateProvider']['firstNames'];
-            $parsedIdentity['last_name'] = $data['certificateProvider']['lastName'];
-            $parsedIdentity['dob'] = '1999-01-01'; //temp setting should be null in prod
-            $parsedIdentity['address'] = $address;
+            if (! empty($data['opg.poas.lpastore'])) {
+                $address = $this->processAddress($data['opg.poas.lpastore']['donor']['address']);
+
+                return [
+                    'first_name' => $data['opg.poas.lpastore']['donor']['firstNames'],
+                    'last_name' => $data['opg.poas.lpastore']['donor']['lastName'],
+                    'dob' => (new DateTime($data['opg.poas.lpastore']['donor']['dateOfBirth']))->format("Y-m-d"),
+                    'address' => $address,
+                ];
+            }
+
+            $address = $this->processAddress($data['opg.poas.sirius']['donor']['address']);
+
+            return [
+                'first_name' => $data['opg.poas.sirius']['donor']['firstname'],
+                'last_name' => $data['opg.poas.sirius']['donor']['surname'],
+                'dob' => (new DateTime($data['opg.poas.sirius']['donor']['dob']))->format("Y-m-d"),
+                'address' => $address,
+            ];
+        } elseif ($type === 'certificateProvider') {
+            if ($data['opg.poas.lpastore'] === null) {
+                throw new HttpException(
+                    400,
+                    'Cannot ID check this certificate provider as the LPA has not yet been submitted',
+                );
+            }
+
+            $address = $this->processAddress($data['opg.poas.lpastore']['certificateProvider']['address']);
+
+            return [
+                'first_name' => $data['opg.poas.lpastore']['certificateProvider']['firstNames'],
+                'last_name' => $data['opg.poas.lpastore']['certificateProvider']['lastName'],
+                'dob' => '1000-01-01', //temp setting should be null in prod
+                'address' => $address,
+            ];
         }
-//        die(json_encode($parsedIdentity));
-        return $parsedIdentity;
+
+        throw new HttpException(400, 'Person type "' . $type . '" is not valid');
     }
 
-    private function processAddress(string $type, array $siriusAddress): array
+    /**
+     * @param Address $siriusAddress
+     * @return string[]
+     */
+    private function processAddress(array $siriusAddress): array
     {
         $address = [];
 
@@ -99,19 +124,6 @@ class IndexController extends AbstractActionController
             $address[] = $line;
         }
 
-//        if ($type === 'donor') {
-//            $address[] = $siriusAddress['line1'];
-//            $address[] = $siriusAddress['line2'];
-////            $address['town'] = $siriusAddress['town'];
-//            $address[] = $siriusAddress['postcode'];
-//            $address[] = $siriusAddress['country'];
-//        } else {
-//            $address[] = $siriusAddress['line1'];
-//            $address[] = $siriusAddress['line2'];
-//            $address[] = $siriusAddress['line3'];
-////            $address['postcode'] = $siriusAddress['postcode'];
-//            $address[] = $siriusAddress['country'];
-//        }
         return $address;
     }
 }

--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -10,6 +10,41 @@ use Laminas\Http\Header\Cookie;
 use Laminas\Http\Request;
 use Laminas\Stdlib\RequestInterface;
 
+/**
+ * @psalm-type Address = array{
+ *  line1: string,
+ *  line2?: string,
+ *  line3?: string,
+ *  town?: string,
+ *  postcode?: string,
+ *  country: string,
+ * }
+ *
+ * @psalm-type Lpa = array{
+ *  "opg.poas.sirius": array{
+ *    donor: array{
+ *      firstname: string,
+ *      surname: string,
+ *      dob: string,
+ *      address: Address,
+ *    },
+ *  },
+ *  "opg.poas.lpastore": ?array{
+ *    donor: array{
+ *      firstNames: string,
+ *      lastName: string,
+ *      dateOfBirth: string,
+ *      address: Address,
+ *    },
+ *    certificateProvider: array{
+ *      firstNames: string,
+ *      lastName: string,
+ *      address: Address,
+ *    },
+ *  },
+ * }
+ */
+
 class SiriusApiService
 {
     public function __construct(
@@ -55,7 +90,7 @@ class SiriusApiService
     }
 
     /**
-     * @return array{"opg.poas.lpastore": array<string, mixed>}
+     * @return Lpa
      */
     public function getLpaByUid(string $uid, Request $request): array
     {

--- a/service-front/module/Application/test/Controller/IndexControllerTest.php
+++ b/service-front/module/Application/test/Controller/IndexControllerTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace ApplicationTest\Controller;
 
-use Application\Contracts\OpgApiServiceInterface;
 use Application\Controller\IndexController;
+use Application\Services\OpgApiService;
+use Application\Services\SiriusApiService;
 use Laminas\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
-use PHPUnit\Framework\MockObject\MockObject;
 
+/**
+ * @psalm-import-type Lpa from SiriusApiService
+ */
 class IndexControllerTest extends AbstractHttpControllerTestCase
 {
     public function setUp(): void
@@ -41,5 +44,155 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->dispatch('/invalid/route', 'GET');
         $this->assertResponseStatusCode(404);
+    }
+
+    /**
+     * @return array<string, array{Lpa, string, array<mixed>}>
+     */
+    public static function startActionDataProvider(): array
+    {
+        $siriusData = ['donor' => [
+            'firstname' => 'Lili', 'surname' => 'Laur', 'dob' => '2019-02-18',
+            'address' => ['line1' => '17 East Lane', 'line2' => 'Wickerham', 'postcode' => 'W1 3EJ', 'country' => 'GB'],
+        ]];
+
+        $lpaStoreData = [
+            'donor' => [
+                'firstNames' => 'Lilith', 'lastName' => 'Laur', 'dateOfBirth' => '2009-02-18',
+                'address' => [
+                    'line1' => 'Unit 15', 'line2' => 'Uberior House', 'town' => 'Edinburgh',
+                    'postcode' => 'EH1 2EJ', 'country' => 'GB',
+                ],
+            ],
+            'certificateProvider' => [
+                'firstNames' => 'x', 'lastName' => 'x',
+                'address' => ['line1' => '16a Avenida Lucana', 'line2' => 'Cordón', 'country' => 'ES'],
+            ],
+        ];
+
+        return [
+            'draft, donor' => [
+                [
+                    'opg.poas.sirius' => $siriusData,
+                    'opg.poas.lpastore' => null
+                ],
+                'donor',
+                [
+                    'Lili', 'Laur', '2019-02-18', 'donor', ['M-1234-5678-90AB'],
+                    ['17 East Lane', 'Wickerham', 'W1 3EJ', 'GB'],
+                ]
+            ],
+            'executed, donor' => [
+                [
+                    'opg.poas.sirius' => $siriusData,
+                    'opg.poas.lpastore' => $lpaStoreData
+                ],
+                'donor',
+                [
+                    'Lilith', 'Laur', '2009-02-18', 'donor', ['M-1234-5678-90AB'],
+                    ['Unit 15', 'Uberior House', 'Edinburgh', 'EH1 2EJ', 'GB'],
+                ]
+            ],
+            'executed, cp' => [
+                [
+                    'opg.poas.sirius' => $siriusData,
+                    'opg.poas.lpastore' => $lpaStoreData
+                ],
+                'certificateProvider',
+                [
+                    'x', 'x', '1000-01-01', 'certificateProvider', ['M-1234-5678-90AB'],
+                    ['16a Avenida Lucana', 'Cordón', 'ES'],
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider startActionDataProvider
+     * @param Lpa $lpa
+     * @return void
+     */
+    public function testStartAction($lpa, string $type, array $createCaseArgs): void
+    {
+        $siriusApiService = $this->createMock(SiriusApiService::class);
+        $opgApiService = $this->createMock(OpgApiService::class);
+
+        $serviceManager = $this->getApplicationServiceLocator();
+        $serviceManager->setService(SiriusApiService::class, $siriusApiService);
+        $serviceManager->setService(OpgApiService::class, $opgApiService);
+
+        $siriusApiService->expects($this->once())
+            ->method('getLpaByUid')
+            ->willReturn($lpa);
+
+        $opgApiService->expects($this->once())
+            ->method('createCase')
+            ->with(...$createCaseArgs)
+            ->willReturn(['uuid' => 'e9a50129-aebf-4bbc-a5cb-916d42ee2e56']);
+
+        $this->dispatch('/start?personType=' . $type . '&lpas[]=M-1234-5678-90AB', 'GET');
+        $this->assertResponseStatusCode(302);
+        $this->assertResponseHeaderRegex('Location', '/e9a50129-aebf-4bbc-a5cb-916d42ee2e56/');
+    }
+
+    /**
+     * If the LPA has not yet been executed, we don't have any CP details and we can't do their ID check
+     */
+    public function testStartActionFailsForDraftCPs(): void
+    {
+        $siriusApiService = $this->createMock(SiriusApiService::class);
+        $opgApiService = $this->createMock(OpgApiService::class);
+
+        $serviceManager = $this->getApplicationServiceLocator();
+        $serviceManager->setService(SiriusApiService::class, $siriusApiService);
+        $serviceManager->setService(OpgApiService::class, $opgApiService);
+
+        $draftLpa = [
+            'opg.poas.sirius' => [],
+            'opg.poas.lpastore' => null
+        ];
+
+        $siriusApiService->expects($this->once())
+            ->method('getLpaByUid')
+            ->willReturn($draftLpa);
+
+        $opgApiService->expects($this->never())
+            ->method('createCase');
+
+        $this->dispatch('/start?personType=certificateProvider&lpas[]=M-1234-5678-90AB', 'GET');
+        $this->assertResponseStatusCode(400);
+        $this->assertStringContainsString(
+            'Cannot ID check this certificate provider as the LPA has not yet been submitted',
+            $this->getResponse()->getBody()
+        );
+    }
+
+    public function testStartActionFailsWithInvalidType(): void
+    {
+        $siriusApiService = $this->createMock(SiriusApiService::class);
+        $opgApiService = $this->createMock(OpgApiService::class);
+
+        $serviceManager = $this->getApplicationServiceLocator();
+        $serviceManager->setService(SiriusApiService::class, $siriusApiService);
+        $serviceManager->setService(OpgApiService::class, $opgApiService);
+
+        $draftLpa = [
+            'opg.poas.sirius' => [],
+            'opg.poas.lpastore' => null
+        ];
+
+        $siriusApiService->expects($this->once())
+            ->method('getLpaByUid')
+            ->willReturn($draftLpa);
+
+        $opgApiService->expects($this->never())
+            ->method('createCase');
+
+        $this->dispatch('/start?personType=invalid&lpas[]=M-1234-5678-90AB', 'GET');
+        $this->assertResponseStatusCode(400);
+        $this->assertStringContainsString(
+            'Person type &quot;invalid&quot; is not valid',
+            $this->getResponse()->getBody()
+        );
     }
 }

--- a/service-front/module/Application/view/error/index.twig
+++ b/service-front/module/Application/view/error/index.twig
@@ -9,6 +9,11 @@
   <p class="govuk-body">
     Please use your browser to go back to the previous page, or return to the <a class="govuk-link" href="{{ SIRIUS_PUBLIC_URL }}">Sirius homepage</a>.
   </p>
+{% elseif exception.statusCode == 400 %}
+  <h1 class="govuk-heading-l">Invalid request</h1>
+  <p class="govuk-body">
+    {{ exception.message }}
+  </p>
 {% else %}
   <h1 class="govuk-heading-l">An error occurred</h1>
   <span class="govuk-caption-l">{{ message }}</span>


### PR DESCRIPTION
# Purpose

If the donor details cannot be found in the LPA Store, fallback to the draft data found in Sirius.

As this is not possible for CPs, throw a 400 exception if a CP ID check is requested and their data isn't in the store.

Fixes ID-144 #minor

## Approach

Updated the mock to occasionally return draft LPAs, but this can be forced by changing the mock to only ever return null from the store.

I introduced array shapes for response data from the Sirius API so that Psalm can more fully type-check all the array keys and values.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [ ] The team have tested these changes
