### PR TITLE
Use CaseData in DataImportHandler->insertData

### DIFF
--- a/service-api/module/Application/src/Controller/IdentityController.php
+++ b/service-api/module/Application/src/Controller/IdentityController.php
@@ -52,20 +52,11 @@ class IdentityController extends AbstractActionController
             ->setData(get_object_vars($caseData));
 
         if ($validator->isValid()) {
-            $uuid = Uuid::uuid4();
-            $item = [
-                'id'            => ['S' => $uuid->toString()],
-                'personType'     => ['S' => $caseData->personType],
-                'firstName'     => ['S' => $caseData->firstName],
-                'lastName'      => ['S' => $caseData->lastName],
-                'dob'           => ['S' => $caseData->dob],
-                'lpas'          => ['SS' => $caseData->lpas],
-                'address'       => ['SS' => $caseData->address]
-            ];
+            $caseData->id = strval(Uuid::uuid4());
 
-            $this->dataImportHandler->insertData($item);
+            $this->dataImportHandler->insertData($caseData);
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_200);
-            return new JsonModel(['uuid' => $uuid]);
+            return new JsonModel(['uuid' => $caseData->id]);
         }
 
         $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
@@ -197,10 +188,7 @@ class IdentityController extends AbstractActionController
 
         if (! $uuid) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
-            $response = [
-                "error" => "Missing UUID"
-            ];
-            return new JsonModel($response);
+            return new JsonModel(new Problem('Missing UUID'));
         }
 
         $case = $this->dataQueryHandler->getCaseByUUID($uuid);
@@ -251,10 +239,7 @@ class IdentityController extends AbstractActionController
 
         if (! $uuid || is_null($case)) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
-            $response = [
-                "error" => "Missing UUID or unable to find case"
-            ];
-            return new JsonModel($response);
+            return new JsonModel(new Problem("Missing UUID or unable to find case"));
         }
 
         $questions = json_decode($case->kbvQuestions, true);
@@ -281,10 +266,7 @@ class IdentityController extends AbstractActionController
 
         if (! $uuid) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
-            $response = [
-                "error" => "Missing UUID"
-            ];
-            return new JsonModel($response);
+            return new JsonModel(new Problem("Missing UUID"));
         }
 
         $this->dataImportHandler->updateCaseData(
@@ -308,10 +290,7 @@ class IdentityController extends AbstractActionController
 
         if (! $uuid) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
-            $response = [
-                "error" => "Missing UUID"
-            ];
-            return new JsonModel($response);
+            return new JsonModel(new Problem('Missing UUID'));
         }
 
         $this->dataImportHandler->updateCaseData(
@@ -335,10 +314,7 @@ class IdentityController extends AbstractActionController
 
         if (! $uuid) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
-            $response = [
-                "error" => "Missing UUID"
-            ];
-            return new JsonModel($response);
+            return new JsonModel(new Problem('Missing UUID'));
         }
 
         $this->dataImportHandler->updateCaseData(
@@ -362,10 +338,7 @@ class IdentityController extends AbstractActionController
 
         if (! $uuid) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
-            $response = [
-                "error" => "Missing UUID"
-            ];
-            return new JsonModel($response);
+            return new JsonModel(new Problem('Missing UUID'));
         }
 
         $this->dataImportHandler->updateCaseData(

--- a/service-api/module/Application/src/Fixtures/DataImportHandler.php
+++ b/service-api/module/Application/src/Fixtures/DataImportHandler.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Application\Fixtures;
 
+use Application\Model\Entity\CaseData;
 use Aws\DynamoDb\DynamoDbClient;
+use Aws\DynamoDb\Marshaler;
 use Aws\Exception\AwsException;
 use Psr\Log\LoggerInterface;
 
@@ -19,12 +21,16 @@ class DataImportHandler
     ) {
     }
 
-    public function insertData(array $item): void
+    public function insertData(CaseData $item): void
     {
+        $marsheler = new Marshaler();
+        $encoded = $marsheler->marshalItem($item->jsonSerialize());
+
         $params = [
             'TableName' => $this->tableName,
-            'Item' => $item
+            'Item' => $encoded
         ];
+
         try {
             $this->dynamoDbClient->putItem($params);
         } catch (AwsException $e) {

--- a/service-api/module/Application/src/Fixtures/DataQueryHandler.php
+++ b/service-api/module/Application/src/Fixtures/DataQueryHandler.php
@@ -121,12 +121,8 @@ class DataQueryHandler
             /** @var array $record */
             foreach ($result['Items'] as $record) {
                 $marshal = new Marshaler();
-                $item = $marshal->unmarshalItem($record);
-
-                // Converts (nested) `SetValue` objects into native arrays
-                $item = json_decode(json_encode($item), true);
-
-                $displayResults[] = $item;
+                $json = $marshal->unmarshalJson($record);
+                $displayResults[] = json_decode($json, true);
             }
         }
         return $displayResults;

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -6,12 +6,14 @@ namespace Application\Model\Entity;
 
 use Application\Validators\IsType;
 use Application\Validators\LpaUidValidator;
+use Exception;
 use JsonSerializable;
 use Laminas\Form\Annotation;
 use Laminas\Form\Annotation\Validator;
 use Laminas\Validator\Explode;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\Regex;
+use Laminas\Validator\Uuid;
 
 /**
  * DTO for holding data required to make new case entry post
@@ -21,6 +23,11 @@ use Laminas\Validator\Regex;
  */
 class CaseData implements JsonSerializable
 {
+    #[Annotation\Required(false)]
+    #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
+    #[Validator(Uuid::class)]
+    public string $id;
+
     #[Validator(NotEmpty::class)]
     public string $personType;
 
@@ -55,20 +62,19 @@ class CaseData implements JsonSerializable
     public bool $documentComplete = false;
 
     /**
-     * Factory method
-     *
-     * @param array{personType: string, firstName: string, lastName: string, dob: string,
-     *     lpas: array{}, address: array{} } $data
+     * @param array<string, mixed> $data
      */
     public static function fromArray(mixed $data): self
     {
         $instance = new self();
-        $instance->personType = $data['personType'];
-        $instance->firstName = $data['firstName'];
-        $instance->lastName = $data['lastName'];
-        $instance->dob = $data['dob'];
-        $instance->lpas = $data['lpas'];
-        $instance->address = $data['address'];
+
+        foreach ($data as $key => $value) {
+            if (! property_exists($instance, $key)) {
+                throw new Exception(sprintf('%s does not have property "%s"', $instance::class, $key));
+            }
+
+            $instance->{$key} = $value;
+        }
 
         return $instance;
     }

--- a/service-api/module/Application/test/Controller/IdentityControllerTest.php
+++ b/service-api/module/Application/test/Controller/IdentityControllerTest.php
@@ -181,11 +181,8 @@ class IdentityControllerTest extends TestCase
         $this->assertMatchedRouteName('check_kbv_answers');
 
         if ($result === "error") {
-            $this->assertEquals(
-                '{"error":"Missing UUID or unable to find case"}',
-                $this->getResponse()->getContent()
-            )
-            ;
+            $response = json_decode($this->getResponse()->getContent(), true);
+            $this->assertEquals('Missing UUID or unable to find case', $response['title']);
         } else {
             $this->assertEquals('{"result":"' . $result . '"}', $this->getResponse()->getContent());
         }
@@ -235,14 +232,15 @@ class IdentityControllerTest extends TestCase
 
     public function testKBVQuestionsWithNoUUID(): void
     {
-        $response = '{"error":"Missing UUID"}';
         $this->dispatch('/cases/kbv-questions', 'GET');
         $this->assertResponseStatusCode(400);
-        $this->assertEquals($response, $this->getResponse()->getContent());
         $this->assertModuleName('application');
         $this->assertControllerName(IdentityController::class);
         $this->assertControllerClass('IdentityController');
         $this->assertMatchedRouteName('get_kbv_questions');
+
+        $response = json_decode($this->getResponse()->getContent(), true);
+        $this->assertEquals('Missing UUID', $response['title']);
     }
 
     /**


### PR DESCRIPTION
# Purpose

We should use the `CaseData` DTO to pass data around, not arrays.

#patch

## Approach

Perform the marshalling of the object inside the method rather than accepting an arbitrary array.

Also replace `CaseData->fromArray` with something generic.


## Checklist

* [x] I have performed a self-review of my own code