### PR TITLE
Add XSRF header to Sirius requests

### DIFF
--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Application\Services;
 
+use Application\Helpers\AddressProcessorHelper;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Laminas\Http\Header\Cookie;
 use Laminas\Http\Request;
 use Laminas\Stdlib\RequestInterface;
-use Application\Helpers\AddressProcessorHelper;
 
 /**
  * @psalm-type Address = array{
@@ -50,7 +50,6 @@ use Application\Helpers\AddressProcessorHelper;
  *  },
  * }
  */
-
 class SiriusApiService
 {
     public function __construct(
@@ -66,12 +65,13 @@ class SiriusApiService
 
         $cookieHeader = $request->getHeader('Cookie');
 
-        if (! ($cookieHeader instanceof Cookie)) {
+        if (! ($cookieHeader instanceof Cookie) || ! isset($cookieHeader['XSRF-TOKEN'])) {
             return null;
         }
 
         return [
             'Cookie' => $cookieHeader->getFieldValue(),
+            'X-XSRF-TOKEN' => $cookieHeader['XSRF-TOKEN'],
         ];
     }
 


### PR DESCRIPTION
## Purpose

To pass authentication in write requests

Fixes ID-317 #patch

## Approach

Extract header from cookie value

## Learning

Sirius doesn't log XSRF errors very well, I'll improve things on the API side to make it clearer in the future.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * Will do in Sirius
* [x] I have updated documentation where relevant
  * I've added it to [the documentation](https://opgtransform.atlassian.net/wiki/spaces/LS/pages/3645767693/How+authentication+works+in+Sirius)
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
