### PR TITLE
Show enhanced error information in debug mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,7 @@ services:
       - API_BASE_URI=http://api-web
       - SIRIUS_BASE_URL=http://sirius-mock:4010 # http://host.docker.internal:8080 for real Sirius
       - SIRIUS_PUBLIC_URL=http://localhost:8080
+      - APP_DEBUG=1
     healthcheck:
       test: SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000
       interval: 15s

--- a/service-front/module/Application/config/module.config.php
+++ b/service-front/module/Application/config/module.config.php
@@ -12,10 +12,12 @@ use Application\Factories\SiriusApiServiceFactory;
 use Application\Services\OpgApiService;
 use Application\Services\SiriusApiService;
 use Application\Views\TwigExtension;
+use Application\Views\TwigExtensionFactory;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Segment;
 use Laminas\Mvc\Controller\LazyControllerAbstractFactory;
 use Psr\Log\LoggerInterface;
+use Twig\Extension\DebugExtension;
 
 $prefix = getenv("PREFIX");
 if (! is_string($prefix)) {
@@ -317,19 +319,21 @@ return [
         'aliases' => [
             Contracts\OpgApiServiceInterface::class => Services\OpgApiService::class,
         ],
-        'invokables' => [
-            TwigExtension::class => TwigExtension::class,
-        ],
         'factories' => [
             AuthListener::class => AuthListenerFactory::class,
+            LoggerInterface::class => LoggerFactory::class,
             OpgApiService::class => OpgApiServiceFactory::class,
             SiriusApiService::class => SiriusApiServiceFactory::class,
-            LoggerInterface::class => LoggerFactory::class,
+            TwigExtension::class => TwigExtensionFactory::class,
         ],
     ],
-    'zend_twig'       => [
+    'zend_twig' => [
         'extensions' => [
             TwigExtension::class,
+            DebugExtension::class,
+        ],
+        'environment' => [
+            'debug' => filter_var(getenv('APP_DEBUG'), FILTER_VALIDATE_BOOLEAN),
         ],
     ],
     'opg_settings' => [

--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -82,7 +82,6 @@ class SiriusApiService
                 'headers' => $headers,
             ]);
         } catch (GuzzleException $e) {
-            error_log($e->getMessage());
             return false;
         }
 

--- a/service-front/module/Application/src/Views/TwigExtension.php
+++ b/service-front/module/Application/src/Views/TwigExtension.php
@@ -10,6 +10,10 @@ use Twig\TwigFilter;
 
 class TwigExtension extends AbstractExtension implements GlobalsInterface
 {
+    public function __construct(public readonly bool $debug)
+    {
+    }
+
     public function getFilters()
     {
         $prefix = getenv("PREFIX");
@@ -26,6 +30,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     {
         return [
             'SIRIUS_PUBLIC_URL' => getenv("SIRIUS_PUBLIC_URL"),
+            'DEBUG' => $this->debug,
         ];
     }
 }

--- a/service-front/module/Application/src/Views/TwigExtensionFactory.php
+++ b/service-front/module/Application/src/Views/TwigExtensionFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Views;
+
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+
+class TwigExtensionFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string                          $requestedName
+     * @param array<mixed>|null               $options
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): TwigExtension
+    {
+        $config = $container->get('config');
+        $twigDebug = $config['zend_twig']['environment']['debug'];
+
+        return new TwigExtension($twigDebug);
+    }
+}

--- a/service-front/module/Application/view/error/index.twig
+++ b/service-front/module/Application/view/error/index.twig
@@ -16,5 +16,18 @@
   </p>
 {% else %}
   <h1 class="govuk-heading-l">An error occurred</h1>
-  <span class="govuk-caption-l">{{ message }}</span>
+  <p class="govuk-body">{{ message }}</p>
+{% endif %}
+
+{% if DEBUG %}
+  <h2 class="govuk-heading-m">Debug information</h2>
+  <p class="govuk-body"><strong>Internal error:</strong> {{ exception.message }}</p>
+  <details class="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">Full details and trace</span>
+    </summary>
+    <div class="govuk-details__text">
+      <pre>{{ dump(exception) }}</pre>
+    </div>
+  </details>
 {% endif %}


### PR DESCRIPTION
# Purpose

If `APP_DEBUG` is enabled, show additional error information on error pages.

This will make it easier to debug problems locally, but not change what's shown in remote environments.

The trace details could be nicer, but what we have is sufficient for now.

| Prod mode | Debug mode |
| --- | --- |
| ![Example error page with very little information](https://github.com/ministryofjustice/opg-paper-identity/assets/100852/d2db0d29-cc7a-4563-87a3-b84bae64a7aa) | ![Example error page with additional developer-focussed information](https://github.com/ministryofjustice/opg-paper-identity/assets/100852/64f58366-867b-4f8c-b059-6cbd654fe490) |

#minor

## Approach

Introduced `APP_DEBUG` env var as that's commonly used in PHP frameworks (Symfony and Laravel). This is used to enable debug mode in Twig, and our custom extension also passes through a `DEBUG` global so that templates can determine if they're in debug mode. 

## Learning

Laminas doesn't use `APP_DEBUG` or really have an equivalent, which is why I borrowed from other frameworks.

The `debug()` function in Twig requires the `DebugExtension` _and_ for debug mode to be enabled, which is why there's a little bit of duplication of approach.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * N/A
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
