### PR TITLE
ID-328-Refactor-dynamo-dataHandling

### DIFF
--- a/service-api/docker-compose.env
+++ b/service-api/docker-compose.env
@@ -18,7 +18,7 @@ SECRETS_MANAGER_ENDPOINT=http://localstack:4566
 SIRIUS_BASE_URL=http://sirius-mock:4010 # http://host.docker.internal:8080 for real Sirius
 YOTI_BASE_URL=http://yoti-mock:8080
 YOTI_LETTER_EMAIL=opg-all-team+yoti@digital.justice.gov.uk
-YOTI_NOTIFICATION_URL=https://localhost.com/notifyyy2
+YOTI_NOTIFICATION_URL=https://localhost.com/notify2
 # number in whole days for Yoti session completion
 YOTI_SESSION_DEADLINE=30
 SECRETS_MANAGER_PREFIX=local/paper-identity/

--- a/service-api/module/Application/config/module.config.php
+++ b/service-api/module/Application/config/module.config.php
@@ -16,7 +16,7 @@ use Application\DrivingLicense\ValidatorFactory as LicenseFactory;
 use Application\DrivingLicense\ValidatorInterface as LicenseInterface;
 use Application\Passport\ValidatorInterface as PassportValidatorInterface;
 use Application\Passport\ValidatorFactory as PassportValidatorFactory;
-use Application\Fixtures\DataImportHandler;
+use Application\Fixtures\DataWriteHandler;
 use Application\Fixtures\DataQueryHandler;
 use Application\Passport\ValidatorInterface;
 use Application\Yoti\SessionConfig;
@@ -417,14 +417,14 @@ return [
                 $serviceLocator->get(DynamoDbClient::class),
                 $tableName
             ),
-            DataImportHandler::class => fn(ServiceLocatorInterface $serviceLocator) => new DataImportHandler(
+            DataWriteHandler::class => fn(ServiceLocatorInterface $serviceLocator) => new DataWriteHandler(
                 $serviceLocator->get(DynamoDbClient::class),
                 $tableName,
                 $serviceLocator->get(LoggerInterface::class)
             ),
             SessionStatusService::class => fn(ServiceLocatorInterface $serviceLocator) => new SessionStatusService(
                 $serviceLocator->get(YotiServiceInterface::class),
-                $serviceLocator->get(DataImportHandler::class),
+                $serviceLocator->get(DataWriteHandler::class),
                 $serviceLocator->get(LoggerInterface::class)
             ),
             SessionConfig::class => InvokableFactory::class,

--- a/service-api/module/Application/src/Controller/IdentityController.php
+++ b/service-api/module/Application/src/Controller/IdentityController.php
@@ -9,7 +9,7 @@ use Application\Nino\ValidatorInterface;
 use Application\DrivingLicense\ValidatorInterface as LicenseValidatorInterface;
 use Application\Passport\ValidatorInterface as PassportValidator;
 use Application\KBV\KBVServiceInterface;
-use Application\Fixtures\DataImportHandler;
+use Application\Fixtures\DataWriteHandler;
 use Application\Fixtures\DataQueryHandler;
 use Application\Model\Entity\CaseData;
 use Application\Model\Entity\Problem;
@@ -36,7 +36,7 @@ class IdentityController extends AbstractActionController
     public function __construct(
         private readonly ValidatorInterface $ninoService,
         private readonly DataQueryHandler $dataQueryHandler,
-        private readonly DataImportHandler $dataImportHandler,
+        private readonly DataWriteHandler $dataHandler,
         private readonly LicenseValidatorInterface $licenseValidator,
         private readonly PassportValidator $passportService,
         private readonly KBVServiceInterface $KBVService,
@@ -63,7 +63,7 @@ class IdentityController extends AbstractActionController
             $caseData->id = strval(Uuid::uuid4());
 
             try {
-                $this->dataImportHandler->insertData($caseData);
+                $this->dataHandler->insertUpdateData($caseData);
             } catch (\Exception $exception) {
                 $this->getResponse()->setStatusCode(Response::STATUS_CODE_500);
                 return new JsonModel(new Problem($exception->getMessage()));
@@ -207,7 +207,7 @@ class IdentityController extends AbstractActionController
         } else {
             $questions = $this->KBVService->fetchFormattedQuestions($uuid);
 
-            $this->dataImportHandler->updateCaseData(
+            $this->dataHandler->updateCaseData(
                 $uuid,
                 'kbvQuestions',
                 'S',
@@ -259,7 +259,7 @@ class IdentityController extends AbstractActionController
             return new JsonModel(new Problem("Missing UUID"));
         }
         try {
-            $this->dataImportHandler->updateCaseData(
+            $this->dataHandler->updateCaseData(
                 $uuid,
                 'idMethod',
                 'S',
@@ -287,7 +287,7 @@ class IdentityController extends AbstractActionController
             return new JsonModel(new Problem('Missing UUID'));
         }
         try {
-            $this->dataImportHandler->updateCaseData(
+            $this->dataHandler->updateCaseData(
                 $uuid,
                 'searchPostcode',
                 'S',
@@ -319,7 +319,7 @@ class IdentityController extends AbstractActionController
         ];
 
         try {
-            $this->dataImportHandler->updateCaseData(
+            $this->dataHandler->updateCaseData(
                 $uuid,
                 'counterService',
                 'M',
@@ -358,7 +358,7 @@ class IdentityController extends AbstractActionController
         $counterServiceMap["selectedPostOfficeDeadline"] = $data['deadline'];
 
         try {
-            $this->dataImportHandler->updateCaseData(
+            $this->dataHandler->updateCaseData(
                 $uuid,
                 'counterService',
                 'M',
@@ -391,7 +391,7 @@ class IdentityController extends AbstractActionController
             $lpas = $data->lpas;
             if (! in_array($lpa, $lpas)) {
                 $lpas[] = $lpa;
-                $this->dataImportHandler->updateCaseData(
+                $this->dataHandler->updateCaseData(
                     $uuid,
                     'lpas',
                     'SS',
@@ -429,7 +429,7 @@ class IdentityController extends AbstractActionController
                         $keptLpas[] = $keptLpa;
                     }
                 }
-                $this->dataImportHandler->updateCaseData(
+                $this->dataHandler->updateCaseData(
                     $uuid,
                     'lpas',
                     'SS',
@@ -465,7 +465,7 @@ class IdentityController extends AbstractActionController
         }
 
         try {
-            $this->dataImportHandler->updateCaseData(
+            $this->dataHandler->updateCaseData(
                 $uuid,
                 'alternateAddress',
                 'M',
@@ -502,7 +502,7 @@ class IdentityController extends AbstractActionController
         }
 
         try {
-            $this->dataImportHandler->updateCaseData(
+            $this->dataHandler->updateCaseData(
                 $uuid,
                 'documentComplete',
                 'BOOL',
@@ -547,7 +547,7 @@ class IdentityController extends AbstractActionController
         }
 
         try {
-            $this->dataImportHandler->updateCaseData(
+            $this->dataHandler->updateCaseData(
                 $uuid,
                 'dob',
                 'S',
@@ -578,7 +578,7 @@ class IdentityController extends AbstractActionController
         }
 
         try {
-            $this->dataImportHandler->updateCaseData(
+            $this->dataHandler->updateCaseData(
                 $uuid,
                 'idMethodIncludingNation',
                 'M',
@@ -615,7 +615,7 @@ class IdentityController extends AbstractActionController
         }
 
         try {
-            $this->dataImportHandler->updateCaseData(
+            $this->dataHandler->updateCaseData(
                 $uuid,
                 'progressPage',
                 'M',

--- a/service-api/module/Application/src/Controller/YotiController.php
+++ b/service-api/module/Application/src/Controller/YotiController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Controller;
 
-use Application\Fixtures\DataImportHandler;
+use Application\Fixtures\DataWriteHandler;
 use Application\Fixtures\DataQueryHandler;
 use Application\Model\Entity\Problem;
 use Application\Yoti\Http\Exception\YotiException;
@@ -28,7 +28,7 @@ class YotiController extends AbstractActionController
 {
     public function __construct(
         private readonly YotiServiceInterface $yotiService,
-        private readonly DataImportHandler $dataImportHandler,
+        private readonly DataWriteHandler $dataHandler,
         private readonly DataQueryHandler $dataQuery,
         private readonly SessionStatusService $sessionService,
         private readonly SessionConfig $sessionConfig,
@@ -94,25 +94,14 @@ class YotiController extends AbstractActionController
         try {
             $result = $this->yotiService->createSession($sessionData, $nonce, $timestamp);
             $yotiSessionId = $result["data"]["session_id"];
+            $case->yotiSessionId = $yotiSessionId;
 
             if ($case->counterService !== null) {
                 $case->counterService->notificationsAuthToken = $notificationsAuthToken;
             }
 
             if ($result["status"] < 400) {
-                $this->dataImportHandler->updateCaseChildAttribute(
-                    $uuid,
-                    'counterService.notificationsAuthToken',
-                    'S',
-                    $notificationsAuthToken
-                );
-
-                $this->dataImportHandler->updateCaseData(
-                    $uuid,
-                    'yotiSessionId',
-                    'S',
-                    $yotiSessionId
-                );
+                $this->dataHandler->insertUpdateData($case);
             }
             //Prepare and generate PDF
             $this->yotiService->preparePDFLetter($case, $nonce, $timestamp, $yotiSessionId);
@@ -204,7 +193,7 @@ class YotiController extends AbstractActionController
             //authorize
             if ($caseData->counterService->notificationsAuthToken === $token) {
                 //now update counterService data
-                $this->dataImportHandler->updateCaseChildAttribute(
+                $this->dataHandler->updateCaseChildAttribute(
                     $caseData->id,
                     'counterService.notificationState',
                     'S',

--- a/service-api/module/Application/src/Fixtures/DataWriteHandler.php
+++ b/service-api/module/Application/src/Fixtures/DataWriteHandler.php
@@ -15,7 +15,7 @@ use Laminas\Form\Annotation\AttributeBuilder;
 use Laminas\InputFilter\InputInterface;
 use Psr\Log\LoggerInterface;
 
-class DataImportHandler
+class DataWriteHandler
 {
     public function __construct(
         private readonly DynamoDbClient $dynamoDbClient,
@@ -24,7 +24,7 @@ class DataImportHandler
     ) {
     }
 
-    public function insertData(CaseData $item): void
+    public function insertUpdateData(CaseData $item): void
     {
         $marsheler = new Marshaler();
         $encoded = $marsheler->marshalItem($item->jsonSerialize());

--- a/service-api/module/Application/src/Yoti/SessionStatusService.php
+++ b/service-api/module/Application/src/Yoti/SessionStatusService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Yoti;
 
-use Application\Fixtures\DataImportHandler;
+use Application\Fixtures\DataWriteHandler;
 use Application\Model\Entity\CaseData;
 use Application\Model\Entity\CounterService;
 use Application\Yoti\Http\Exception\YotiException;
@@ -17,7 +17,7 @@ class SessionStatusService
 {
     public function __construct(
         public readonly YotiServiceInterface $yotiService,
-        public readonly DataImportHandler $dataImportHandler,
+        public readonly DataWriteHandler $dataImportHandler,
         private readonly LoggerInterface $logger,
     ) {
     }
@@ -53,18 +53,8 @@ class SessionStatusService
             $caseData->counterService->state = $state;
             $caseData->counterService->result = $finalResult;
 
-            $this->dataImportHandler->updateCaseChildAttribute(
-                $caseData->id,
-                'counterService.state',
-                'S',
-                $state,
-            );
-            $this->dataImportHandler->updateCaseChildAttribute(
-                $caseData->id,
-                'counterService.result',
-                'BOOL',
-                $finalResult,
-            );
+            $this->dataImportHandler->insertUpdateData($caseData);
+
             //add to logs until we can send status updates directly to Sirius
             $this->logger->info("Update for CaseId " . $caseData->id . "- State: $state, Result: " . $finalResult);
         } catch (YotiException $e) {

--- a/service-api/module/Application/test/ApplicationTest/Fixtures/DataImportHandlerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Fixtures/DataImportHandlerTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ApplicationTest\Fixtures;
 
-use Application\Fixtures\DataImportHandler;
+use Application\Fixtures\DataWriteHandler;
 use Application\Model\Entity\CaseData;
 use Application\Model\IdMethod;
 use Aws\CommandInterface;
@@ -20,7 +20,7 @@ class DataImportHandlerTest extends TestCase
 {
     private DynamoDbClient|MockObject $dynamoDbClientMock;
     private LoggerInterface|MockObject $loggerMock;
-    private DataImportHandler $sut;
+    private DataWriteHandler $sut;
 
     public function setUp(): void
     {
@@ -30,7 +30,7 @@ class DataImportHandlerTest extends TestCase
         $this->dynamoDbClientMock = $this->createMock(DynamoDbClient::class);
         $this->loggerMock = $this->createMock(LoggerInterface::class);
         // Create an instance of SUT with mocked dependencies
-        $this->sut = new DataImportHandler($this->dynamoDbClientMock, 'cases', $this->loggerMock);
+        $this->sut = new DataWriteHandler($this->dynamoDbClientMock, 'cases', $this->loggerMock);
     }
 
     /**
@@ -74,7 +74,7 @@ class DataImportHandlerTest extends TestCase
         $this->loggerMock->expects($this->never())->method('error');
 
         // Call the insertData method with test data
-        $this->sut->insertData($case);
+        $this->sut->insertUpdateData($case);
     }
 
 
@@ -123,7 +123,7 @@ class DataImportHandlerTest extends TestCase
             );
 
         // Call the insertData method with test data
-        $this->sut->insertData($caseData);
+        $this->sut->insertUpdateData($caseData);
     }
 
     /**

--- a/service-api/module/Application/test/ApplicationTest/Fixtures/DataWriteHandlerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Fixtures/DataWriteHandlerTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
-class DataImportHandlerTest extends TestCase
+class DataWriteHandlerTest extends TestCase
 {
     private DynamoDbClient|MockObject $dynamoDbClientMock;
     private LoggerInterface|MockObject $loggerMock;

--- a/service-api/module/Application/test/ApplicationTest/Services/SessionStatusServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Services/SessionStatusServiceTest.php
@@ -136,7 +136,7 @@ class SessionStatusServiceTest extends TestCase
         $this->assertTrue($result->result);
         $this->assertEquals('COMPLETED', $result->state);
     }
-    
+
     public function testResultsAreFetchedAfterWithOneRejectionSavesFalseResult(): void
     {
         $caseData = CaseData::fromArray([

--- a/service-api/module/Application/test/ApplicationTest/Services/SessionStatusServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Services/SessionStatusServiceTest.php
@@ -92,11 +92,6 @@ class SessionStatusServiceTest extends TestCase
         $this->sut->getSessionStatus($caseData);
     }
 
-    /**
-     * @return void
-     * @throws \Exception
-     * @psalm-suppress MissingClosureParamType
-     */
     public function testResultsAreFetchedAfterSessionCompletionNotification(): void
     {
         $caseData = CaseData::fromArray([
@@ -141,12 +136,7 @@ class SessionStatusServiceTest extends TestCase
         $this->assertTrue($result->result);
         $this->assertEquals('COMPLETED', $result->state);
     }
-
-    /**
-     * @return void
-     * @throws \Exception
-     * @psalm-suppress MissingClosureParamType
-     */
+    
     public function testResultsAreFetchedAfterWithOneRejectionSavesFalseResult(): void
     {
         $caseData = CaseData::fromArray([

--- a/service-api/module/Application/test/Controller/IdentityControllerTest.php
+++ b/service-api/module/Application/test/Controller/IdentityControllerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace ApplicationTest\Controller;
 
 use Application\Controller\IdentityController;
-use Application\Fixtures\DataImportHandler;
+use Application\Fixtures\DataWriteHandler;
 use Application\Fixtures\DataQueryHandler;
 use Application\KBV\KBVServiceInterface;
 use Application\Model\Entity\CaseData;
@@ -24,7 +24,7 @@ class IdentityControllerTest extends TestCase
 {
     private DataQueryHandler&MockObject $dataQueryHandlerMock;
     private KBVServiceInterface&MockObject $KBVServiceMock;
-    private DataImportHandler&MockObject $dataImportHandler;
+    private DataWriteHandler&MockObject $dataImportHandler;
     private YotiService&MockObject $yotiServiceMock;
     private SessionConfig&MockObject $sessionConfigMock;
 
@@ -43,7 +43,7 @@ class IdentityControllerTest extends TestCase
 
         $this->dataQueryHandlerMock = $this->createMock(DataQueryHandler::class);
         $this->KBVServiceMock = $this->createMock(KBVServiceInterface::class);
-        $this->dataImportHandler = $this->createMock(DataImportHandler::class);
+        $this->dataImportHandler = $this->createMock(DataWriteHandler::class);
         $this->yotiServiceMock = $this->createMock(YotiService::class);
         $this->sessionConfigMock = $this->createMock(SessionConfig::class);
 
@@ -53,7 +53,7 @@ class IdentityControllerTest extends TestCase
         $serviceManager = $this->getApplicationServiceLocator();
         $serviceManager->setAllowOverride(true);
         $serviceManager->setService(DataQueryHandler::class, $this->dataQueryHandlerMock);
-        $serviceManager->setService(DataImportHandler::class, $this->dataImportHandler);
+        $serviceManager->setService(DataWriteHandler::class, $this->dataImportHandler);
         $serviceManager->setService(KBVServiceInterface::class, $this->KBVServiceMock);
         $serviceManager->setService(YotiServiceInterface::class, $this->yotiServiceMock);
         $serviceManager->setService(SessionConfig::class, $this->sessionConfigMock);

--- a/service-api/module/Application/test/Controller/YotiControllerTest.php
+++ b/service-api/module/Application/test/Controller/YotiControllerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace ApplicationTest\Controller;
 
 use Application\Controller\YotiController;
-use Application\Fixtures\DataImportHandler;
+use Application\Fixtures\DataWriteHandler;
 use Application\Fixtures\DataQueryHandler;
 use Application\Model\Entity\CaseData;
 use Application\Yoti\Http\Exception\YotiException;
@@ -27,7 +27,7 @@ class YotiControllerTest extends TestCase
 
     private DataQueryHandler&MockObject $dataQueryHandlerMock;
 
-    private DataImportHandler&MockObject $dataImportHandler;
+    private DataWriteHandler&MockObject $dataHandler;
 
     private SessionConfig&MockObject $sessionConfigMock;
 
@@ -47,7 +47,7 @@ class YotiControllerTest extends TestCase
         $this->YotiServiceMock = $this->createMock(YotiService::class);
         $this->statusService = $this->createMock(SessionStatusService::class);
         $this->dataQueryHandlerMock = $this->createMock(DataQueryHandler::class);
-        $this->dataImportHandler = $this->createMock(DataImportHandler::class);
+        $this->dataHandler = $this->createMock(DataWriteHandler::class);
         $this->sessionConfigMock = $this->createMock(SessionConfig::class);
 
 
@@ -59,7 +59,7 @@ class YotiControllerTest extends TestCase
         $serviceManager->setService(DataQueryHandler::class, $this->dataQueryHandlerMock);
         $serviceManager->setService(SessionStatusService::class, $this->statusService);
         $serviceManager->setService(SessionConfig::class, $this->sessionConfigMock);
-        $serviceManager->setService(DataImportHandler::class, $this->dataImportHandler);
+        $serviceManager->setService(DataWriteHandler::class, $this->dataHandler);
     }
 
     public function testInvalidRouteDoesNotCrash(): void
@@ -202,11 +202,8 @@ class YotiControllerTest extends TestCase
             ->with($response["data"]["session_id"])
             ->willReturn($pdfLetter);
 
-        $this->dataImportHandler
-            ->expects($this->atLeast(1))->method('updateCaseData');
-
-        $this->dataImportHandler
-            ->expects($this->atLeast(1))->method('updateCaseChildAttribute');
+        $this->dataHandler
+            ->expects($this->once())->method('insertUpdateData');
 
         $this->dispatch('/counter-service/test-uuid/create-session', 'POST', []);
         $this->assertResponseStatusCode(200);
@@ -237,7 +234,7 @@ class YotiControllerTest extends TestCase
                 ]
             ]));
 
-        $this->dataImportHandler
+        $this->dataHandler
             ->expects($this->never())->method('updateCaseChildAttribute');
 
         $this->dispatchJSON(
@@ -278,7 +275,7 @@ class YotiControllerTest extends TestCase
                 ]
             ]));
 
-        $this->dataImportHandler
+        $this->dataHandler
             ->expects($this->once())->method('updateCaseChildAttribute');
 
         $this->dispatchJSON(
@@ -308,7 +305,7 @@ class YotiControllerTest extends TestCase
             ->with('18f8ecad-066f-4540-9c11-8fbd103ce935')
             ->willReturn(null);
 
-        $this->dataImportHandler
+        $this->dataHandler
             ->expects($this->never())->method('updateCaseChildAttribute');
 
         $this->dispatchJSON(
@@ -335,7 +332,7 @@ class YotiControllerTest extends TestCase
         $this->dataQueryHandlerMock
             ->expects($this->never())->method('queryByYotiSessionId');
 
-        $this->dataImportHandler
+        $this->dataHandler
             ->expects($this->never())->method('updateCaseData');
 
         $this->dispatchJSON(


### PR DESCRIPTION
This PR refactors data handling areas, **_DataImportHandler_** was originally created to import data for initial project tasks, but to reflect actual use now been renamed to **_DataWriteHandler_**

It also makes use of dynamoDbs putItem() feature to also to update the entire $caseData at once rather than making several calls to update specific elements of it. 


## Purpose

_Briefly describe the purpose of the change._

Fixes ###-####

## Approach

_Explain how your code addresses the purpose of the change._

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
