### PR TITLE
Fixes to Yoti mock #patch

### DIFF
--- a/docker/yoti/openapi.yml
+++ b/docker/yoti/openapi.yml
@@ -92,11 +92,7 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
               examples:
                 PAYLOAD_VALIDATION:
-                  value:
-                    code: PAYLOAD_VALIDATION
-                    errors:
-                      - property: requested_checks
-                        message: must not be empty
+                  $ref: "#/components/examples/PayloadValidationError"
                 MALFORMED_REQUEST:
                   $ref: "#/components/examples/MalformedRequestDigestError"
         401:

--- a/docker/yoti/yoti-config.yaml
+++ b/docker/yoti/yoti-config.yaml
@@ -1,9 +1,6 @@
 plugin: openapi
 specFile: openapi.yml
 
-validation:
-  request: true
-
 resources:
   - path: "/idverify/v1/sessions/{sessionId}"
     method: get


### PR DESCRIPTION
## Purpose

A couple of fixes to unblock local development.

## Approach

- Turn off request validation: it expects everything to be JSON-encoded, which is unnecessary, and isn't providing any value
- Use an internal $ref for example errors: the manual one doesn't match expected structure
