### PR TITLE
Create Experian IIQ cert file in bootstrap script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
         condition: service_healthy
       yoti-mock:
         condition: service_healthy
+    entrypoint: /usr/local/bin/docker-php-entrypoint
+    command: ["php-fpm"]
     env_file: ./service-api/docker-compose.env
     healthcheck:
       test: SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
     depends_on:
       localstack:
         condition: service_healthy
+    entrypoint: /usr/local/bin/docker-php-entrypoint
+    command: ["php-fpm"]
     env_file: ./service-api/docker-compose.env
     healthcheck:
       test: SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect 127.0.0.1:9000

--- a/docs/architecture/decisions/0004-managing-certificate-files.md
+++ b/docs/architecture/decisions/0004-managing-certificate-files.md
@@ -1,0 +1,23 @@
+# 4. Managing certificate files
+
+Date: 2024-08-08
+
+## Status
+
+Accepted
+
+## Context
+
+Some external API integrations require a signed PEM file to be provided over an SSL connection. Due to how PHP's SOAP client works, this must be present on the file system for the duration of the requests to the API. This means it cannot be passed as a string variable, or through a temporary file.
+
+## Decision
+
+We store the PEM certificate as a `.pem` file on disk. It will be created as a startup script on the container, rather than during runtime.
+
+The file will be in a private directory, which only the `www-data` user can write to or read from.
+
+The contents of the PEM file will be retrieved from secrets manager and written to disk.
+
+## Consequences
+
+Rotating the certificate will require updating secrets manager, then restarting each API container to regenerate the PEM file.

--- a/scripts/localstack/init/localstack_init.sh
+++ b/scripts/localstack/init/localstack_init.sh
@@ -25,3 +25,15 @@ awslocal secretsmanager create-secret --name local/paper-identity/yoti/certifica
 awslocal secretsmanager create-secret --name local/paper-identity/yoti/sdk-client-id \
     --description "ID of Yoti client" \
     --secret-string "empty"
+
+awslocal secretsmanager create-secret --name local/paper-identity/experian-idiq/certificate \
+    --description "Experian IIQ auth certificate" \
+    --secret-string "empty"
+
+awslocal secretsmanager create-secret --name local/paper-identity/experian-idiq/certificate-key \
+    --description "Experian IIQ auth certificate private key" \
+    --secret-string "empty"
+
+awslocal secretsmanager create-secret --name local/paper-identity/experian-idiq/certificate-key-passphrase \
+    --description "Experian IIQ auth certificate private key passphrase" \
+    --secret-string "empty"

--- a/service-api/Dockerfile
+++ b/service-api/Dockerfile
@@ -17,8 +17,17 @@ COPY docker/php/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY docker/php/www.conf /usr/local/etc/php-fpm.d/www.conf
 COPY docker/php/apcu.ini /usr/local/etc/php/conf.d/apcu.ini
 
+COPY docker/php-entrypoint /usr/local/bin/opg-paper-identity-entrypoint
+COPY docker/scripts /usr/local/bin/scripts
+
+RUN chmod +x /usr/local/bin/opg-paper-identity-entrypoint
+ENTRYPOINT ["/usr/local/bin/opg-paper-identity-entrypoint"]
+CMD ["php-fpm"]
+
 RUN mkdir /tmp/cache &&\
   chown -R www-data /tmp/cache &&\
+  mkdir -m 700 /opg-private &&\
+  chown -R www-data /opg-private &&\
   chown -R www-data /var/www/
 
 ENV PHP_FPM_MAX_CHILDREN "8"

--- a/service-api/docker-compose.env
+++ b/service-api/docker-compose.env
@@ -16,5 +16,4 @@ YOTI_LETTER_EMAIL=opg-all-team+yoti@digital.justice.gov.uk
 YOTI_NOTIFICATION_URL=https://localhost.com/notifyyy2
 # number in whole days for Yoti session completion
 YOTI_SESSION_DEADLINE=30
-SECRETS_MANAGER_PREFIX=local/paper-identity
-
+SECRETS_MANAGER_PREFIX=local/paper-identity/

--- a/service-api/docker/php-entrypoint
+++ b/service-api/docker/php-entrypoint
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+php /usr/local/bin/scripts/create-cert.php
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- php-fpm "$@"
+fi
+
+exec "$@"

--- a/service-api/docker/scripts/create-cert.php
+++ b/service-api/docker/scripts/create-cert.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\SecretsManager\SecretsManagerClient;
+
+include '/var/www/vendor/autoload.php';
+
+$prefix = getenv('SECRETS_MANAGER_PREFIX');
+if (!is_string($prefix)) {
+    throw new RuntimeException('Env var "SECRETS_MANAGER_PREFIX" required');
+}
+
+$smClient = new SecretsManagerClient([
+  'endpoint' => getenv('SECRETS_MANAGER_ENDPOINT') ?: '',
+]);
+
+$certificate = $smClient->getSecretValue([
+    'SecretId' => $prefix . 'experian-idiq/certificate',
+]);
+
+$certificateKey = $smClient->getSecretValue([
+  'SecretId' => $prefix . 'experian-idiq/certificate-key',
+]);
+
+$pemFilename = '/opg-private/experian-iiq-cert.pem';
+$pemContents = $certificate['SecretString'] . "\n\n" . $certificateKey['SecretString'];
+
+file_put_contents($pemFilename, $pemContents);
+chmod($pemFilename, 0400);

--- a/service-api/module/Application/src/Aws/Secrets/AwsSecretsCache.php
+++ b/service-api/module/Application/src/Aws/Secrets/AwsSecretsCache.php
@@ -26,7 +26,7 @@ class AwsSecretsCache
      */
     public function getValue(string $name): string
     {
-        $name = $this->prefix . '/' . $name;
+        $name = $this->prefix . $name;
         $key = self::NAMESPACE_AWS . ':' . $name;
 
         if ($this->storage->hasItem($key)) {

--- a/service-api/module/Application/src/Module.php
+++ b/service-api/module/Application/src/Module.php
@@ -34,7 +34,6 @@ class Module
         $application = $event->getApplication();
         /** @var ServiceManager $serviceManager */
         $serviceManager = $application->getServiceManager();
-        /** @var AwsSecretsCache $secretsCache */
         $secretsCache = $serviceManager->get(AwsSecretsCache::class);
         AwsSecret::setCache($secretsCache);
     }

--- a/service-api/module/Application/test/Aws/Secrets/AwsSecretsCacheTest.php
+++ b/service-api/module/Application/test/Aws/Secrets/AwsSecretsCacheTest.php
@@ -21,7 +21,7 @@ class AwsSecretsCacheTest extends TestCase
     {
         $this->client = $this->createMock(SecretsManagerClient::class);
         $this->storage = $this->createMock(StorageInterface::class);
-        $this->sut = new AwsSecretsCache('local', $this->storage, $this->client);
+        $this->sut = new AwsSecretsCache('local/', $this->storage, $this->client);
     }
 
     /**
@@ -46,11 +46,11 @@ class AwsSecretsCacheTest extends TestCase
     {
         return [
             'Return secret string' => [
-                'awsResponse' => ['SecretString' => 'secret']
+                'awsResponse' => ['SecretString' => 'secret'],
             ],
             'Return secret binary' => [
-                'awsResponse' => ['SecretBinary' => base64_encode('secret')]
-            ]
+                'awsResponse' => ['SecretBinary' => base64_encode('secret')],
+            ],
         ];
     }
 

--- a/service-api/module/Application/test/Controller/IdentityControllerTest.php
+++ b/service-api/module/Application/test/Controller/IdentityControllerTest.php
@@ -59,12 +59,6 @@ class IdentityControllerTest extends TestCase
         $serviceManager->setService(SessionConfig::class, $this->sessionConfigMock);
     }
 
-    public function testIndexActionResponse(): void
-    {
-        $this->dispatch('/', 'GET');
-        $this->assertEquals('{"Laminas":"Paper ID Service API"}', $this->getResponse()->getContent());
-    }
-
     public function testInvalidRouteDoesNotCrash(): void
     {
         $this->jsonHeaders();

--- a/service-api/module/Application/test/stubs/container.phpstub
+++ b/service-api/module/Application/test/stubs/container.phpstub
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psr\Container {
+
+    interface ContainerInterface
+    {
+        /** @param string|class-string $name */
+        public function has(string $name): bool;
+
+        /**
+         * @template T of object
+         * @psalm-param string|class-string<T> $name
+         * @psalm-return ($name is class-string ? T : mixed)
+         */
+        public function get(string $name): object;
+    }
+}

--- a/service-api/psalm.xml
+++ b/service-api/psalm.xml
@@ -41,6 +41,7 @@
     </issueHandlers>
 
     <stubs>
+        <file name="module/Application/test/stubs/container.phpstub"/>
         <file name="module/Application/test/stubs/laminas.phpstub"/>
     </stubs>
 


### PR DESCRIPTION
## Purpose

To be used when authenticating with the Experian IIQ API

Fixes ID-254 #minor

## Approach

Create a folder `/opg-private` which is only read/writeable by the `www-data` user.

Add a new Docker entrypoint that creates a cert file in that folder based on secrets from Secrets Manager.

In local/CI builds, use the default PHP entrypoint instead since we won't be able to generate a valid cert file.

Plus a couple of fixes:
- Add placeholder cert secrets in localstack
- Remove extra slashes from secret IDs
- Add Psalm stub file for better typing on Psr\Container\ContainerInterface

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
  * N/A, though I've tested in a popup env
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A, nothing to test
