### PR TITLE
Add postcode lookup endpoint to Sirius mock

### DIFF
--- a/docker/sirius/openapi.yml
+++ b/docker/sirius/openapi.yml
@@ -44,6 +44,53 @@ paths:
                 $ref: "#/components/schemas/CombinedLpa"
         "401":
           description: Error
+  /api/v1/postcode-lookup:
+    parameters:
+      - name: postcode
+        in: query
+        required: true
+        schema:
+          type: string
+          nullable: false
+    get:
+      summary: Lookup addresses based on a post code
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  required:
+                    - addressLine1
+                    - addressLine2
+                    - addressLine3
+                    - town
+                    - postcode
+                    - description
+                  properties:
+                    addressLine1:
+                      type: string
+                      x-faker: address.streetAddress
+                    addressLine2:
+                      type: string
+                      x-faker: address.streetName
+                    addressLine3:
+                      type: string
+                      x-faker: address.cityName
+                    town:
+                      type: string
+                      x-faker: address.cityName
+                    postcode:
+                      type: string
+                      x-faker:
+                        helpers.replaceSymbols: "??# #??"
+                    description:
+                      type: string
+                      x-faker:
+                        fake: "A concatenation of the address lines"
 components:
   schemas:
     User:

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,4 +1,4 @@
-# Purpose
+## Purpose
 
 _Briefly describe the purpose of the change._
 


### PR DESCRIPTION
## Purpose

Can be used to find an address based on a postcode.

Fixes ID-164 #patch

## Approach

Due to tooling limitations the mock returns a fixed response for the "description" property: it would normally be the concatenation of all the address lines, in order.
