### PR TITLE
Upgrade version of OpenSSL used in images

### DIFF
--- a/service-api/Dockerfile
+++ b/service-api/Dockerfile
@@ -5,6 +5,9 @@ RUN apk --no-cache add fcgi icu-dev $PHPIZE_DEPS \
   && docker-php-ext-enable sodium
 RUN pecl install apcu && docker-php-ext-enable apcu
 
+# Patch Vulnerabilities
+RUN apk upgrade --no-cache openssl
+
 WORKDIR /var/www/
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"

--- a/service-front/Dockerfile
+++ b/service-front/Dockerfile
@@ -4,6 +4,9 @@ WORKDIR /app
 
 RUN apk add --no-cache git
 
+# Patch Vulnerabilities
+RUN apk upgrade --no-cache openssl
+
 RUN mkdir -p public
 
 COPY package.json .


### PR DESCRIPTION
## Purpose

The version of OpenSSL (3.3.0) on the api and front images has a vulnerability.

Fixes ID-211 #patch

## Approach

Use APK to upgrade the version on the image during build.

## Checklist

* [x] I have performed a self-review of my own code
