### PR TITLE
Improve error message when creating case

### DIFF
--- a/service-api/module/Application/src/Controller/IdentityController.php
+++ b/service-api/module/Application/src/Controller/IdentityController.php
@@ -11,6 +11,7 @@ use Application\KBV\KBVServiceInterface;
 use Application\Fixtures\DataImportHandler;
 use Application\Fixtures\DataQueryHandler;
 use Application\Model\Entity\CaseData;
+use Laminas\Form\Annotation\AttributeBuilder;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\JsonModel;
@@ -45,7 +46,11 @@ class IdentityController extends AbstractActionController
 
         $caseData = CaseData::fromArray($data);
 
-        if ($caseData->isValid()) {
+        $validator = (new AttributeBuilder())
+            ->createForm($caseData)
+            ->setData(get_object_vars($caseData));
+
+        if ($validator->isValid()) {
             $uuid = Uuid::uuid4();
             $item = [
                 'id'            => ['S' => $uuid->toString()],
@@ -64,7 +69,11 @@ class IdentityController extends AbstractActionController
 
         $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
 
-        return new JsonModel(['error' => 'Invalid data']);
+        return new JsonModel([
+            'type' => 'HTTP400',
+            'title'  => 'Invalid data',
+            'error' => $validator->getMessages(),
+        ]);
     }
 
     public function detailsAction(): JsonModel

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -6,7 +6,6 @@ namespace Application\Model\Entity;
 
 use Application\Validators\LpaUidValidator;
 use Laminas\Form\Annotation;
-use Laminas\Form\Annotation\AttributeBuilder;
 use Laminas\Form\Annotation\Validator;
 use Laminas\Validator\Explode;
 use Laminas\Validator\NotEmpty;
@@ -21,28 +20,30 @@ use Laminas\Validator\Regex;
 class CaseData
 {
     #[Validator(NotEmpty::class)]
-    private string $personType;
+    public string $personType;
 
-    #[Validator(Regex::class, options: ["pattern" => "/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/"])]
-    private string $dob;
+    #[Validator(Regex::class, options: ["pattern" => "/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/", "messages" => [
+        Regex::NOT_MATCH => 'Please enter a valid date of birth in the format YYYY-MM-DD'
+    ]])]
+    public string $dob;
 
     #[Validator(NotEmpty::class)]
-    private string $firstName;
+    public string $firstName;
 
     #[Validator(NotEmpty::class)]
-    private string $lastName;
+    public string $lastName;
 
     /**
      * @var string[]
      */
     #[Validator(NotEmpty::class)]
-    private array $address;
+    public array $address;
 
     /**
      * @var string[]
      */
     #[Annotation\Validator(Explode::class, options: ['validator' => ['name' => LpaUidValidator::class]])]
-    private array $lpas;
+    public array $lpas;
 
     /**
      * Factory method
@@ -61,13 +62,6 @@ class CaseData
         $instance->address = $data['address'];
 
         return $instance;
-    }
-    public function isValid(): bool
-    {
-        return (new AttributeBuilder())
-            ->createForm(get_class($this))
-            ->setData(get_object_vars($this))
-            ->isValid();
     }
 
     /**

--- a/service-api/module/Application/src/Module.php
+++ b/service-api/module/Application/src/Module.php
@@ -33,7 +33,7 @@ class Module
         /** @var Response */
         $response = $event->getResponse();
 
-        if ($response->getStatusCode() >= 400) {
+        if ($response->getStatusCode() >= 400 && empty($response->getBody())) {
             $exception = $event->getParam('exception');
             $problem = [
                 'status' => $response->getStatusCode(),

--- a/service-api/module/Application/test/ApplicationTest/Model/Entity/CaseDataTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Model/Entity/CaseDataTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ApplicationTest\Model\Entity;
 
 use Application\Model\Entity\CaseData;
+use Laminas\Form\Annotation\AttributeBuilder;
 use PHPUnit\Framework\TestCase;
 
 class CaseDataTest extends TestCase
@@ -15,7 +16,12 @@ class CaseDataTest extends TestCase
     public function testIsValid(array $data, bool $expectedIsValidResult): void
     {
         $requestData = CaseData::fromArray($data);
-        $this->assertEquals($requestData->isValid(), $expectedIsValidResult);
+
+        $validator = (new AttributeBuilder())
+            ->createForm($requestData)
+            ->setData(get_object_vars($requestData));
+
+        $this->assertEquals($validator->isValid(), $expectedIsValidResult);
     }
 
     public static function isValidDataProvider(): array

--- a/service-api/module/Application/test/Controller/IdentityControllerTest.php
+++ b/service-api/module/Application/test/Controller/IdentityControllerTest.php
@@ -97,7 +97,7 @@ class IdentityControllerTest extends TestCase
 
     public function testDetailsWithNoUUID(): void
     {
-        $response = '{"status":400,"type":"HTTP400","title":"Bad Request"}';
+        $response = '{"error":"Missing uuid"}';
         $this->dispatch('/identity/details', 'GET');
         $this->assertResponseStatusCode(400);
         $this->assertEquals($response, $this->getResponse()->getContent());
@@ -176,7 +176,7 @@ class IdentityControllerTest extends TestCase
 
         if ($result === "error") {
             $this->assertEquals(
-                '{"status":400,"type":"HTTP400","title":"Bad Request"}',
+                '{"error":"Missing UUID or unable to find case"}',
                 $this->getResponse()->getContent()
             )
             ;
@@ -224,7 +224,7 @@ class IdentityControllerTest extends TestCase
 
     public function testKBVQuestionsWithNoUUID(): void
     {
-        $response = '{"status":400,"type":"HTTP400","title":"Bad Request"}';
+        $response = '{"error":"Missing UUID"}';
         $this->dispatch('/cases/kbv-questions', 'GET');
         $this->assertResponseStatusCode(400);
         $this->assertEquals($response, $this->getResponse()->getContent());


### PR DESCRIPTION
# Purpose

This is primarily to help debug something in the integration environment, but is also good practice.

Fixes ID-149 #minor

## Approach

So rather than:
```json
{"status":400,"type":"HTTP400","title":"Bad Request"}
```
You get:
```json
{"type":"HTTP400","title":"Invalid data","error":{"dob":{"regexNotMatch":"Please enter a valid date of birth in the format YYYY-MM-DD"}}}
```

To enable that a couple of changes:
- If a body is already provided on an error response, don't overwrite it with the generic body. The generic body should just be used for uncaught errors
- Move `isValid` out of `CaseData`: the DTO should be responsible for defining its validation rules, but not for providing the validator. This _kind of_ removes a dependency in the DTO on laminas-form, as it's now just used for validation

## Learning

I had to make the properties on `CaseData` public so the validator could work, but this is also necessary for another thing I'm working on. It felt a bit wrong, but with type-hinting built in to PHP now we don't really need setters and getters.

I've used RFC7807 formatting for the error response, which I'd like to use for all API errors. In a subsequent PR I'll add a helper class for this and similarly make `CaseData` serializable so that it can be directly returned in controllers (e.g. `return JsonModel(new CaseData())`).

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * N/A
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
