### PR TITLE
Fix autocomplete Cypress tests

### DIFF
--- a/e2e-tests/cypress/e2e/donor/counter-service.cy.ts
+++ b/e2e-tests/cypress/e2e/donor/counter-service.cy.ts
@@ -42,7 +42,8 @@ describe("Counter service donor journey", () => {
     cy.get(".govuk-button").contains("Continue").click();
 
     cy.contains("Choose country");
-    cy.getInputByLabel("Choose country").select("Austria");
+    cy.getInputByLabel("Choose country").type("Austria");
+    cy.contains("Austria").click();
     cy.get(".govuk-button").contains("Continue").click();
 
     cy.contains("Choose document");


### PR DESCRIPTION
Cypress tests needed to be updated to account for introduction of the autocomplete component.

#patch