### PR TITLE
Run test suites without dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,19 @@ down: ## Stop application
 	docker compose down
 
 api-psalm: ## Run Psalm checks against API code
-	docker compose -p api-psalm run --rm api-test vendor/bin/psalm -c ./psalm.xml --report=build/psalm-junit.xml
+	docker compose -p api-psalm run --rm --no-deps api-test vendor/bin/psalm -c ./psalm.xml --report=build/psalm-junit.xml
 
 api-phpcs: ## Run PHPCS checks against API code
-	docker compose -p api-phpcs run --rm api-test vendor/bin/phpcs --report=junit --report-file=build/phpcs-junit.xml
+	docker compose -p api-phpcs run --rm --no-deps api-test vendor/bin/phpcs --report=junit --report-file=build/phpcs-junit.xml
 
 api-unit-test: ## Run API unit tests
-	docker compose -p api-unit-test run --rm api-test vendor/bin/phpunit --log-junit=build/phpunit-junit.xml
+	docker compose -p api-unit-test run --rm --no-deps api-test vendor/bin/phpunit --log-junit=build/phpunit-junit.xml
 
 front-psalm: ## Run Psalm checks against front end code
-	docker compose -p front-psalm run --rm front-test vendor/bin/psalm -c ./psalm.xml --report=build/psalm-junit.xml
+	docker compose -p front-psalm run --rm --no-deps front-test vendor/bin/psalm -c ./psalm.xml --report=build/psalm-junit.xml
 
 front-phpcs: ## Run PHPCS checks against front end code
-	docker compose -p front-phpcs run --rm front-test vendor/bin/phpcs --report=junit --report-file=build/phpcs-junit.xml
+	docker compose -p front-phpcs run --rm --no-deps front-test vendor/bin/phpcs --report=junit --report-file=build/phpcs-junit.xml
 
 front-unit-test: ## Run front end unit tests
 	docker compose -p front-unit-test run --rm --volume ${PWD}/build/output/pacts:/tmp/pacts front-test vendor/bin/phpunit --log-junit=build/phpunit-junit.xml

--- a/scripts/localstack/init/localstack_init.sh
+++ b/scripts/localstack/init/localstack_init.sh
@@ -25,18 +25,3 @@ awslocal secretsmanager create-secret --name local/paper-identity/yoti/certifica
 awslocal secretsmanager create-secret --name local/paper-identity/yoti/sdk-client-id \
     --description "ID of Yoti client" \
     --secret-string "empty"
-
-# following keys are mostly for use by tests
-
-openssl genpkey -algorithm RSA -out /tmp/private_key.pem -pkeyopt rsa_keygen_bits:2048
-openssl rsa -pubout -in /tmp/private_key.pem -out /tmp/public_key.pem
-
-awslocal secretsmanager create-secret --name local/paper-identity/yoti/public-key \
-    --region "eu-west-1" \
-    --description "Local dev public key" \
-    --secret-string file:///tmp/public_key.pem
-
-awslocal secretsmanager create-secret --name local/paper-identity/yoti/private-key \
-    --region "eu-west-1" \
-    --description "Local dev private key" \
-    --secret-string file:///tmp/private_key.pem

--- a/service-api/module/Application/test/ApplicationTest/Yoti/Http/RequestSignerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Yoti/Http/RequestSignerTest.php
@@ -7,30 +7,31 @@ namespace ApplicationTest\Yoti\Http;
 use Application\Aws\Secrets\AwsSecret;
 use Application\Yoti\Http\Exception\YotiAuthException;
 use Application\Yoti\Http\RequestSigner;
-use Aws\Result;
-use Aws\SecretsManager\SecretsManagerClient;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class RequestSignerTest extends TestCase
 {
     private AwsSecret|MockObject $pemFileMock;
-    private SecretsManagerClient $secretsManagerClient;
-    private Result $privateResult;
-    private const PATH = '/api/endpoint';
-    private const METHOD = 'POST';
+    private static string $pemKeyPrivate;
+    private static string $pemKeyPublic;
+    private const string PATH = '/api/endpoint';
+    private const string METHOD = 'POST';
     private RequestSigner $sut;
+
+    public static function setUpBeforeClass(): void
+    {
+        $privateKey = openssl_pkey_new(['private_key_bits' => 2048]);
+        self::$pemKeyPublic = openssl_pkey_get_details(openssl_pkey_get_private($privateKey))['key'];
+
+        openssl_pkey_export(openssl_pkey_get_private($privateKey), $privateKeyContents);
+        self::$pemKeyPrivate = $privateKeyContents;
+    }
+
+
     public function setUp(): void
     {
         $this->pemFileMock = $this->createMock(AwsSecret::class);
-
-        $this->secretsManagerClient = new SecretsManagerClient([
-            'endpoint' => getenv('SECRETS_MANAGER_ENDPOINT'),
-            'region' => 'eu-west-1'
-        ]);
-        $this->privateResult = $this->secretsManagerClient->getSecretValue([
-            'SecretId' => 'local/paper-identity/yoti/private-key',
-        ]);
 
         $this->sut = new RequestSigner();
     }
@@ -46,7 +47,7 @@ class RequestSignerTest extends TestCase
 
         $this->pemFileMock->expects($this->atLeastOnce())
             ->method("getValue")
-            ->willReturn($this->privateResult['SecretString']);
+            ->willReturn(self::$pemKeyPrivate);
 
         $signedMessage = $this->sut->generateSignature(
             self::PATH,
@@ -55,12 +56,8 @@ class RequestSignerTest extends TestCase
             $payload
         );
         $messageToSign = self::METHOD . '&' . self::PATH . '&' . base64_encode($payload);
-        /** @var array $publicKeyResult */
-        $publicKeyResult = $this->secretsManagerClient->getSecretValue([
-            'SecretId' => 'local/paper-identity/yoti/public-key',
-        ]);
 
-        $publicKey = openssl_pkey_get_public($publicKeyResult['SecretString']);
+        $publicKey = openssl_pkey_get_public(self::$pemKeyPublic);
 
         $verify = openssl_verify($messageToSign, base64_decode($signedMessage), $publicKey, OPENSSL_ALGO_SHA256);
 
@@ -74,7 +71,7 @@ class RequestSignerTest extends TestCase
     {
         $this->pemFileMock->expects($this->atLeastOnce())
             ->method("getValue")
-            ->willReturn($this->privateResult["SecretString"]);
+            ->willReturn(self::$pemKeyPrivate);
 
         // Generate signature
         $signature = $this->sut->generateSignature(


### PR DESCRIPTION
## Purpose

PHPCS, Psalm and PHPUnit tests should not require any dependencies to run, so should be run in `--no-deps` mode.

#patch

## Approach

I rewrote `RequestSignerTest` to generate the SSL key in PHP rather than doing so via localstack. This saves about 15s when running the suite cold.

`front-unit-test` still needs to be run with dependencies to use Pact, but we'll be able to internalise that when Pact v10 is released.