### PR TITLE
Return objects in API responses

### DIFF
--- a/service-api/module/Application/src/Controller/IdentityController.php
+++ b/service-api/module/Application/src/Controller/IdentityController.php
@@ -11,10 +11,11 @@ use Application\KBV\KBVServiceInterface;
 use Application\Fixtures\DataImportHandler;
 use Application\Fixtures\DataQueryHandler;
 use Application\Model\Entity\CaseData;
+use Application\Model\Entity\Problem;
+use Application\View\JsonModel;
 use Laminas\Form\Annotation\AttributeBuilder;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\View\Model\JsonModel;
 use Ramsey\Uuid\Uuid;
 
 /**
@@ -69,11 +70,10 @@ class IdentityController extends AbstractActionController
 
         $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
 
-        return new JsonModel([
-            'type' => 'HTTP400',
-            'title'  => 'Invalid data',
-            'error' => $validator->getMessages(),
-        ]);
+        return new JsonModel(new Problem(
+            'Invalid data',
+            extra: ['errors' => $validator->getMessages()],
+        ));
     }
 
     public function detailsAction(): JsonModel
@@ -83,18 +83,18 @@ class IdentityController extends AbstractActionController
 
         if (! $uuid) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
-            return new JsonModel(['error' => 'Missing uuid']);
+            return new JsonModel(new Problem('Missing uuid'));
         }
 
-        $data = $this->dataQueryHandler->getCaseByUUID($uuid);
+        $case = $this->dataQueryHandler->getCaseByUUID($uuid);
         $this->getResponse()->setStatusCode(Response::STATUS_CODE_200);
 
-        if (! empty($data)) {
-            return new JsonModel($data[0]);
+        if (! empty($case)) {
+            return new JsonModel($case);
         }
 
         $this->getResponse()->setStatusCode(Response::STATUS_CODE_404);
-        return new JsonModel(['error' => 'Case not found']);
+        return new JsonModel(new Problem('Case not found'));
     }
 
     public function findByNameAction(): JsonModel
@@ -203,9 +203,9 @@ class IdentityController extends AbstractActionController
             return new JsonModel($response);
         }
 
-        $case = $this->dataQueryHandler->getCaseByUUID($uuid);
+        $case = $this->dataQueryHandler->getCaseByUUID($uuid)?->toArray();
 
-        if (! $case || $case[0]['documentComplete'] === false) {
+        if (is_null($case) || $case['documentComplete'] === false) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_200);
             $response = [
                 "error" => "Document checks incomplete or unable to locate case"
@@ -217,8 +217,8 @@ class IdentityController extends AbstractActionController
 
         $this->getResponse()->setStatusCode(Response::STATUS_CODE_200);
 
-        if (array_key_exists('kbvQuestions', $case[0])) {
-            $questions = json_decode($case[0]['kbvQuestions'], true);
+        if (array_key_exists('kbvQuestions', $case)) {
+            $questions = json_decode($case['kbvQuestions'], true);
 
             foreach ($questions as $number => $question) {
                 unset($question['answer']);
@@ -244,13 +244,13 @@ class IdentityController extends AbstractActionController
     {
         $uuid = $this->params()->fromRoute('uuid');
         $data = json_decode($this->getRequest()->getContent(), true);
-        $case = $this->dataQueryHandler->getCaseByUUID($uuid);
+        $case = $this->dataQueryHandler->getCaseByUUID($uuid)?->toArray();
 
 
         $result = 'pass';
         $response = [];
 
-        if (! $uuid || ! $case) {
+        if (! $uuid || is_null($case)) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
             $response = [
                 "error" => "Missing UUID or unable to find case"
@@ -258,7 +258,7 @@ class IdentityController extends AbstractActionController
             return new JsonModel($response);
         }
 
-        $questions = json_decode($case[0]['kbvQuestions'], true);
+        $questions = json_decode($case['kbvQuestions'], true);
         //compare against all stored answers to ensure all answers passed
         foreach ($questions as $key => $question) {
             if (! isset($data['answers'][$key])) {
@@ -392,21 +392,21 @@ class IdentityController extends AbstractActionController
 
         //pending design decision - may need this code
 
-//        if($lpa == null || $lpa == '') {
-//            $status = Response::STATUS_CODE_400;
-//            $message = "Enter an LPA number to continue.";
-//            $response['message'] = $message;
-//            $response['status'] = $status;
-//            return new JsonModel($response);
-//        }
-//
-//        if (1 !== preg_match('/M(-([0-9A-Z]){4}){3}/', $lpa)) {
-//            $status = Response::STATUS_CODE_400;
-//            $message = "Not a valid LPA number. Enter an LPA number to continue.";
-//            $response['message'] = $message;
-//            $response['status'] = $status;
-//            return new JsonModel($response);
-//        }
+        //        if($lpa == null || $lpa == '') {
+        //            $status = Response::STATUS_CODE_400;
+        //            $message = "Enter an LPA number to continue.";
+        //            $response['message'] = $message;
+        //            $response['status'] = $status;
+        //            return new JsonModel($response);
+        //        }
+        //
+        //        if (1 !== preg_match('/M(-([0-9A-Z]){4}){3}/', $lpa)) {
+        //            $status = Response::STATUS_CODE_400;
+        //            $message = "Not a valid LPA number. Enter an LPA number to continue.";
+        //            $response['message'] = $message;
+        //            $response['status'] = $status;
+        //            return new JsonModel($response);
+        //        }
 
         switch ($lpa) {
             case 'M-0000-0000-0000':
@@ -481,8 +481,8 @@ class IdentityController extends AbstractActionController
 
     public function addCaseLpaAction(): JsonModel
     {
-//        $uuid = $this->params()->fromRoute('uuid');
-//        $lpa = $this->params()->fromRoute('lpa');
+        //        $uuid = $this->params()->fromRoute('uuid');
+        //        $lpa = $this->params()->fromRoute('lpa');
         $response = [];
         $response['result'] = "Updated";
         return new JsonModel($response);

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Application\Model\Entity;
 
+use Application\Validators\IsType;
 use Application\Validators\LpaUidValidator;
+use JsonSerializable;
 use Laminas\Form\Annotation;
 use Laminas\Form\Annotation\Validator;
 use Laminas\Validator\Explode;
@@ -17,7 +19,7 @@ use Laminas\Validator\Regex;
  * Needed here due to false positive from Laminas’s uninitialised properties
  * @psalm-suppress UnusedProperty
  */
-class CaseData
+class CaseData implements JsonSerializable
 {
     #[Validator(NotEmpty::class)]
     public string $personType;
@@ -45,6 +47,13 @@ class CaseData
     #[Annotation\Validator(Explode::class, options: ['validator' => ['name' => LpaUidValidator::class]])]
     public array $lpas;
 
+    public ?string $kbvQuestions = null;
+
+    #[Annotation\Required(false)]
+    #[Annotation\Validator(IsType::class, options: ['type' => 'boolean'])]
+    #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
+    public bool $documentComplete = false;
+
     /**
      * Factory method
      *
@@ -71,18 +80,32 @@ class CaseData
      *     lastName: string,
      *     dob: string,
      *     address: string[],
-     *     lpas: string[]
+     *     lpas: string[],
+     *     kbvQuestions?: string,
+     *     documentComplete: bool
      * }
      */
     public function toArray(): array
     {
-        return [
+        $arr = [
             'personType' => $this->personType,
             'firstName' => $this->firstName,
             'lastName' => $this->lastName,
             'dob' => $this->dob,
             'address' => $this->address,
             'lpas' => $this->lpas,
+            'documentComplete' => $this->documentComplete,
         ];
+
+        if ($this->kbvQuestions !== null) {
+            $arr['kbvQuestions'] = $this->kbvQuestions;
+        }
+
+        return $arr;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 }

--- a/service-api/module/Application/src/Model/Entity/Problem.php
+++ b/service-api/module/Application/src/Model/Entity/Problem.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Model\Entity;
+
+use JsonSerializable;
+
+/**
+ * Serializable class to support errors in a RFC7807 format
+ */
+class Problem implements JsonSerializable
+{
+    public function __construct(
+        public readonly string $title,
+        public readonly string $type = '',
+        public readonly int $status = 0,
+        public readonly string $detail = '',
+        public readonly array $extra = [],
+    ) {
+    }
+
+    public function jsonSerialize(): array
+    {
+        $json = [
+            'title' => $this->title,
+            ...$this->extra,
+        ];
+
+        if ($this->type !== '') {
+            $json['type'] = $this->type;
+        }
+
+        if ($this->status !== 0) {
+            $json['status'] = $this->status;
+        }
+
+        if ($this->detail !== '') {
+            $json['detail'] = $this->detail;
+        }
+
+        return $json;
+    }
+}

--- a/service-api/module/Application/src/Validators/IsType.php
+++ b/service-api/module/Application/src/Validators/IsType.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Validators;
+
+use Laminas\Validator\AbstractValidator;
+
+class IsType extends AbstractValidator
+{
+    public const INVALID_TYPE = 'invalid_type';
+
+    protected array $messageTemplates = [
+        self::INVALID_TYPE => 'The type is not valid',
+    ];
+
+    /**
+     * @var string[]
+     */
+    public readonly array $allowedTypes;
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod
+     * This is called from within laminas-form
+     *
+     * @param {types: string[]|string} $options
+     */
+    public function __construct(array $options)
+    {
+        if (is_array($options['type'])) {
+            $this->allowedTypes = $options['type'];
+        } elseif (is_string($options['type'])) {
+            $this->allowedTypes = [$options['type']];
+        } else {
+            $this->allowedTypes = [];
+        }
+    }
+
+    public function isValid(mixed $value): bool
+    {
+        $type = gettype($value);
+
+        if (! in_array($type, $this->allowedTypes)) {
+            $this->error(self::INVALID_TYPE);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/service-api/module/Application/src/View/JsonModel.php
+++ b/service-api/module/Application/src/View/JsonModel.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\View;
+
+use ArrayAccess;
+use JsonSerializable;
+use Laminas\View\Model\JsonModel as LaminasJsonModel;
+use Traversable;
+
+class JsonModel extends LaminasJsonModel
+{
+    /**
+     * @param  array|ArrayAccess|Traversable|JsonSerializable $variables
+     * @param  bool $overwrite Whether or not to overwrite the internal container with $variables
+     */
+    public function setVariables($variables, $overwrite = false)
+    {
+        if ($variables instanceof JsonSerializable) {
+            $variables = $variables->jsonSerialize();
+        }
+
+        return parent::setVariables($variables, $overwrite);
+    }
+}

--- a/service-api/module/Application/test/ApplicationTest/Model/Entity/CaseDataTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Model/Entity/CaseDataTest.php
@@ -15,13 +15,18 @@ class CaseDataTest extends TestCase
      */
     public function testIsValid(array $data, bool $expectedIsValidResult): void
     {
-        $requestData = CaseData::fromArray($data);
-
         $validator = (new AttributeBuilder())
-            ->createForm($requestData)
-            ->setData(get_object_vars($requestData));
+            ->createForm(CaseData::class)
+            ->setData($data);
 
-        $this->assertEquals($validator->isValid(), $expectedIsValidResult);
+        if ($expectedIsValidResult) {
+            $this->assertTrue(
+                $validator->isValid(),
+                'Data provided is not valid: ' . json_encode($validator->getMessages())
+            );
+        } else {
+            $this->assertFalse($validator->isValid());
+        }
     }
 
     public static function isValidDataProvider(): array
@@ -48,6 +53,9 @@ class CaseDataTest extends TestCase
             [array_merge($validData, ['lastName' => '']), false],
             [array_merge($validData, ['dob' => '11-11-2020']), false],
             [array_replace_recursive($validData, ['lpas' => ['xx']]), false],
+            [array_merge($validData, ['documentComplete' => true]), true],
+            [array_merge($validData, ['documentComplete' => false]), true],
+            [array_merge($validData, ['documentComplete' => 'grergiro']), false],
         ];
     }
 }


### PR DESCRIPTION
## Purpose

The general goal here is that, rather than having to define the response shape in every controller action:
```php
$case = new CaseData(...);

return JsonModel([
  'id' => $case->getId(),
  // etc.
]);
```

You can just return the object:
```php
$case = new CaseData(...);

return JsonModel($case);
```

This has a few benefits:
- It ensures the data shape is consistent where multiple endpoints return the same shape (in particular, errors)
- It allows typed objects to be passed through methods more easily, rather than arrays that may or may not contain expected data (e.g. how DataQueryHandler->getCaseByUUID now returns CaseData)
- In turn, that forces us to define our data models better (I found that `kbvQuestions` and `documentComplete` were missing from `CaseData`)
- It will let us annotate the OpenAPI spec directly from the objects with [swagger-php](https://zircote.github.io/swagger-php/)

#minor

## Approach

I made the objects we want to return JsonSerializable and introduced a new JsonModel variant that uses that method. That seemed easier than supporting the official JsonModel class, which only handles Traversables, because it's much more verbose to make a class Traversable.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
