### PR TITLE
Content fixes for ID-324

### DIFF
--- a/service-front/module/Application/src/Controller/CPFlowController.php
+++ b/service-front/module/Application/src/Controller/CPFlowController.php
@@ -648,6 +648,10 @@ class CPFlowController extends AbstractActionController
         }
 
         $countriesData = PostOfficeCountry::cases();
+        $countriesData = array_filter(
+            $countriesData,
+            fn (PostOfficeCountry $country) => $country !== PostOfficeCountry::GBR
+        );
 
         $view->setVariable('form', $form);
         $view->setVariable('options_data', $idOptionsData);

--- a/service-front/module/Application/src/Controller/PostOfficeFlowController.php
+++ b/service-front/module/Application/src/Controller/PostOfficeFlowController.php
@@ -288,6 +288,10 @@ class PostOfficeFlowController extends AbstractActionController
         }
 
         $countriesData = PostOfficeCountry::cases();
+        $countriesData = array_filter(
+            $countriesData,
+            fn (PostOfficeCountry $country) => $country !== PostOfficeCountry::GBR
+        );
 
         $view->setVariable('form', $form);
         $view->setVariable('countries_data', $countriesData);

--- a/service-front/module/Application/test/Controller/CPFlowControllerTest.php
+++ b/service-front/module/Application/test/Controller/CPFlowControllerTest.php
@@ -276,6 +276,9 @@ class CPFlowControllerTest extends AbstractHttpControllerTestCase
         $this->assertControllerName(CpFlowController::class); // as specified in router's controller name alias
         $this->assertControllerClass('CpFlowController');
         $this->assertMatchedRouteName('root/cp_choose_country');
+
+        $this->assertQueryContentContains('[name="country"] > option[value="AUT"]', 'Austria');
+        $this->assertNotQuery('[name="country"] > option[value="GBR"]');
     }
 
     public function testPostOfficeCountriesIdPage(): void

--- a/service-front/module/Application/test/Controller/PostOfficeDonorFlowControllerTest.php
+++ b/service-front/module/Application/test/Controller/PostOfficeDonorFlowControllerTest.php
@@ -67,8 +67,8 @@ class PostOfficeDonorFlowControllerTest extends AbstractHttpControllerTestCase
             "yotiSessionId" => "00000000-0000-0000-0000-000000000000",
             "idMethodIncludingNation" => [
                 "country" => "AUT",
-                "id_method" => "DRIVING_LICENCE"
-            ]
+                "id_method" => "DRIVING_LICENCE",
+            ],
         ];
     }
 
@@ -82,18 +82,18 @@ class PostOfficeDonorFlowControllerTest extends AbstractHttpControllerTestCase
                         "line1" => "93274 Goldner Club",
                         "line3" => "Oak Lawn",
                         "postcode" => "YG9 3RV",
-                        "town" => "Caguas"
+                        "town" => "Caguas",
                     ],
                     "channel" => "paper",
                     "firstNames" => "Wilma",
                     "identityCheck" => [
                         "checkedAt" => "1940-11-01T22:28:42.0Z",
-                        "type" => "one-login"
+                        "type" => "one-login",
                     ],
                     "lastName" => "Lynch",
                     "phone" => "proident elit dolor cupidatat ut",
                     "signedAt" => "1967-02-10T08:53:14.0Z",
-                    "uid" => "a72f52bd-1c26-e0ab-88a0-233e5611cd62"
+                    "uid" => "a72f52bd-1c26-e0ab-88a0-233e5611cd62",
                 ],
                 "channel" => "paper",
                 "donor" => [
@@ -102,7 +102,7 @@ class PostOfficeDonorFlowControllerTest extends AbstractHttpControllerTestCase
                         "line1" => "9077 Bertrand Lane",
                         "line2" => "Grady Haven",
                         "line3" => "Hollywood",
-                        "postcode" => "XW0 6ZQ"
+                        "postcode" => "XW0 6ZQ",
                     ],
                     "contactLanguagePreference" => "en",
                     "dateOfBirth" => "1920-02-16",
@@ -110,7 +110,7 @@ class PostOfficeDonorFlowControllerTest extends AbstractHttpControllerTestCase
                     "firstNames" => "Akeem",
                     "lastName" => "Wiegand",
                     "otherNamesKnownBy" => "Melba King",
-                    "uid" => "d4c3d084-303a-3cd3-eab0-e981618b1fe8"
+                    "uid" => "d4c3d084-303a-3cd3-eab0-e981618b1fe8",
                 ],
                 "howAttorneysMakeDecisions" => "jointly-for-some-severally-for-others",
                 "howReplacementAttorneysStepInDetails" => "in ut",
@@ -120,7 +120,7 @@ class PostOfficeDonorFlowControllerTest extends AbstractHttpControllerTestCase
                 "status" => "registered",
                 "uid" => "M-X7BG-VMAO-1V2F",
                 "updatedAt" => "1906-03-13T01:06:58.0Z",
-                "whenTheLpaCanBeUsed" => "when-capacity-lost"
+                "whenTheLpaCanBeUsed" => "when-capacity-lost",
             ],
             "opg.poas.sirius" => [
                 "donor" => [
@@ -129,11 +129,11 @@ class PostOfficeDonorFlowControllerTest extends AbstractHttpControllerTestCase
                     "firstname" => "Isai",
                     "postcode" => "WR5 4XT",
                     "surname" => "Spencer",
-                    "town" => "Galveston"
+                    "town" => "Galveston",
                 ],
                 "id" => 36902521,
-                "uId" => "M-F4JG-7IHS-STS5"
-            ]
+                "uId" => "M-F4JG-7IHS-STS5",
+            ],
         ];
     }
 
@@ -255,6 +255,9 @@ class PostOfficeDonorFlowControllerTest extends AbstractHttpControllerTestCase
         $this->assertControllerName(PostOfficeFlowController::class);
         $this->assertControllerClass('PostOfficeFlowController');
         $this->assertMatchedRouteName('root/donor_choose_country');
+
+        $this->assertQueryContentContains('[name="country"] > option[value="AUT"]', 'Austria');
+        $this->assertNotQuery('[name="country"] > option[value="GBR"]');
     }
 
     public function testPostOfficeCountriesIdPage(): void

--- a/service-front/module/Application/view/application/pages/cp/how_will_the_cp_confirm.twig
+++ b/service-front/module/Application/view/application/pages/cp/how_will_the_cp_confirm.twig
@@ -149,8 +149,8 @@
                             <div class="govuk-details__text">
                                 <ul class="govuk-list govuk-list--bullet govuk-hint">
                                     <li>International passport</li>
-                                    <li>EU/EAA photocard driving licence</li>
-                                    <li>EU/EAA national identity card</li>
+                                    <li>EU/EEA photocard driving licence</li>
+                                    <li>EU/EEA national identity card</li>
                                     <li>Biometric residence permit</li>
                                 </ul>
                             </div>

--- a/service-front/module/Application/view/application/pages/how_will_the_donor_confirm.twig
+++ b/service-front/module/Application/view/application/pages/how_will_the_donor_confirm.twig
@@ -150,8 +150,8 @@
                             <div class="govuk-details__text">
                                 <ul class="govuk-list govuk-list--bullet govuk-hint">
                                     <li>International passport</li>
-                                    <li>EU/EAA photocard driving licence</li>
-                                    <li>EU/EAA national identity card</li>
+                                    <li>EU/EEA photocard driving licence</li>
+                                    <li>EU/EEA national identity card</li>
                                     <li>Biometric residence permit</li>
                                 </ul>
                             </div>


### PR DESCRIPTION
## Purpose

Content fixes for ID-324

Fixes ID-324 #patch

## Approach

- Correct spelling of "EEA"
- Don't include GBR in list of international countries

## Learning

I've not used the DOM crawler assertions in laminas-test before, they're pretty straightforward to use.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A