### PR TITLE
feature/ID-169-ID-Service-API-endpoint-to-handle-Yoti-notification

### DIFF
--- a/scripts/localstack/init/localstack_init.sh
+++ b/scripts/localstack/init/localstack_init.sh
@@ -8,6 +8,16 @@ awslocal dynamodb create-table \
     AttributeName=id,KeyType=HASH \
   --provisioned-throughput ReadCapacityUnits=1000,WriteCapacityUnits=1000
 
+sleep 5
+
+awslocal dynamodb update-table \
+    --table-name identity-verify \
+    --attribute-definitions AttributeName=sessionId,AttributeType=S \
+    --global-secondary-index-updates \
+        "[{\"Create\":{\"IndexName\": \"sessionId-index\",\"KeySchema\":[{\"AttributeName\":\"sessionId\",\"KeyType\":\"HASH\"}], \
+        \"ProvisionedThroughput\": {\"ReadCapacityUnits\": 20, \"WriteCapacityUnits\": 10 }, \
+        \"Projection\":{\"ProjectionType\":\"ALL\"}}}]"
+
 awslocal secretsmanager create-secret --name local/paper-identity/yoti/certificate \
     --description "PEM certificate for authentication with Yoti API" \
     --secret-string "empty"

--- a/scripts/localstack/init/localstack_init.sh
+++ b/scripts/localstack/init/localstack_init.sh
@@ -12,9 +12,9 @@ sleep 5
 
 awslocal dynamodb update-table \
     --table-name identity-verify \
-    --attribute-definitions AttributeName=sessionId,AttributeType=S \
+    --attribute-definitions AttributeName=yotiSessionId,AttributeType=S \
     --global-secondary-index-updates \
-        "[{\"Create\":{\"IndexName\": \"sessionId-index\",\"KeySchema\":[{\"AttributeName\":\"sessionId\",\"KeyType\":\"HASH\"}], \
+        "[{\"Create\":{\"IndexName\": \"yotiSessionId-index\",\"KeySchema\":[{\"AttributeName\":\"yotiSessionId\",\"KeyType\":\"HASH\"}], \
         \"ProvisionedThroughput\": {\"ReadCapacityUnits\": 20, \"WriteCapacityUnits\": 10 }, \
         \"Projection\":{\"ProjectionType\":\"ALL\"}}}]"
 

--- a/service-api/module/Application/config/module.config.php
+++ b/service-api/module/Application/config/module.config.php
@@ -241,6 +241,16 @@ return [
                     ],
                 ]
             ],
+            'yoti_notification' => [
+                'type'    => Segment::class,
+                'options' => [
+                    'route'    => '/counter-service/notification',
+                    'defaults' => [
+                        'controller' => Controller\YotiController::class,
+                        'action'     => 'notification',
+                    ],
+                ],
+            ],
             'add_search_postcode' => [
                 'type' => Segment::class,
                 'options' => [

--- a/service-api/module/Application/src/Controller/IdentityController.php
+++ b/service-api/module/Application/src/Controller/IdentityController.php
@@ -570,7 +570,6 @@ class IdentityController extends AbstractActionController
                     $counterServiceMap["selectedPostOfficeDeadline"] =
                         $case->counterService->selectedPostOfficeDeadline;
                 }
-                $counterServiceMap["sessionId"] = $yotiSessionId;
                 $counterServiceMap["notificationsAuthToken"] = $notificationsAuthToken;
 
                 if ($result["status"] < 400) {
@@ -581,6 +580,13 @@ class IdentityController extends AbstractActionController
                         array_map(fn (mixed $v) => [
                             'S' => $v
                         ], $counterServiceMap),
+                    );
+
+                    $this->dataImportHandler->updateCaseData(
+                        $uuid,
+                        'sessionId',
+                        'S',
+                        $yotiSessionId
                     );
                 }
                 //Prepare and generate PDF

--- a/service-api/module/Application/src/Controller/YotiController.php
+++ b/service-api/module/Application/src/Controller/YotiController.php
@@ -6,7 +6,6 @@ namespace Application\Controller;
 
 use Application\Fixtures\DataImportHandler;
 use Application\Fixtures\DataQueryHandler;
-use Application\Model\Entity\CaseData;
 use Application\Model\Entity\Problem;
 use Application\Yoti\Http\Exception\YotiException;
 use Application\Yoti\SessionConfig;
@@ -89,22 +88,20 @@ class YotiController extends AbstractActionController
     public function notificationAction(): JsonModel
     {
         $data = json_decode($this->getRequest()->getContent(), true);
-        $values = filter_input_array($data);
         if ( !isset($data['session_id'], $data['topic'])) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
             return new JsonModel(new Problem('Missing required parameters'));
         }
 
-        if ( !in_array($data['topic'], array('FIRST_BRANCH_VISIT', 'SESSION_COMPLETION'))) {
+        if ( !in_array($data['topic'], array('first_branch_visit', 'session_completion'))) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
             return new JsonModel(new Problem('Invalid type'));
         }
 
         $sessionId = filter_var($data['session_id'], FILTER_SANITIZE_SPECIAL_CHARS);
-        //$sessionToken = filter_var($data['sessionToken'], FILTER_SANITIZE_SPECIAL_CHARS);
 
         $caseData = $this->dataQuery->queryByYotiSessionId($sessionId);
-        //now update
+        //now update counterService data
         $counterServiceMap = [];
 
         if ($caseData->counterService !== null) {

--- a/service-api/module/Application/src/Controller/YotiController.php
+++ b/service-api/module/Application/src/Controller/YotiController.php
@@ -113,4 +113,39 @@ class YotiController extends AbstractActionController
         $data['response'] = $this->yotiService->retrieveLetterPDF($session);
         return new JsonModel($data);
     }
+
+    /**
+     * @return JsonModel
+     */
+    public function notificationAction(): JsonModel
+    {
+        $branches = [];
+        $data = json_decode($this->getRequest()->getContent(), true);
+        $values = filter_input_array($data);
+        if ( !isset($data['sessionId'], $data['sessionToken'], $data['type'])) {
+            $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
+            return new JsonModel(new Problem('Missing required parameters'));
+        }
+
+        if ( !in_array($data['type'], array('FIRST_BRANCH_VISIT', 'SESSION_COMPLETION'))) {
+            $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
+            return new JsonModel(new Problem('Invalid type'));
+        }
+
+        $sessionId = filter_var($data['sessionId'], FILTER_SANITIZE_SPECIAL_CHARS);
+        $sessionToken = filter_var($data['sessionToken'], FILTER_SANITIZE_SPECIAL_CHARS);
+
+        try {
+            //call yotiservice to save the updates to case or maybe just use dataImporthandler directly?
+
+        } catch (YotiException $e) {
+            $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
+            return new JsonModel(new Problem(
+                'Service issue',
+                extra: ['errors' => $e->getMessage()],
+            ));
+        }
+        $this->getResponse()->setStatusCode(Response::STATUS_CODE_200);
+        return new JsonModel($branches);
+    }
 }

--- a/service-api/module/Application/src/Controller/YotiController.php
+++ b/service-api/module/Application/src/Controller/YotiController.php
@@ -84,6 +84,7 @@ class YotiController extends AbstractActionController
 
     /**
      * @return JsonModel
+     * @psalm-suppress PossiblyInvalidMethodCall, PossiblyUndefinedMethod, PossiblyNullPropertyFetch
      */
     public function notificationAction(): JsonModel
     {
@@ -118,11 +119,11 @@ class YotiController extends AbstractActionController
         //authorize
         if ($caseData->counterService->notificationsAuthToken === $token) {
             //now update counterService data
-            $this->dataImportHandler->updateCaseData(
+            $this->dataImportHandler->updateCaseChildAttribute(
                 $caseData->id,
                 'counterService.notificationState',
                 'S',
-                $data['topic']
+                $data['topic'],
             );
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_200);
             return new JsonModel(["Notification Status" => "Updated"]);

--- a/service-api/module/Application/src/Controller/YotiController.php
+++ b/service-api/module/Application/src/Controller/YotiController.php
@@ -88,12 +88,12 @@ class YotiController extends AbstractActionController
     public function notificationAction(): JsonModel
     {
         $data = json_decode($this->getRequest()->getContent(), true);
-        if ( !isset($data['session_id'], $data['topic'])) {
+        if (! isset($data['session_id'], $data['topic'])) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
             return new JsonModel(new Problem('Missing required parameters'));
         }
 
-        if ( !in_array($data['topic'], array('first_branch_visit', 'session_completion'))) {
+        if (! in_array($data['topic'], ['first_branch_visit', 'session_completion'])) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
             return new JsonModel(new Problem('Invalid type'));
         }
@@ -101,6 +101,11 @@ class YotiController extends AbstractActionController
         $sessionId = filter_var($data['session_id'], FILTER_SANITIZE_SPECIAL_CHARS);
 
         $caseData = $this->dataQuery->queryByYotiSessionId($sessionId);
+
+        if (! $caseData) {
+            $this->getResponse()->setStatusCode(Response::STATUS_CODE_500);
+            return new JsonModel(new Problem('Case with session_id not found'));
+        }
         //now update counterService data
         $counterServiceMap = [];
 

--- a/service-api/module/Application/src/Fixtures/DataImportHandler.php
+++ b/service-api/module/Application/src/Fixtures/DataImportHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Fixtures;
 
 use Application\Model\Entity\CaseData;
+use Application\Model\Entity\CounterService;
 use Aws\DynamoDb\DynamoDbClient;
 use Aws\DynamoDb\Exception\DynamoDbException;
 use Aws\DynamoDb\Marshaler;
@@ -88,6 +89,69 @@ class DataImportHandler
             ]);
         } catch (AwsException $e) {
             $this->logger->error('Unable to update data [' . $e->getMessage() . '] for case' . $uuid, [
+                'data' => [$attrName => $attrValue]
+            ]);
+        }
+    }
+    /**
+     * Specifically for use cases to update map attributes passing in counterService.deadline etc
+     * @psalm-suppress ArgumentTypeCoercion
+     */
+    public function updateCaseChildAttribute(string $uuid, string $attrName, string $attrType, mixed $attrValue): void
+    {
+        $attributes = explode(".", $attrName);
+
+        $caseSubClass = '\\' . ucfirst($attributes[0]);
+
+        $fqnClass = "Application\Model\Entity" . $caseSubClass;
+
+        if (! property_exists($fqnClass, $attributes[1])) {
+            throw new InvalidArgumentException(
+                sprintf($caseSubClass . ' has no such property "%s"', $attributes[1])
+            );
+        }
+        $inputFilter = (new AttributeBuilder())
+            ->createForm($fqnClass)
+            ->getInputFilter();
+        $input = $inputFilter->get($attributes[1]);
+
+        if ($input instanceof InputInterface) {
+            $input->setValue($attrValue);
+
+            if (! $input->isValid()) {
+                throw new InvalidArgumentException(sprintf(
+                    '"%s" is not a valid value for %s',
+                    is_string($attrValue) ? $attrValue : json_encode($attrValue),
+                    $attributes[1]
+                ));
+            }
+        }
+
+        $idKey = [
+            'key' => [
+                'id' => [
+                    'S' => $uuid,
+                ],
+            ],
+        ];
+
+        try {
+            $this->dynamoDbClient->updateItem([
+                'Key' => $idKey['key'],
+                'TableName' => $this->tableName,
+                'UpdateExpression' => "set #CV.#NV=:NV",
+                'ExpressionAttributeNames' => [
+                    '#CV' => $attributes[0],
+                    '#NV' => $attributes[1],
+                ],
+                'ExpressionAttributeValues' => [
+                    ':NV' => [
+                        $attrType => $attrValue
+                    ]
+                ],
+            ]);
+        } catch (AwsException $e) {
+            $this->logger->error('Unable to update attributes [' . $e->getMessage() . '] for case' . $uuid, [
                 'data' => [$attrName => $attrValue]
             ]);
         }

--- a/service-api/module/Application/src/Fixtures/DataQueryHandler.php
+++ b/service-api/module/Application/src/Fixtures/DataQueryHandler.php
@@ -49,9 +49,8 @@ class DataQueryHandler
         return $arr ? CaseData::fromArray($arr) : null;
     }
 
-    public function queryByYotiSessionId(string $sessionId): array
+    public function queryByYotiSessionId(string $sessionId): ?CaseData
     {
-        //return some subset of data
         $idKey = [
             'key' => [
                 'sessionId' => [
@@ -62,7 +61,9 @@ class DataQueryHandler
         $index = "sessionId-index";
         $result = $this->query($idKey, $index);
 
-        return $this->returnUnmarshalResult($result);
+        $array = $this->returnUnmarshalResult($result)[0];
+
+        return $array ? CaseData::fromArray($array) : null;
     }
 
     public function queryByIDNumber(string $idNumber): array

--- a/service-api/module/Application/src/Fixtures/DataQueryHandler.php
+++ b/service-api/module/Application/src/Fixtures/DataQueryHandler.php
@@ -49,6 +49,22 @@ class DataQueryHandler
         return $arr ? CaseData::fromArray($arr) : null;
     }
 
+    public function queryByYotiSessionId(string $sessionId): array
+    {
+        //return some subset of data
+        $idKey = [
+            'key' => [
+                'sessionId' => [
+                    'S' => $sessionId,
+                ],
+            ],
+        ];
+        $index = "sessionId-index";
+        $result = $this->query($idKey, $index);
+
+        return $this->returnUnmarshalResult($result);
+    }
+
     public function queryByIDNumber(string $idNumber): array
     {
         //return some subset of data

--- a/service-api/module/Application/src/Fixtures/DataQueryHandler.php
+++ b/service-api/module/Application/src/Fixtures/DataQueryHandler.php
@@ -53,12 +53,12 @@ class DataQueryHandler
     {
         $idKey = [
             'key' => [
-                'sessionId' => [
+                'yotiSessionId' => [
                     'S' => $sessionId,
                 ],
             ],
         ];
-        $index = "sessionId-index";
+        $index = "yotiSessionId-index";
         $result = $this->query($idKey, $index);
 
         $array = $this->returnUnmarshalResult($result)[0];

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -79,6 +79,9 @@ class CaseData implements JsonSerializable
     public ?string $searchPostcode = null;
 
     #[Annotation\Required(false)]
+    #[Annotation\Validator(Uuid::class)]
+    public ?string $sessionId = null;
+    #[Annotation\Required(false)]
     public ?CounterService $counterService = null;
 
     #[Annotation\Required(false)]
@@ -117,10 +120,9 @@ class CaseData implements JsonSerializable
      *     alternateAddress?: string[],
      *     searchPostcode?: string,
      *     idMethod?: string,
+     *     sessionId?: string,
      *     counterService?: string[],
      *     kbvQuestions?: string[]
-     *     idMethod?: string
-     *     kbvQuestions?: string[],
      *     idMethodIncludingNation?: string[]
      * }
      */
@@ -138,13 +140,13 @@ class CaseData implements JsonSerializable
             'alternateAddress' => $this->alternateAddress,
             'searchPostcode' => $this->searchPostcode,
             'idMethod' => $this->idMethod,
+            'sessionId' => $this->sessionId,
             'idMethodIncludingNation' => $this->idMethodIncludingNation,
         ];
         if ($this->counterService !== null) {
             $arr['counterService'] = [
                 'selectedPostOffice' => $this->counterService->selectedPostOffice,
                 'selectedPostOfficeDeadline' => $this->counterService->selectedPostOfficeDeadline,
-                'sessionId' => $this->counterService->sessionId,
                 'notificationsAuthToken' => $this->counterService->notificationsAuthToken
             ];
         }

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -80,7 +80,7 @@ class CaseData implements JsonSerializable
 
     #[Annotation\Required(false)]
     #[Annotation\Validator(Uuid::class)]
-    public string $sessionId = '7871cae1-6712-4d3f-9111-1c1e38ceb222';
+    public string $yotiSessionId = 'empty';
     #[Annotation\Required(false)]
     public ?CounterService $counterService = null;
 
@@ -120,7 +120,7 @@ class CaseData implements JsonSerializable
      *     alternateAddress?: string[],
      *     searchPostcode?: string,
      *     idMethod?: string,
-     *     sessionId?: string,
+     *     yotiSessionId?: string,
      *     counterService?: string[],
      *     kbvQuestions?: string[]
      *     idMethodIncludingNation?: string[]
@@ -140,7 +140,7 @@ class CaseData implements JsonSerializable
             'alternateAddress' => $this->alternateAddress,
             'searchPostcode' => $this->searchPostcode,
             'idMethod' => $this->idMethod,
-            'sessionId' => $this->sessionId,
+            'yotiSessionId' => $this->yotiSessionId,
             'idMethodIncludingNation' => $this->idMethodIncludingNation,
         ];
         if ($this->counterService !== null) {

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -80,7 +80,8 @@ class CaseData implements JsonSerializable
 
     #[Annotation\Required(false)]
     #[Annotation\Validator(Uuid::class)]
-    public string $yotiSessionId = 'b2b1508a-f418-49b4-ac01-c315e34cd15f';
+    //Due to dynamodb quarks, due to index this always need to have a value
+    public string $yotiSessionId = '00000000-0000-0000-0000-000000000000';
     #[Annotation\Required(false)]
     public ?CounterService $counterService = null;
 

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -80,7 +80,7 @@ class CaseData implements JsonSerializable
 
     #[Annotation\Required(false)]
     #[Annotation\Validator(Uuid::class)]
-    public ?string $sessionId = null;
+    public string $sessionId = '7871cae1-6712-4d3f-9111-1c1e38ceb222';
     #[Annotation\Required(false)]
     public ?CounterService $counterService = null;
 
@@ -147,8 +147,8 @@ class CaseData implements JsonSerializable
             $arr['counterService'] = [
                 'selectedPostOffice' => $this->counterService->selectedPostOffice,
                 'selectedPostOfficeDeadline' => $this->counterService->selectedPostOfficeDeadline,
-                'notificationsAuthToken' => $this->counterService->notificationsAuthToken,
-                'notificationState' => $this->counterService
+                'notificationState' => $this->counterService->notificationState,
+                'notificationsAuthToken' => $this->counterService->notificationsAuthToken
             ];
         }
 

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -80,7 +80,7 @@ class CaseData implements JsonSerializable
 
     #[Annotation\Required(false)]
     #[Annotation\Validator(Uuid::class)]
-    public string $yotiSessionId = 'empty';
+    public string $yotiSessionId = 'b2b1508a-f418-49b4-ac01-c315e34cd15f';
     #[Annotation\Required(false)]
     public ?CounterService $counterService = null;
 

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -125,7 +125,6 @@ class CaseData implements JsonSerializable
      *     searchPostcode?: string,
      *     yotiSessionId?: string,
      *     counterService?: string[],
-     *     kbvQuestions?: string[],
      *     idMethod?: string,
      *     idMethodIncludingNation?: string[],
      *     progressPage?: string,

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -147,7 +147,8 @@ class CaseData implements JsonSerializable
             $arr['counterService'] = [
                 'selectedPostOffice' => $this->counterService->selectedPostOffice,
                 'selectedPostOfficeDeadline' => $this->counterService->selectedPostOfficeDeadline,
-                'notificationsAuthToken' => $this->counterService->notificationsAuthToken
+                'notificationsAuthToken' => $this->counterService->notificationsAuthToken,
+                'notificationState' => $this->counterService
             ];
         }
 

--- a/service-api/module/Application/src/Model/Entity/CounterService.php
+++ b/service-api/module/Application/src/Model/Entity/CounterService.php
@@ -19,7 +19,6 @@ class CounterService implements JsonSerializable
     #[Annotation\Required(false)]
     public string $notificationState = '';
 
-
     #[Annotation\Required(false)]
     #[Annotation\Validator(Uuid::class)]
     #[Annotation\Validator(NotEmpty::class)]

--- a/service-api/module/Application/src/Model/Entity/CounterService.php
+++ b/service-api/module/Application/src/Model/Entity/CounterService.php
@@ -17,9 +17,8 @@ class CounterService implements JsonSerializable
     public string $selectedPostOfficeDeadline = '';
 
     #[Annotation\Required(false)]
-    #[Annotation\Validator(Uuid::class)]
-    #[Annotation\Validator(NotEmpty::class)]
-    public string $sessionId = '';
+    public string $notificationState = '';
+
 
     #[Annotation\Required(false)]
     #[Annotation\Validator(Uuid::class)]
@@ -48,8 +47,8 @@ class CounterService implements JsonSerializable
      * @returns array{
      *     selectedPostOffice: string,
      *     selectedPostOfficeDeadline: string,
-     *     sessionId: string,
-     *     notificationsAuthToken: string
+     *     notificationsAuthToken: string,
+     *     notificationState: string
      * }
      */
     public function toArray(): array
@@ -57,8 +56,8 @@ class CounterService implements JsonSerializable
         return [
             'selectedPostOffice' => $this->selectedPostOffice,
             'selectedPostOfficeDeadline' => $this->selectedPostOfficeDeadline,
-            'sessionId' => $this->sessionId,
-            'notificationsAuthToken' => $this->notificationsAuthToken
+            'notificationsAuthToken' => $this->notificationsAuthToken,
+            'notificationState' => $this->notificationState
         ];
     }
 

--- a/service-api/module/Application/test/ApplicationTest/Fixtures/DataImportHandlerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Fixtures/DataImportHandlerTest.php
@@ -172,6 +172,40 @@ class DataImportHandlerTest extends TestCase
             ])
         );
     }
+    /**
+     * @psalm-suppress UndefinedMagicMethod
+     * @psalm-suppress PossiblyUndefinedMethod
+     */
+    public function testUpdateCaseChildAttribute(): void
+    {
+        $this->dynamoDbClientMock->expects($this->once())
+            ->method('__call')
+            ->with(
+                'updateItem',
+                $this->callback(function ($params) {
+                    // Ensure correct parameters passed to updateItem
+                    $input = $params[0];
+                    $this->assertEquals(['id' => ['S' => 'a9bc8ab8-389c-4367-8a9b-762ab3050491']], $input['Key']);
+                    $this->assertArrayHasKey('UpdateExpression', $input);
+                    $this->assertEquals(
+                        ['#CV' => 'counterService','#NV' => 'notificationState'],
+                        $input['ExpressionAttributeNames']
+                    );
+                    return true;
+                })
+            );
+
+        // Expect the logger to be called if an exception occurs
+        $this->loggerMock->expects($this->never())->method('error');
+
+        // Call the updateCaseData method with test data
+        $this->sut->updateCaseChildAttribute(
+            'a9bc8ab8-389c-4367-8a9b-762ab3050491',
+            'counterService.notificationState',
+            'S',
+            'complete'
+        );
+    }
 
     /**
      * @throws Exception

--- a/service-api/module/Application/test/ApplicationTest/Fixtures/DataQueryHandlerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Fixtures/DataQueryHandlerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Fixtures;
+
+use Application\Fixtures\DataQueryHandler;
+use Aws\DynamoDb\DynamoDbClient;
+use Aws\Result;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class DataQueryHandlerTest extends TestCase
+{
+    private DynamoDbClient|MockObject $dynamoDbClientMock;
+    private DataQueryHandler $sut;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        // Mocking the DynamoDB client and logger
+        $this->dynamoDbClientMock = $this->createMock(DynamoDbClient::class);
+        // Create an instance of SUT with mocked dependencies
+        $this->sut = new DataQueryHandler($this->dynamoDbClientMock, 'cases');
+    }
+
+    /**
+     * @psalm-suppress UndefinedMagicMethod
+     */
+    public function testGetCaseByYotiSessionIdCallsIndex(): void
+    {
+        // Stub the query method of DynamoDB client
+        $this->dynamoDbClientMock->expects($this->once())
+            ->method('__call')
+            ->with(
+                'query',
+                $this->callback(function ($params) {
+                    // Ensure correct parameters passed to query
+                    $input = $params[0];
+                    $this->assertEquals('cases', $input['TableName']);
+                    $this->assertEquals('yotiSessionId-index', $input['IndexName']);
+                    return true;
+                })
+            )
+            ->willReturn(new Result(
+                ['Items' => [['yotiSessionId' => ['S' => 'a9bc8ab8-389c-4367-8a9b-762ab3050491']]]]
+            ));
+
+        $this->sut->queryByYotiSessionId('a9bc8ab8-389c-4367-8a9b-762ab3050491');
+    }
+}

--- a/service-api/module/Application/test/Controller/YotiControllerTest.php
+++ b/service-api/module/Application/test/Controller/YotiControllerTest.php
@@ -273,7 +273,7 @@ class YotiControllerTest extends TestCase
         $headers->addHeaderLine('Accept', 'application/json');
         $headers->addHeaderLine('Content-Type', 'application/json');
 
-        if ($authorize) {
+        if ($authorize !== null) {
             $headers->addHeaderLine('authorization', $authorize);
         }
         /** @var HttpRequest $request */

--- a/service-api/module/Application/test/Controller/YotiControllerTest.php
+++ b/service-api/module/Application/test/Controller/YotiControllerTest.php
@@ -78,6 +78,11 @@ class YotiControllerTest extends TestCase
 
     public function testStatusWithID(): void
     {
+        $this->YotiServiceMock
+            ->expects($this->once())
+            ->method('retrieveResults')
+            ->willReturn(['state' => 'test']);
+
         $this->dispatch('/counter-service/wuefhdfhaksjd/retrieve-status', 'GET');
         $this->assertResponseStatusCode(200);
         $this->assertModuleName('application');

--- a/service-api/module/Application/test/Controller/YotiControllerTest.php
+++ b/service-api/module/Application/test/Controller/YotiControllerTest.php
@@ -124,9 +124,11 @@ class YotiControllerTest extends TestCase
         $this->assertMatchedRouteName('find_postoffice_branches');
     }
 
-    public function testYotiNotificationCallsCaseUpdate(): void
+    public function testYotiNotificationRequestFailsWithInvalidToken(): void
     {
-        $response = '{"Notification Status":"Updated"}';
+        $response = '{"title":"Unauthorised request"}';
+        $incorrectToken = 'incorrect';
+        $bearerToken = 'b2b1508a-f418-49b4-ac01-c315e34cd15a';
         $this->dataQueryHandlerMock
             ->expects($this->once())->method('queryByYotiSessionId')
             ->with('18f8ecad-066f-4540-9c11-8fbd103ce935')
@@ -138,15 +140,65 @@ class YotiControllerTest extends TestCase
                 'dob' => '',
                 'lpas' => [],
                 'address' => [],
+                'counterService' => [
+                    'notificationsAuthToken' => $bearerToken
+                ]
+            ]));
+
+        $this->dataImportHandler
+            ->expects($this->never())->method('updateCaseData');
+
+        $this->dispatchJSON(
+            '/counter-service/notification',
+            'POST',
+            [
+            'session_id' => '18f8ecad-066f-4540-9c11-8fbd103ce935',
+            'topic' => 'first_branch_visit',
+
+            ],
+            'Bearer ' . $incorrectToken,
+        );
+        $this->assertResponseStatusCode(403);
+        $this->assertEquals($response, $this->getResponse()->getContent());
+        $this->assertModuleName('application');
+        $this->assertControllerName(YotiController::class);
+        $this->assertControllerClass('YotiController');
+        $this->assertMatchedRouteName('yoti_notification');
+    }
+
+    public function testYotiNotificationCallsCaseUpdate(): void
+    {
+        $response = '{"Notification Status":"Updated"}';
+        $bearerToken = 'b2b1508a-f418-49b4-ac01-c315e34cd15a';
+        $this->dataQueryHandlerMock
+            ->expects($this->once())->method('queryByYotiSessionId')
+            ->with('18f8ecad-066f-4540-9c11-8fbd103ce935')
+            ->willReturn(CaseData::fromArray([
+                'id' => '2b45a8c1-dd35-47ef-a00e-c7b6264bf1cc',
+                'personType' => 'donor',
+                'firstName' => '',
+                'lastName' => '',
+                'dob' => '',
+                'lpas' => [],
+                'address' => [],
+                'counterService' => [
+                    'notificationsAuthToken' => $bearerToken
+                ]
             ]));
 
         $this->dataImportHandler
             ->expects($this->once())->method('updateCaseData');
 
-        $this->dispatchJSON('/counter-service/notification', 'POST', [
+        $this->dispatchJSON(
+            '/counter-service/notification',
+            'POST',
+            [
             'session_id' => '18f8ecad-066f-4540-9c11-8fbd103ce935',
-            'topic' => 'first_branch_visit'
-        ]);
+            'topic' => 'first_branch_visit',
+
+            ],
+            'Bearer ' . $bearerToken,
+        );
         $this->assertResponseStatusCode(200);
         $this->assertEquals($response, $this->getResponse()->getContent());
         $this->assertModuleName('application');
@@ -158,6 +210,7 @@ class YotiControllerTest extends TestCase
     public function testYotiNotificationThrowsErrorForCaseNotFound(): void
     {
         $response = '{"title":"Case with session_id not found"}';
+        $bearerToken = 'b2b1508a-f418-49b4-ac01-c315e34cd15a';
         $this->dataQueryHandlerMock
             ->expects($this->once())->method('queryByYotiSessionId')
             ->with('18f8ecad-066f-4540-9c11-8fbd103ce935')
@@ -166,10 +219,15 @@ class YotiControllerTest extends TestCase
         $this->dataImportHandler
             ->expects($this->never())->method('updateCaseData');
 
-        $this->dispatchJSON('/counter-service/notification', 'POST', [
+        $this->dispatchJSON(
+            '/counter-service/notification',
+            'POST',
+            [
             'session_id' => '18f8ecad-066f-4540-9c11-8fbd103ce935',
-            'topic' => 'first_branch_visit'
-        ]);
+            'topic' => 'first_branch_visit',
+            ],
+            'Bearer ' . $bearerToken,
+        );
         $this->assertResponseStatusCode(500);
         $this->assertEquals($response, $this->getResponse()->getContent());
         $this->assertModuleName('application');
@@ -181,15 +239,21 @@ class YotiControllerTest extends TestCase
     public function testYotiNotificationErrorWhenMissingParameters(): void
     {
         $response = '{"title":"Missing required parameters"}';
+        $bearerToken = 'b2b1508a-f418-49b4-ac01-c315e34cd15a';
         $this->dataQueryHandlerMock
             ->expects($this->never())->method('queryByYotiSessionId');
 
         $this->dataImportHandler
             ->expects($this->never())->method('updateCaseData');
 
-        $this->dispatchJSON('/counter-service/notification', 'POST', [
+        $this->dispatchJSON(
+            '/counter-service/notification',
+            'POST',
+            [
             'session_id' => '18f8ecad-066f-4540-9c11-8fbd103ce935',
-        ]);
+            ],
+            'Bearer ' . $bearerToken,
+        );
         $this->assertResponseStatusCode(400);
         $this->assertEquals($response, $this->getResponse()->getContent());
         $this->assertModuleName('application');
@@ -198,12 +262,15 @@ class YotiControllerTest extends TestCase
         $this->assertMatchedRouteName('yoti_notification');
     }
 
-    public function dispatchJSON(string $path, string $method, mixed $data = null): void
+    public function dispatchJSON(string $path, string $method, mixed $data = null, string $authorize = null): void
     {
         $headers = new Headers();
         $headers->addHeaderLine('Accept', 'application/json');
         $headers->addHeaderLine('Content-Type', 'application/json');
 
+        if ($authorize) {
+            $headers->addHeaderLine('authorization', $authorize);
+        }
         /** @var HttpRequest $request */
         $request = $this->getRequest();
         $request->setHeaders($headers);

--- a/service-api/module/Application/test/Controller/YotiControllerTest.php
+++ b/service-api/module/Application/test/Controller/YotiControllerTest.php
@@ -151,7 +151,7 @@ class YotiControllerTest extends TestCase
             ]));
 
         $this->dataImportHandler
-            ->expects($this->never())->method('updateCaseData');
+            ->expects($this->never())->method('updateCaseChildAttribute');
 
         $this->dispatchJSON(
             '/counter-service/notification',
@@ -192,7 +192,7 @@ class YotiControllerTest extends TestCase
             ]));
 
         $this->dataImportHandler
-            ->expects($this->once())->method('updateCaseData');
+            ->expects($this->once())->method('updateCaseChildAttribute');
 
         $this->dispatchJSON(
             '/counter-service/notification',
@@ -222,7 +222,7 @@ class YotiControllerTest extends TestCase
             ->willReturn(null);
 
         $this->dataImportHandler
-            ->expects($this->never())->method('updateCaseData');
+            ->expects($this->never())->method('updateCaseChildAttribute');
 
         $this->dispatchJSON(
             '/counter-service/notification',


### PR DESCRIPTION
## Purpose

This PR handles expected notification data from Yoti. It creates a new secondary index on sessionId 

Due to adding sessionId, this is now a required parameter and needs a default value, which is overwritten when session is actually created.

Fixes ###-####

## Approach

_Explain how your code addresses the purpose of the change._

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
