### PR TITLE
Use IIQ auth token to fetch questions

### DIFF
--- a/service-api/module/Application/config/module.config.php
+++ b/service-api/module/Application/config/module.config.php
@@ -10,6 +10,8 @@ use Application\Aws\Secrets\AwsSecretsCache;
 use Application\Aws\Secrets\AwsSecretsCacheFactory;
 use Application\DrivingLicense\ValidatorFactory as LicenseFactory;
 use Application\DrivingLicense\ValidatorInterface as LicenseInterface;
+use Application\Experian\IIQ\Soap\IIQClient;
+use Application\Experian\IIQ\Soap\IIQClientFactory;
 use Application\Experian\IIQ\Soap\WaspClient;
 use Application\Experian\IIQ\Soap\WaspClientFactory;
 use Application\Factories\EventSenderFactory;
@@ -433,6 +435,7 @@ return [
             YotiServiceInterface::class => YotiServiceFactory::class,
             EventSender::class => EventSenderFactory::class,
             WaspClient::class => WaspClientFactory::class,
+            IIQClient::class => IIQClientFactory::class,
         ],
     ],
     'view_manager' => [

--- a/service-api/module/Application/src/Experian/IIQ/IIQService.php
+++ b/service-api/module/Application/src/Experian/IIQ/IIQService.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Experian\IIQ;
+
+use Application\Experian\IIQ\Soap\IIQClient;
+
+class IIQService
+{
+    public function __construct(private readonly IIQClient $client)
+    {
+    }
+
+    public function startAuthenticationAttempt(): array
+    {
+        $request = $this->client->SAA([
+            'sAARequest' => [
+                'Applicant' => [
+                    'ApplicantIdentifier' => '1',
+                    'Name' => [
+                        'Title' => 'Mr',
+                        'Forename' => 'Albert',
+                        'Surname' => 'Arkil',
+                    ],
+                    'DateOfBirth' => [
+                        'CCYY' => '1951',
+                        'MM' => '02',
+                        'DD' => '18',
+
+                    ],
+                ],
+                'ApplicationData' => [
+                    'SearchConsent' => 'Y',
+                ],
+                'Control' => [
+                    'TestDatabase' => 'A',
+                ],
+                'LocationDetails' => [
+                    'LocationIdentifier' => '1',
+                    'UKLocation' => [
+                        'HouseNumber' => '3',
+                        'Street' => 'STOCKS HILL',
+                        'District' => 'HIGH HARRINGTON',
+                        'PostTown' => 'WORKINGTON',
+                        'Postcode' => 'CA14 5PH',
+                    ],
+                ],
+            ],
+          ]);
+
+        return (array)$request->SAAResult->Questions->Question;
+    }
+}

--- a/service-api/module/Application/src/Experian/IIQ/KBVService.php
+++ b/service-api/module/Application/src/Experian/IIQ/KBVService.php
@@ -11,7 +11,7 @@ use Psr\Log\LoggerInterface;
 class KBVService implements KBVServiceInterface
 {
     public function __construct(
-        private readonly WaspService $authService,
+        private readonly IIQService $authService,
         private readonly LoggerInterface $logger,
         private readonly MockKBVService $mockKbvService,
     ) {
@@ -19,9 +19,9 @@ class KBVService implements KBVServiceInterface
 
     public function fetchFormattedQuestions(string $uuid): array
     {
-        $token = $this->authService->loginWithCertificate();
+        $questions = $this->authService->startAuthenticationAttempt();
 
-        $this->logger->info(sprintf('Token length %s', strlen($token)));
+        $this->logger->info(sprintf('Found %d questions', count($questions)));
 
         return $this->mockKbvService->fetchFormattedQuestions($uuid);
     }

--- a/service-api/module/Application/src/Experian/IIQ/Soap/IIQClient.php
+++ b/service-api/module/Application/src/Experian/IIQ/Soap/IIQClient.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Experian\IIQ\Soap;
+
+use SoapClient;
+
+class IIQClient extends SoapClient
+{
+}

--- a/service-api/module/Application/src/Experian/IIQ/Soap/IIQClientFactory.php
+++ b/service-api/module/Application/src/Experian/IIQ/Soap/IIQClientFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Experian\IIQ\Soap;
+
+use Application\Aws\Secrets\AwsSecretsCache;
+use Application\Experian\IIQ\WaspService;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+use SoapHeader;
+use SoapVar;
+
+class IIQClientFactory implements FactoryInterface
+{
+    /**
+     * @param string $requestedName
+     * @param null|array<mixed> $options
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): IIQClient
+    {
+        $wsdlPath = getenv('EXPERIAN_IIQ_WSDL');
+        if (! is_string($wsdlPath)) {
+            throw new RuntimeException('Env var EXPERIAN_IIQ_WSDL must be set');
+        }
+
+        $awsSecretsCache = $container->get(AwsSecretsCache::class);
+        $passphrase = $awsSecretsCache->getValue('experian-idiq/certificate-key-passphrase');
+
+        $pemFilePath = '/opg-private/experian-iiq-cert.pem';
+
+        $config = [];
+        if (file_exists($pemFilePath)) {
+            $config['local_cert'] = $pemFilePath;
+            $config['passphrase'] = $passphrase;
+        }
+
+        $client = new IIQClient(
+            $wsdlPath,
+            $config,
+        );
+
+        $endpoint = getenv('EXPERIAN_IIQ_LOCATION');
+        if (is_string($endpoint)) {
+            $client->__setLocation($endpoint);
+        }
+
+        $waspService = $container->get(WaspService::class);
+        $client->__setSoapHeaders([
+            $this->getSecurityHeader($waspService->loginWithCertificate()),
+        ]);
+
+        return $client;
+    }
+
+    private function getSecurityHeader(string $token): SoapHeader
+    {
+        $wsseNamespace = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd';
+        $encType = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary';
+
+        return new SoapHeader($wsseNamespace, 'Security', new SoapVar(['
+            <wsse:Security xmlns:wsse="' . $wsseNamespace . '">
+                <wsse:BinarySecurityToken
+                    EncodingType="' . $encType . '"
+                    ValueType="ExperianWASP"
+                    wsu:Id="SecurityToken-9e855049-1dc9-477a-ab9a-7f7d164132ca"
+                    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+                >' . $token . '</wsse:BinarySecurityToken>
+            </wsse:Security>
+        '], XSD_ANYXML));
+    }
+}

--- a/service-api/module/Application/test/ApplicationTest/Experian/IIQ/IIQServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Experian/IIQ/IIQServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Experian\IIQ;
+
+use Application\Experian\IIQ\IIQService;
+use Application\Experian\IIQ\Soap\IIQClient;
+use PHPUnit\Framework\TestCase;
+
+class IIQServiceTest extends TestCase
+{
+    public function testStartAuthenticationAttempt(): void
+    {
+        $questions = [
+            ['id' => 1],
+            ['id' => 2],
+        ];
+
+        $client = $this->createMock(IIQClient::class);
+
+        $client->expects($this->once())
+            ->method('__call')
+            ->with(
+                'SAA',
+                $this->callback(fn ($args) => $args[0]['sAARequest']['Applicant']['Name']['Forename'] === 'Albert'),
+            )
+            ->willReturn((object)[
+                'SAAResult' => (object)[
+                    'Questions' => (object)[
+                        'Question' => $questions,
+                    ],
+                ],
+            ]);
+
+        $sut = new IIQService($client);
+
+        $this->assertEquals($questions, $sut->startAuthenticationAttempt());
+    }
+}

--- a/service-api/module/Application/test/ApplicationTest/Experian/IIQ/KBVServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Experian/IIQ/KBVServiceTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace ApplicationTest\Experian\IIQ;
 
+use Application\Experian\IIQ\IIQService;
 use Application\Experian\IIQ\KBVService;
-use Application\Experian\IIQ\WaspService;
 use Application\Mock\KBV\KBVService as MockKBVService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -17,15 +17,15 @@ class KBVServiceTest extends TestCase
         $uuid = '68f0bee7-5b05-41da-95c4-2f1d5952184d';
         $questions = ['test' => 'value'];
 
-        $waspService = $this->createMock(WaspService::class);
-        $waspService->expects($this->once())
-            ->method('loginWithCertificate')
-            ->willReturn('my-token');
+        $iiqService = $this->createMock(IIQService::class);
+        $iiqService->expects($this->once())
+            ->method('startAuthenticationAttempt')
+            ->willReturn([1, 2, 3]);
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
             ->method('info')
-            ->with('Token length 8');
+            ->with('Found 3 questions');
 
         $mockKbvService = $this->createMock(MockKBVService::class);
         $mockKbvService->expects($this->once())
@@ -33,7 +33,7 @@ class KBVServiceTest extends TestCase
             ->with($uuid)
             ->willReturn($questions);
 
-        $sut = new KBVService($waspService, $logger, $mockKbvService);
+        $sut = new KBVService($iiqService, $logger, $mockKbvService);
 
         $this->assertEquals($questions, $sut->fetchFormattedQuestions($uuid));
     }


### PR DESCRIPTION
## Purpose

Having generated an auth token for IIQ, use it to send an SAA request to the service.

For ID-257 #minor

## Approach

Similar architectural approach to adding WaspService. Updated KBVService to fetch questions rather than generating a token.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
