### PR TITLE
Move certificate generation into localstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL = '/bin/bash'
 help:
 	@grep --no-filename -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-build: scripts/localstack/init/private_key.pem ## Build containers
+build: ## Build containers
 	docker compose build --parallel api front api-test yoti-mock
 
 up: ## Start application
@@ -18,7 +18,7 @@ api-psalm: ## Run Psalm checks against API code
 api-phpcs: ## Run PHPCS checks against API code
 	docker compose -p api-phpcs run --rm api-test vendor/bin/phpcs --report=junit --report-file=build/phpcs-junit.xml
 
-api-unit-test: scripts/localstack/init/private_key.pem ## Run API unit tests
+api-unit-test: ## Run API unit tests
 	docker compose -p api-unit-test run --rm api-test vendor/bin/phpunit --log-junit=build/phpunit-junit.xml
 
 front-psalm: ## Run Psalm checks against front end code
@@ -43,7 +43,3 @@ clean-junit-output:
 	sed -i -E 's/testcase name="(.*?)\/var\/www\/([^ ]+?)( \(([0-9]+):[0-9]+\))?"/& file="\2" line="\4"/g' ./service-front/build/phpcs-junit.xml
 	sed -i -E 's/testcase name="(.*?):([0-9]+)"/& file="\1" line="\2"/g' ./service-api/build/psalm-junit.xml
 	sed -i -E 's/testcase name="(.*?):([0-9]+)"/& file="\1" line="\2"/g' ./service-front/build/psalm-junit.xml
-
-scripts/localstack/init/private_key.pem:
-	openssl genpkey -algorithm RSA -out scripts/localstack/init/private_key.pem -pkeyopt rsa_keygen_bits:2048
-	openssl rsa -pubout -in scripts/localstack/init/private_key.pem -out scripts/localstack/init/public_key.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,8 +177,6 @@ services:
   localstack:
     image: localstack/localstack:3.5
     volumes:
-      - "./scripts/localstack/init/private_key.pem:/tmp/private_key.pem"
-      - "./scripts/localstack/init/public_key.pem:/tmp/public_key.pem"
       - "./scripts/localstack/init:/etc/localstack/init/ready.d"
       - "./scripts/localstack/wait:/scripts/wait"
 

--- a/scripts/localstack/init/localstack_init.sh
+++ b/scripts/localstack/init/localstack_init.sh
@@ -16,6 +16,9 @@ awslocal secretsmanager create-secret --name local/paper-identity/yoti/sdk-clien
     --description "ID of Yoti client" \
     --secret-string "empty"
 
+openssl genpkey -algorithm RSA -out /tmp/private_key.pem -pkeyopt rsa_keygen_bits:2048
+openssl rsa -pubout -in /tmp/private_key.pem -out /tmp/public_key.pem
+
 awslocal secretsmanager create-secret --name local/paper-identity/public-key \
     --region "eu-west-1" \
     --description "Local dev public key" \


### PR DESCRIPTION
## Purpose

This avoids having keys on developers' machines, reducing the risk of them being committed to repos or otherwise shared.

#patch

## Approach

Generate the key in the initialisation script inside localstack, rather than doing it on local machine and mounting it into the docker image.

## Learning

To update a secret to another value, you can exec onto the box:
```sh
docker compose exec localstack awslocal secretsmanager put-secret-value --secret-id={SECRET_ID} --secret-string={SECRET_VALUE}
```

## Checklist

* [x] I have performed a self-review of my own code
