### PR TITLE
Log invalid topics

### DIFF
--- a/service-api/module/Application/src/Controller/YotiController.php
+++ b/service-api/module/Application/src/Controller/YotiController.php
@@ -185,6 +185,11 @@ class YotiController extends AbstractActionController
         }
 
         if (! in_array($data['topic'], ['first_branch_visit', 'session_completion'])) {
+            $this->logger->info('Unhandled topic from Yoti notification', [
+                'session_id' => $data['session_id'],
+                'topic' => $data['topic'],
+            ]);
+
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
             return new JsonModel(new Problem('Invalid type'));
         }


### PR DESCRIPTION
When Yoti sends a topic that we don't handle, log it to console.

This ensures we can track all notifications from Yoti for debugging, and will allow us to extend further in the future.

#patch
