### PR TITLE
Pin Prism to v5.8.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   sirius-mock:
-    image: stoplight/prism:5.11.0
+    image: stoplight/prism:5.8.2
     command: mock -h 0.0.0.0 -p 4010 -d /tmp/openapi.yml
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
v5.11.0 has an issue loading JSON files, so revert back to v5.8.2 #patch