### PR TITLE
Use Twig layouts rather than laminas ones

### DIFF
--- a/service-front/module/Application/config/module.config.php
+++ b/service-front/module/Application/config/module.config.php
@@ -435,6 +435,7 @@ return [
         'doctype'                  => 'HTML5',
         'not_found_template'       => 'error/404',
         'exception_template'       => 'error/index',
+        'layout'                   => 'layout/plain',
         'template_map' => [
             'layout/layout'           => __DIR__ . '/../view/layout/layout.phtml',
             'application/index/index' => __DIR__ . '/../view/application/index/index.phtml',

--- a/service-front/module/Application/view/application/index/index.twig
+++ b/service-front/module/Application/view/application/index/index.twig
@@ -1,6 +1,9 @@
+{% extends "layout/layout" %}
+
+{% block content %}
 <div class="govuk-width-container">
     <main class="govuk-main-wrapper">
-        <h1 class="govuk-heading-xl">Is the caller prepared to perform the ID check?</h1>
+        <h1 class="govuk-heading-xl">{% block title %}Is the caller prepared to perform the ID check?{% endblock %}</h1>
 
         <p class="govuk-body">
             Things to check:
@@ -71,3 +74,4 @@
 
     </main>
 </div>
+{% endblock %}

--- a/service-front/module/Application/view/application/pages/how_will_the_donor_confirm.twig
+++ b/service-front/module/Application/view/application/pages/how_will_the_donor_confirm.twig
@@ -1,8 +1,11 @@
+{% extends "layout/layout" %}
+
+{% block content %}
 {% include 'layout/id_check_banner.twig' with details_data %}
 <div class="govuk-width-container govuk-!-padding-top-5">
 
         <form method="POST">
-            <h1 class="govuk-heading-xl govuk-!-width-two-thirds">How will they confirm their identity</h1>
+            <h1 class="govuk-heading-xl govuk-!-width-two-thirds">{% block title %}How will they confirm their identity{% endblock %}</h1>
 
             <p class="govuk-body govuk-!-width-two-thirds">
                 Confirming their identity over the phone is the quickest and easiest option - they'll need an NI number, passport or driving licence and to answer some identity check questions during the call.
@@ -58,3 +61,4 @@
         </form>
 
 </div>
+{% endblock %}

--- a/service-front/module/Application/view/layout/layout.twig
+++ b/service-front/module/Application/view/layout/layout.twig
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>GOV.UK - The best place to find government services and information</title>
+    <title>{% block title %}GOV.UK - The best place to find government services and information{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <link rel="icon" sizes="48x48" href="{{ '/assets/images/favicon.ico' | basepath }}">
@@ -41,7 +41,7 @@
 </header>
 <div class="govuk-width-container">
     <main class="app-main-wrapper govuk-!-padding-bottom-7" id="main-content" role="main">
-        {{ content | raw }}
+        {% block content %}{% endblock %}
     </main>
 </div>
 <footer class="govuk-footer" role="contentinfo">

--- a/service-front/module/Application/view/layout/plain.twig
+++ b/service-front/module/Application/view/layout/plain.twig
@@ -1,0 +1,1 @@
+{{ content | raw }}


### PR DESCRIPTION
**WIP:** For this to work, every template needs to be updated to extend a layout.

---

By default laminas renders your template to `$content`, then renders your layout passing in `$content` as a variable. This is quite limiting as it means we can't use Twig features like blocks.

This PR replaces the laminas template with a complete passthrough (`plain.twig`) and insteads uses Twig's [extends tag](https://twig.symfony.com/doc/3.x/tags/extends.html) to do the layout rendering inside Twig.

This allows us to use blocks, and specifically makes it easy to pair the `<h1>` and `<title>` tags.

It also reduces our dependency on Laminas, as the templates are technically standalone and renderable without the framework.
