### PR TITLE
ID-291-donor-CP-bug-post-office-does-not

### DIFF
--- a/docker/yoti/data/branches.json
+++ b/docker/yoti/data/branches.json
@@ -5,7 +5,7 @@
       "fad_code": "12345678",
       "name": "St Neots",
       "address": "35 High Street, St. Neots, Cambridgeshire",
-      "postcode": "PE19 1NL",
+      "post_code": "PE19 1NL",
       "location": {
         "latitude": 52.22864,
         "longitude": -0.26762
@@ -16,7 +16,7 @@
       "fad_code": "12345677",
       "name": "St Pauls",
       "address": "3 St Pauls Way, St. Pauls, Nottinghamshire",
-      "postcode": "NT 1NL",
+      "post_code": "NT 1NL",
       "location": {
         "latitude": 51.22864,
         "longitude": -0.36762
@@ -27,7 +27,7 @@
       "fad_code": "12345676",
       "name": "Hampstead",
       "address": "66 High Street, Hampstead Heath, LONON",
-      "postcode": "NW3 6LR",
+      "post_code": "NW3 6LR",
       "location": {
         "latitude": 51.56808,
         "longitude": 0.1629

--- a/service-api/module/Application/src/Controller/IdentityController.php
+++ b/service-api/module/Application/src/Controller/IdentityController.php
@@ -584,7 +584,7 @@ class IdentityController extends AbstractActionController
 
                     $this->dataImportHandler->updateCaseData(
                         $uuid,
-                        'sessionId',
+                        'yotiSessionId',
                         'S',
                         $yotiSessionId
                     );

--- a/service-api/module/Application/src/Controller/YotiController.php
+++ b/service-api/module/Application/src/Controller/YotiController.php
@@ -51,7 +51,7 @@ class YotiController extends AbstractActionController
                 $branches[$branch["fad_code"]] = [
                     "name" => $branch["name"],
                     "address" => $branch["address"],
-                    "postcode" => $branch["postcode"]
+                    "post_code" => $branch["post_code"]
                 ];
             }
         } catch (YotiException $e) {

--- a/service-api/module/Application/src/Yoti/YotiService.php
+++ b/service-api/module/Application/src/Yoti/YotiService.php
@@ -271,9 +271,10 @@ class YotiService implements YotiServiceInterface
         ];
         /** @var CounterService $counterServiceData */
         $counterServiceData = $caseData->counterService;
+        $postOfficeData = json_decode($counterServiceData->selectedPostOffice, true);
         $payload["branch"] = [
           "type" => "UK_POST_OFFICE",
-          "fad_code" => $counterServiceData->selectedPostOffice
+          "fad_code" => $postOfficeData['fad']
         ];
         return $payload;
     }

--- a/service-api/module/Application/test/ApplicationTest/Services/YotiServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Services/YotiServiceTest.php
@@ -210,7 +210,7 @@ class YotiServiceTest extends TestCase
                 'line1' => '123 long street',
             ],
             'counterService' => [
-                'selectedPostOffice' => '29348729',
+                'selectedPostOffice' => json_encode(['fad' => '29348729'])
             ],
             'lpas' => []
         ]);

--- a/service-api/module/Application/test/Controller/YotiControllerTest.php
+++ b/service-api/module/Application/test/Controller/YotiControllerTest.php
@@ -112,9 +112,9 @@ class YotiControllerTest extends TestCase
     public function testBranchReturnFormat(): void
     {
         $response = '{"12345678":{"name":"St Neots","address":"35 High Street, St. ' .
-            'Neots, Cambridgeshire","postcode":"PE19 1NL"}' .
+            'Neots, Cambridgeshire","post_code":"PE19 1NL"}' .
                     ',"12345675":{"name":"Hampstead","address":"66 High Street, ' .
-            'Hampstead Heath, London","postcode":"NW3 6LR"}}';
+            'Hampstead Heath, London","post_code":"NW3 6LR"}}';
         $this->YotiServiceMock
             ->expects($this->once())->method('postOfficeBranch')
             ->with('NW1 4PG')
@@ -293,7 +293,7 @@ class YotiControllerTest extends TestCase
                     "fad_code" => "12345678",
                     "name" => "St Neots",
                     "address" => "35 High Street, St. Neots, Cambridgeshire",
-                    "postcode" => "PE19 1NL",
+                    "post_code" => "PE19 1NL",
                     "location" => [
                         "latitude" => 52.22864,
                         "longitude" => -0.26762
@@ -304,7 +304,7 @@ class YotiControllerTest extends TestCase
                     "fad_code" => "12345675",
                     "name" => "Hampstead",
                     "address" => "66 High Street, Hampstead Heath, London",
-                    "postcode" => "NW3 6LR",
+                    "post_code" => "NW3 6LR",
                     "location" => [
                         "latitude" => 52.22864,
                         "longitude" => -0.26762

--- a/service-front/module/Application/src/Controller/DonorPostOfficeFlowController.php
+++ b/service-front/module/Application/src/Controller/DonorPostOfficeFlowController.php
@@ -153,15 +153,15 @@ class DonorPostOfficeFlowController extends AbstractActionController
         $uuid = $this->params()->fromRoute("uuid");
         $optionsdata = $this->config['opg_settings']['post_office_identity_methods'];
         $detailsData = $this->opgApiService->getDetailsData($uuid);
-
+        
         $date = new \DateTime();
         $date->modify("+90 days");
         $deadline = $date->format("d M Y");
 
-        $postOfficeData = json_decode($detailsData['selectedPostOffice'], true);
+        $postOfficeData = json_decode($detailsData["counterService"]["selectedPostOffice"], true);
 
         $postOfficeAddress = explode(",", $postOfficeData['address']);
-        $postOfficeAddress = array_merge($postOfficeAddress, [$postOfficeData['postcode']]);
+        $postOfficeAddress = array_merge($postOfficeAddress, [$postOfficeData['post_code']]);
 
         $view->setVariable('options_data', $optionsdata);
         $view->setVariable('details_data', $detailsData);

--- a/service-front/module/Application/src/Controller/DonorPostOfficeFlowController.php
+++ b/service-front/module/Application/src/Controller/DonorPostOfficeFlowController.php
@@ -153,7 +153,7 @@ class DonorPostOfficeFlowController extends AbstractActionController
         $uuid = $this->params()->fromRoute("uuid");
         $optionsdata = $this->config['opg_settings']['post_office_identity_methods'];
         $detailsData = $this->opgApiService->getDetailsData($uuid);
-        
+
         $date = new \DateTime();
         $date->modify("+90 days");
         $deadline = $date->format("d M Y");


### PR DESCRIPTION
## Purpose

This PR fixed a bug with post code attribute naming, which was incorrectly specified in Yoti docks and this build as reference with mocks and tests

It also fixes the different use of counterService->selectedPostOffice is being send from FE as an object rather than simply containing fad_code

Fixes ###-####

## Approach

_Explain how your code addresses the purpose of the change._

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
