### PR TITLE
Remove dependency on LPA Store data

### DIFF
--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -107,8 +107,10 @@ class SiriusApiService
 
         $responseArray = json_decode(strval($response->getBody()), true);
 
-        $responseArray['opg.poas.lpastore']['certificateProvider']['address'] = (new AddressProcessorHelper())
-            ->getAddress($responseArray['opg.poas.lpastore']['certificateProvider']['address']);
+        if (isset($responseArray['opg.poas.lpastore']['certificateProvider']['address'])) {
+            $responseArray['opg.poas.lpastore']['certificateProvider']['address'] = (new AddressProcessorHelper())
+                ->getAddress($responseArray['opg.poas.lpastore']['certificateProvider']['address']);
+        }
 
         return $responseArray;
     }


### PR DESCRIPTION
## Purpose

You currently can't start an ID check until the donor has submitted CP data, but they need to be able to perform ID checks before submission.

#minor

## Approach

Only try to reformat the CP's address if it has been provided.
