### PR TITLE
Add field-level validation to CaseData update method

### DIFF
--- a/service-api/module/Application/src/Fixtures/DataImportHandler.php
+++ b/service-api/module/Application/src/Fixtures/DataImportHandler.php
@@ -8,11 +8,14 @@ use Application\Model\Entity\CaseData;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\DynamoDb\Marshaler;
 use Aws\Exception\AwsException;
+use InvalidArgumentException;
+use Laminas\Form\Annotation\AttributeBuilder;
+use Laminas\InputFilter\InputInterface;
 use Psr\Log\LoggerInterface;
 
 class DataImportHandler
 {
-    public final const DATA_FILE_PATH = __DIR__ . '/Data/sampleData.json';
+    final public const DATA_FILE_PATH = __DIR__ . '/Data/sampleData.json';
 
     public function __construct(
         private readonly DynamoDbClient $dynamoDbClient,
@@ -40,8 +43,25 @@ class DataImportHandler
         }
     }
 
-    public function updateCaseData(string $uuid, string $attrName, string $attrType, string $attrValue): void
+    public function updateCaseData(string $uuid, string $attrName, string $attrType, mixed $attrValue): void
     {
+        if (! property_exists(CaseData::class, $attrName)) {
+            throw new InvalidArgumentException(sprintf('CaseData has no such property "%s"', $attrName));
+        }
+
+        $inputFilter = (new AttributeBuilder())
+            ->createForm(CaseData::class)
+            ->getInputFilter();
+        $input = $inputFilter->get($attrName);
+
+        if ($input instanceof InputInterface) {
+            $input->setValue($attrValue);
+
+            if (! $input->isValid()) {
+                throw new InvalidArgumentException(sprintf('"%s" is not a valid value for %s', $attrValue, $attrName));
+            }
+        }
+
         $idKey = [
             'key' => [
                 'id' => [
@@ -49,6 +69,7 @@ class DataImportHandler
                 ],
             ],
         ];
+
         try {
             $this->dynamoDbClient->updateItem([
                 'Key' => $idKey['key'],

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Application\Model\Entity;
 
+use Application\Model\IdMethod;
+use Application\Validators\Enum;
 use Application\Validators\IsType;
 use Application\Validators\LpaUidValidator;
 use Exception;
@@ -60,6 +62,10 @@ class CaseData implements JsonSerializable
     #[Annotation\Validator(IsType::class, options: ['type' => 'boolean'])]
     #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
     public bool $documentComplete = false;
+
+    #[Annotation\Required(false)]
+    #[Annotation\Validator(Enum::class, options: ['enum' => IdMethod::class])]
+    public ?string $idMethod = null;
 
     /**
      * @param array<string, mixed> $data

--- a/service-api/module/Application/src/Model/IdMethod.php
+++ b/service-api/module/Application/src/Model/IdMethod.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Model;
+
+enum IdMethod: string
+{
+    case NationalInsuranceNumber = "nin";
+    case PassportNumber = "pn";
+    case DrivingLicenseNumber = "dln";
+    case OnBehalf = "OnBehalf";
+    case PostOffice = "po";
+    case CourtOfProtection = "cpr";
+    case PostOfficeWithUKPassport = "po_ukp";
+    case PostOfficeWithEUPassport = "po_eup";
+    case PostOfficeWithInternationalPassport = "po_inp";
+    case PostOfficeWithUKDrivingLicence = "po_ukd";
+    case PostOfficeWithEUDrivingLicense = "po_eud";
+    case PostOfficeWithInternationalDrivingLicence = "po_ind";
+    case PostOfficeWithNoneOfTheAbove = "po_n";
+}

--- a/service-api/module/Application/src/Validators/Enum.php
+++ b/service-api/module/Application/src/Validators/Enum.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Validators;
+
+use Laminas\Validator\AbstractValidator;
+use Laminas\Validator\Exception\RuntimeException;
+
+class Enum extends AbstractValidator
+{
+    final public const INVALID = 'invalid';
+
+    /** @var array<string, string> */
+    protected $messageTemplates = [
+        self::INVALID => 'The value was not valid for %value%',
+    ];
+
+    /** @var ?class-string */
+    protected ?string $enum = null;
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod
+     * This is called from within laminas-form
+     */
+    public function setEnum(string $enum): static
+    {
+        if (! enum_exists($enum)) {
+            throw new RuntimeException($enum . ' is not a valid enum');
+        }
+
+        $this->enum = $enum;
+
+        return $this;
+    }
+
+    /**
+     * @param mixed $value
+     * @return bool
+     */
+    public function isValid($value)
+    {
+        if (is_null($this->enum)) {
+            throw new RuntimeException('Enum not configured in validator');
+        }
+
+        if (is_string($value) ? $this->enum::tryFrom($value) === null : ! ($value instanceof $this->enum)) {
+            $this->error(self::INVALID, $this->enum);
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/service-api/module/Application/test/ApplicationTest/Fixtures/DataImportHandlerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Fixtures/DataImportHandlerTest.php
@@ -6,9 +6,11 @@ namespace ApplicationTest\Fixtures;
 
 use Application\Fixtures\DataImportHandler;
 use Application\Model\Entity\CaseData;
+use Application\Model\IdMethod;
 use Aws\CommandInterface;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\Exception\AwsException;
+use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -177,7 +179,32 @@ class DataImportHandlerTest extends TestCase
             'a9bc8ab8-389c-4367-8a9b-762ab3050491',
             'idMethod',
             'S',
-            'passport'
+            IdMethod::PassportNumber
+        );
+    }
+
+    /**
+     * @throws Exception
+     * @psalm-suppress UndefinedMagicMethod
+     * @psalm-suppress PossiblyUndefinedMethod
+     */
+    public function testUpdateCaseDataWithBadData(): void
+    {
+        $this->dynamoDbClientMock->expects($this->never())
+            ->method('__call');
+
+        // Expect the logger to be called if an exception occurs
+        $this->loggerMock->expects($this->never())->method('error');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"an invalid value" is not a valid value for idMethod');
+
+        // Call the updateCaseData method with test data
+        $this->sut->updateCaseData(
+            'a9bc8ab8-389c-4367-8a9b-762ab3050491',
+            'idMethod',
+            'S',
+            'an invalid value'
         );
     }
 }

--- a/service-api/module/Application/test/ApplicationTest/Model/Entity/CaseDataTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Model/Entity/CaseDataTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ApplicationTest\Model\Entity;
 
 use Application\Model\Entity\CaseData;
+use Application\Model\IdMethod;
 use Laminas\Form\Annotation\AttributeBuilder;
 use PHPUnit\Framework\TestCase;
 
@@ -56,6 +57,10 @@ class CaseDataTest extends TestCase
             [array_merge($validData, ['documentComplete' => true]), true],
             [array_merge($validData, ['documentComplete' => false]), true],
             [array_merge($validData, ['documentComplete' => 'grergiro']), false],
+            [array_merge($validData, ['idMethod' => IdMethod::PassportNumber]), true],
+            [array_merge($validData, ['idMethod' => IdMethod::PostOfficeWithEUDrivingLicense]), true],
+            [array_merge($validData, ['idMethod' => IdMethod::OnBehalf]), true],
+            [array_merge($validData, ['idMethod' => 'other']), false],
         ];
     }
 }

--- a/service-api/module/Application/test/ApplicationTest/Validators/EnumTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Validators/EnumTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Validator;
+
+use Application\Validators\Enum;
+use PHPUnit\Framework\TestCase;
+
+// phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
+enum Suit: string
+{
+    case Hearts = 'H';
+    case Diamonds = 'D';
+    case Clubs = 'C';
+    case Spades = 'S';
+}
+
+// phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
+enum Face: string
+{
+    case Jack = 'J';
+    case Queen = 'Q';
+    case King = 'K';
+}
+
+// phpcs:ignore PSR1.Classes.ClassDeclaration.MultipleClasses
+class EnumTest extends TestCase
+{
+    /**
+     * @dataProvider provideIsValid
+     */
+    public function testIsValid(mixed $value, bool $expected, ?string $errorMessage): void
+    {
+        $sut = new Enum(['enum' => Suit::class]);
+        self::assertEquals($expected, $sut->isValid($value));
+
+        if ($errorMessage !== null) {
+            self::assertEquals($errorMessage, current($sut->getMessages()));
+        }
+    }
+
+    /**
+     * @return array{mixed, bool, ?string}[]
+     */
+    public static function provideIsValid(): array
+    {
+        return [
+            [null, false, 'The value was not valid for ApplicationTest\Validator\Suit'],
+            ['', false, 'The value was not valid for ApplicationTest\Validator\Suit'],
+            ['Hearts', false, 'The value was not valid for ApplicationTest\Validator\Suit'],
+            ['HS', false, 'The value was not valid for ApplicationTest\Validator\Suit'],
+            ['X', false, 'The value was not valid for ApplicationTest\Validator\Suit'],
+            ['H', true, null],
+            ['S', true, null],
+            [Suit::Hearts, true, null],
+            [Face::Jack, false, 'The value was not valid for ApplicationTest\Validator\Suit'],
+        ];
+    }
+}


### PR DESCRIPTION
## Purpose

Make `DataImportHandler->updateCaseData` validate the property before saving.

Fixes ID-174 #patch

## Approach

This highlighted that `idMethod` wasn't in CaseData, which I added. I also added a Enum to validate its values against and an Enum validator class.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A