### PR TITLE
Send Post Office results to EventBridge

### DIFF
--- a/docker/sirius/openapi.yml
+++ b/docker/sirius/openapi.yml
@@ -198,6 +198,9 @@ components:
           type: string
           pattern: "M(-[0-9A-Z]{4}){3}"
           example: M-789Q-P4DF-4UX3
+        caseSubtype:
+          type: string
+          enum: [personal-welfare, property-and-affairs]
         donor:
           required: [firstname, surname, dob, address]
           type: object
@@ -210,7 +213,9 @@ components:
               x-faker: name.lastName
             dob:
               type: string
-              format: date
+              pattern: "[0-9]{1,2}/[0-9]{1,2}/[0-9]{4}"
+              x-faker:
+                helpers.replaceSymbols: "1#/0#/19##"
             addressLine1:
               type: string
               x-faker: address.streetAddress

--- a/service-api/config/autoload/aws.global.php
+++ b/service-api/config/autoload/aws.global.php
@@ -13,4 +13,7 @@ return [
         'endpoint' => getenv('AWS_DYNAMODB_ENDPOINT') ?: '',
         'region' => getenv('AWS_REGION') ?: "eu-west-1",
     ],
+    'eventbridge' => [
+        'sirius_event_bus_name' => getenv('OUTBOUND_EVENT_BUS_NAME') ?: "local-poas",
+    ],
 ];

--- a/service-api/module/Application/config/module.config.php
+++ b/service-api/module/Application/config/module.config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application;
 
 use Application\Aws\DynamoDbClientFactory;
+use Application\Aws\EventBridgeClientFactory;
 use Application\Aws\Secrets\AwsSecretsCache;
 use Application\Aws\Secrets\AwsSecretsCacheFactory;
 use Application\Factories\LoggerFactory;
@@ -14,17 +15,20 @@ use Application\Nino\ValidatorFactory as NinoValidatorFactory;
 use Application\Nino\ValidatorInterface as NinoValidatorInterface;
 use Application\DrivingLicense\ValidatorFactory as LicenseFactory;
 use Application\DrivingLicense\ValidatorInterface as LicenseInterface;
+use Application\Factories\EventSenderFactory;
 use Application\Passport\ValidatorInterface as PassportValidatorInterface;
 use Application\Passport\ValidatorFactory as PassportValidatorFactory;
 use Application\Fixtures\DataWriteHandler;
 use Application\Fixtures\DataQueryHandler;
 use Application\Passport\ValidatorInterface;
+use Application\Sirius\EventSender;
 use Application\Yoti\SessionConfig;
 use Application\Yoti\SessionStatusService;
 use Application\Yoti\YotiService;
 use Application\Yoti\YotiServiceFactory;
 use Application\Yoti\YotiServiceInterface;
 use Aws\DynamoDb\DynamoDbClient;
+use Aws\EventBridge\EventBridgeClient;
 use Laminas\Mvc\Controller\LazyControllerAbstractFactory;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Method;
@@ -413,6 +417,7 @@ return [
         ],
         'factories' => [
             DynamoDbClient::class => DynamoDbClientFactory::class,
+            EventBridgeClient::class => EventBridgeClientFactory::class,
             DataQueryHandler::class => fn(ServiceLocatorInterface $serviceLocator) => new DataQueryHandler(
                 $serviceLocator->get(DynamoDbClient::class),
                 $tableName
@@ -425,7 +430,8 @@ return [
             SessionStatusService::class => fn(ServiceLocatorInterface $serviceLocator) => new SessionStatusService(
                 $serviceLocator->get(YotiServiceInterface::class),
                 $serviceLocator->get(DataWriteHandler::class),
-                $serviceLocator->get(LoggerInterface::class)
+                $serviceLocator->get(LoggerInterface::class),
+                $serviceLocator->get(EventSender::class),
             ),
             SessionConfig::class => InvokableFactory::class,
             LoggerInterface::class => LoggerFactory::class,
@@ -434,8 +440,8 @@ return [
             PassportValidatorInterface::class => PassportValidatorFactory::class,
             KBVServiceInterface::class => KBVServiceFactory::class,
             AwsSecretsCache::class => AwsSecretsCacheFactory::class,
-            YotiServiceInterface::class => YotiServiceFactory::class
-
+            YotiServiceInterface::class => YotiServiceFactory::class,
+            EventSender::class => EventSenderFactory::class,
         ],
     ],
     'view_manager' => [

--- a/service-api/module/Application/src/Aws/EventBridgeClientFactory.php
+++ b/service-api/module/Application/src/Aws/EventBridgeClientFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Aws;
+
+use Aws\EventBridge\EventBridgeClient;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+
+class EventBridgeClientFactory implements FactoryInterface
+{
+    /**
+     * @param string $requestedName
+     * @param null|array<mixed> $options
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): EventBridgeClient
+    {
+        /** @var array{"aws": array<string, string|bool>} $config */
+        $config = $container->get('Config');
+
+        $eventBridgeClient = new EventBridgeClient($config['aws']);
+
+        return $eventBridgeClient;
+    }
+}

--- a/service-api/module/Application/src/Factories/EventSenderFactory.php
+++ b/service-api/module/Application/src/Factories/EventSenderFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Factories;
+
+use Application\Sirius\EventSender;
+use Aws\EventBridge\EventBridgeClient;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+
+class EventSenderFactory implements FactoryInterface
+{
+    /**
+     * @param string $requestedName
+     * @param null|array<mixed> $options
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): EventSender
+    {
+        /** @var array{eventbridge: array{sirius_event_bus_name: string}} $config */
+        $config = $container->get('Config');
+
+        $eventBridgeClient = new EventSender(
+            $container->get(EventBridgeClient::class),
+            $config['eventbridge']['sirius_event_bus_name'],
+        );
+
+        return $eventBridgeClient;
+    }
+}

--- a/service-api/module/Application/src/Sirius/EventSender.php
+++ b/service-api/module/Application/src/Sirius/EventSender.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Sirius;
+
+use Aws\EventBridge\EventBridgeClient;
+
+class EventSender
+{
+    public function __construct(
+        private readonly EventBridgeClient $eventBridgeClient,
+        private readonly string $eventBusName,
+    ) {
+    }
+
+    /**
+     * @param string $detailType
+     * @param array<mixed> $detail
+     */
+    public function send(string $detailType, array $detail): void
+    {
+        $this->eventBridgeClient->putEvents([
+            'Entries' => [
+                [
+                    'Source' => 'opg.poas.identity-check',
+                    'EventBusName' => $this->eventBusName,
+                    'DetailType' => $detailType,
+                    'Detail' => json_encode($detail),
+                ],
+            ],
+        ]);
+    }
+}

--- a/service-api/module/Application/src/Yoti/SessionStatusService.php
+++ b/service-api/module/Application/src/Yoti/SessionStatusService.php
@@ -7,6 +7,7 @@ namespace Application\Yoti;
 use Application\Fixtures\DataWriteHandler;
 use Application\Model\Entity\CaseData;
 use Application\Model\Entity\CounterService;
+use Application\Sirius\EventSender;
 use Application\Yoti\Http\Exception\YotiException;
 use DateTime;
 use InvalidArgumentException;
@@ -16,9 +17,10 @@ use Ramsey\Uuid\Uuid;
 class SessionStatusService
 {
     public function __construct(
-        public readonly YotiServiceInterface $yotiService,
-        public readonly DataWriteHandler $dataImportHandler,
+        private readonly YotiServiceInterface $yotiService,
+        private readonly DataWriteHandler $dataImportHandler,
         private readonly LoggerInterface $logger,
+        private readonly EventSender $eventSender,
     ) {
     }
 
@@ -34,6 +36,7 @@ class SessionStatusService
                 return $this->handleSessionCompletion($caseData);
             }
         }
+
         return $caseData->counterService;
     }
 
@@ -57,6 +60,14 @@ class SessionStatusService
 
             //add to logs until we can send status updates directly to Sirius
             $this->logger->info("Update for CaseId " . $caseData->id . "- State: $state, Result: " . $finalResult);
+
+            $this->eventSender->send("identity-check-resolved", [
+                "reference" => "opg:" . $caseData->id,
+                "actorType" => $caseData->personType,
+                "lpaIds" => $caseData->lpas,
+                "time" => $response['resources']['id_documents'][0]['created_at'] ?? (new DateTime())->format('c'),
+                "outcome" => $finalResult ? 'success' : 'failure',
+            ]);
         } catch (YotiException $e) {
             $this->logger->error('Yoti result error: ' . $e->getMessage());
         } catch (InvalidArgumentException $exception) {
@@ -73,6 +84,7 @@ class SessionStatusService
                 return false;
             }
         }
+
         return true;
     }
 }

--- a/service-api/module/Application/test/ApplicationTest/Sirius/EventSenderTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Sirius/EventSenderTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Sirius;
+
+use Application\Sirius\EventSender;
+use Aws\EventBridge\EventBridgeClient;
+use PHPUnit\Framework\TestCase;
+
+class EventSenderTest extends TestCase
+{
+    public function testSendsEvents(): void
+    {
+        $eventBridgeMock = $this->createMock(EventBridgeClient::class);
+
+        $sut = new EventSender($eventBridgeMock, 'my-event-bus');
+
+        $eventBridgeMock->expects($this->once())
+            ->method('__call')
+            ->with('putEvents', [
+                [
+                    'Entries' => [
+                        [
+                            'Source' => 'opg.poas.identity-check',
+                            'EventBusName' => 'my-event-bus',
+                            'DetailType' => 'event-type',
+                            'Detail' => '{"key":"value"}',
+                        ],
+                    ],
+                ],
+            ]);
+
+        $sut->send('event-type', [
+            'key' => 'value',
+        ]);
+    }
+}

--- a/service-front/module/Application/src/Controller/CPFlowController.php
+++ b/service-front/module/Application/src/Controller/CPFlowController.php
@@ -122,7 +122,6 @@ class CPFlowController extends AbstractActionController
 
             /**
              * @psalm-suppress PossiblyNullArrayAccess
-             * @psalm-suppress InvalidArrayOffset
              * @psalm-suppress PossiblyNullArgument
              */
             $type = LpaTypes::fromName($lpasData['opg.poas.lpastore']['lpaType']);

--- a/service-front/module/Application/src/Controller/DonorFlowController.php
+++ b/service-front/module/Application/src/Controller/DonorFlowController.php
@@ -143,7 +143,6 @@ class DonorFlowController extends AbstractActionController
 
             /**
              * @psalm-suppress PossiblyNullArrayAccess
-             * @psalm-suppress InvalidArrayOffset
              * @psalm-suppress PossiblyNullArgument
              */
             $type = LpaTypes::fromName($lpasData['opg.poas.lpastore']['lpaType']);

--- a/service-front/module/Application/src/Controller/IndexController.php
+++ b/service-front/module/Application/src/Controller/IndexController.php
@@ -103,7 +103,7 @@ class IndexController extends AbstractActionController
             return [
                 'first_name' => $data['opg.poas.sirius']['donor']['firstname'],
                 'last_name' => $data['opg.poas.sirius']['donor']['surname'],
-                'dob' => (new DateTime($data['opg.poas.sirius']['donor']['dob']))->format("Y-m-d"),
+                'dob' => DateTime::createFromFormat('d/m/Y', $data['opg.poas.sirius']['donor']['dob'])->format("Y-m-d"),
                 'address' => $address,
             ];
         } elseif ($type === 'certificateProvider') {

--- a/service-front/module/Application/src/Controller/PostOfficeFlowController.php
+++ b/service-front/module/Application/src/Controller/PostOfficeFlowController.php
@@ -19,7 +19,6 @@ use Application\Services\SiriusApiService;
 use Laminas\Form\Annotation\AttributeBuilder;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
-use Laminas\Validator\NotEmpty;
 use Laminas\View\Model\ViewModel;
 
 class PostOfficeFlowController extends AbstractActionController
@@ -159,7 +158,7 @@ class PostOfficeFlowController extends AbstractActionController
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 
         $deadline = (new \DateTime($this->opgApiService->estimatePostofficeDeadline($uuid)))->format("d M Y");
-        ;
+
 
         $postOfficeData = json_decode($detailsData["counterService"]["selectedPostOffice"], true);
 
@@ -191,6 +190,7 @@ class PostOfficeFlowController extends AbstractActionController
                 $view->setVariable('errors', ['API Error']);
             }
         }
+
         return $view->setTemplate('application/pages/post_office/confirm_post_office');
     }
 
@@ -200,6 +200,7 @@ class PostOfficeFlowController extends AbstractActionController
         $uuid = $this->params()->fromRoute("uuid");
         $detailsData = $this->opgApiService->getDetailsData($uuid);
         $view->setVariable('details_data', $detailsData);
+
         return $view->setTemplate('application/pages/post_office/what_happens_next');
     }
 
@@ -209,6 +210,7 @@ class PostOfficeFlowController extends AbstractActionController
         $uuid = $this->params()->fromRoute("uuid");
         $detailsData = $this->opgApiService->getDetailsData($uuid);
         $view->setVariable('details_data', $detailsData);
+
         return $view->setTemplate('application/pages/post_office/post_office_route_not_available');
     }
 
@@ -224,22 +226,22 @@ class PostOfficeFlowController extends AbstractActionController
              * @psalm-suppress ArgumentTypeCoercion
              */
             $lpasData = $this->siriusApiService->getLpaByUid($lpa, $this->request);
-            /**
-             * @psalm-suppress PossiblyNullArrayAccess
-             */
-            $name = $lpasData['opg.poas.lpastore']['donor']['firstNames'] . " " .
-                $lpasData['opg.poas.lpastore']['donor']['lastName'];
 
-            /**
-             * @psalm-suppress PossiblyNullArrayAccess
-             * @psalm-suppress InvalidArrayOffset
-             * @psalm-suppress PossiblyNullArgument
-             */
-            $type = LpaTypes::fromName($lpasData['opg.poas.lpastore']['lpaType']);
+            if (! empty($lpasData['opg.poas.lpastore'])) {
+                $name = $lpasData['opg.poas.lpastore']['donor']['firstNames'] . " " .
+                    $lpasData['opg.poas.lpastore']['donor']['lastName'];
+
+                $type = LpaTypes::fromName($lpasData['opg.poas.lpastore']['lpaType']);
+            } else {
+                $name = $lpasData['opg.poas.sirius']['donor']['firstname'] . " " .
+                    $lpasData['opg.poas.sirius']['donor']['surname'];
+
+                $type = LpaTypes::fromName($lpasData['opg.poas.sirius']['caseSubtype']);
+            }
 
             $lpaDetails[$lpa] = [
                 'name' => $name,
-                'type' => $type
+                'type' => $type,
             ];
         }
 

--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -23,6 +23,7 @@ use Laminas\Stdlib\RequestInterface;
  *
  * @psalm-type Lpa = array{
  *  "opg.poas.sirius": array{
+ *    caseSubtype: string,
  *    donor: array{
  *      firstname: string,
  *      surname: string,
@@ -36,6 +37,7 @@ use Laminas\Stdlib\RequestInterface;
  *    },
  *  },
  *  "opg.poas.lpastore": ?array{
+ *    lpaType: string,
  *    donor: array{
  *      firstNames: string,
  *      lastName: string,

--- a/service-front/module/Application/test/Controller/IndexControllerTest.php
+++ b/service-front/module/Application/test/Controller/IndexControllerTest.php
@@ -51,10 +51,13 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
      */
     public static function startActionDataProvider(): array
     {
-        $siriusData = ['donor' => [
-            'firstname' => 'Lili', 'surname' => 'Laur', 'dob' => '2019-02-18',
-            'addressLine1' => '17 East Lane', 'addressLine2' => 'Wickerham',
-            'town' => '', 'postcode' => 'W1 3EJ', 'country' => 'GB'],
+        $siriusData = [
+            'donor' => [
+                'firstname' => 'Lili', 'surname' => 'Laur', 'dob' => '18/02/2019',
+                'addressLine1' => '17 East Lane', 'addressLine2' => 'Wickerham',
+                'town' => '', 'postcode' => 'W1 3EJ', 'country' => 'GB'
+            ],
+            'caseSubtype' => 'property-and-affairs',
         ];
 
         $lpaStoreData = [
@@ -69,6 +72,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
                 'firstNames' => 'x', 'lastName' => 'x',
                 'address' => ['line1' => '16a Avenida Lucana', 'line2' => 'Cordón', 'country' => 'ES'],
             ],
+            'lpaType' => 'personal-welfare',
         ];
 
         return [


### PR DESCRIPTION
## Purpose

When the PO session is completed, send a success/failure event to Sirius so it can update records accordingly.

Fixes ID-183 #minor

## Approach

Add EventBridge client and use putEvents. Created a EventSender class to wrap AWS logic.
