### PR TITLE
Only generate IIQ auth only when needed

### DIFF
--- a/service-api/module/Application/config/module.config.php
+++ b/service-api/module/Application/config/module.config.php
@@ -10,6 +10,8 @@ use Application\Aws\Secrets\AwsSecretsCache;
 use Application\Aws\Secrets\AwsSecretsCacheFactory;
 use Application\DrivingLicense\ValidatorFactory as LicenseFactory;
 use Application\DrivingLicense\ValidatorInterface as LicenseInterface;
+use Application\Experian\IIQ\AuthManager;
+use Application\Experian\IIQ\AuthManagerFactory;
 use Application\Experian\IIQ\Soap\IIQClient;
 use Application\Experian\IIQ\Soap\IIQClientFactory;
 use Application\Experian\IIQ\Soap\WaspClient;
@@ -436,6 +438,7 @@ return [
             EventSender::class => EventSenderFactory::class,
             WaspClient::class => WaspClientFactory::class,
             IIQClient::class => IIQClientFactory::class,
+            AuthManager::class => AuthManagerFactory::class,
         ],
     ],
     'view_manager' => [

--- a/service-api/module/Application/src/Experian/IIQ/AuthManager.php
+++ b/service-api/module/Application/src/Experian/IIQ/AuthManager.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Experian\IIQ;
+
+use Laminas\Cache\Storage\StorageInterface;
+use SoapHeader;
+use SoapVar;
+
+class AuthManager
+{
+    private const string CACHE_KEY = 'experian:iiq:auth-token';
+
+    public function __construct(
+        private readonly StorageInterface $storage,
+        private readonly WaspService $waspService,
+    ) {
+    }
+
+    private function getToken(): string
+    {
+        if ($this->storage->hasItem(self::CACHE_KEY)) {
+            return $this->storage->getItem(self::CACHE_KEY);
+        }
+
+        $token = $this->waspService->loginWithCertificate();
+
+        $this->storage->setItem(self::CACHE_KEY, $token);
+
+        return $token;
+    }
+
+    public function buildSecurityHeader(): SoapHeader
+    {
+        $token = $this->getToken();
+
+        $wsseNamespace = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd';
+        $encType = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary';
+
+        return new SoapHeader($wsseNamespace, 'Security', new SoapVar(['
+            <wsse:Security xmlns:wsse="' . $wsseNamespace . '">
+                <wsse:BinarySecurityToken
+                    EncodingType="' . $encType . '"
+                    ValueType="ExperianWASP"
+                    wsu:Id="SecurityToken-9e855049-1dc9-477a-ab9a-7f7d164132ca"
+                    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+                >' . $token . '</wsse:BinarySecurityToken>
+            </wsse:Security>
+        '], XSD_ANYXML));
+    }
+}

--- a/service-api/module/Application/src/Experian/IIQ/AuthManagerFactory.php
+++ b/service-api/module/Application/src/Experian/IIQ/AuthManagerFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Experian\IIQ;
+
+use Laminas\Cache\Storage\Adapter\Apcu;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+
+class AuthManagerFactory implements FactoryInterface
+{
+    /**
+     * @param string $requestedName
+     * @param null|array<mixed> $options
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): AuthManager
+    {
+        $storage = new Apcu([
+          'ttl' => 25 * 60,
+        ]);
+
+        return new AuthManager($storage, $container->get(WaspService::class));
+    }
+}

--- a/service-api/module/Application/src/Experian/IIQ/IIQService.php
+++ b/service-api/module/Application/src/Experian/IIQ/IIQService.php
@@ -8,12 +8,29 @@ use Application\Experian\IIQ\Soap\IIQClient;
 
 class IIQService
 {
-    public function __construct(private readonly IIQClient $client)
+    private bool $isAuthenticated = false;
+
+    public function __construct(
+        private readonly AuthManager $authManager,
+        private readonly IIQClient $client,
+    ) {
+    }
+
+    public function authenticate(): void
     {
+        if (! $this->isAuthenticated) {
+            $this->client->__setSoapHeaders([
+                $this->authManager->buildSecurityHeader(),
+            ]);
+
+            $this->isAuthenticated = true;
+        }
     }
 
     public function startAuthenticationAttempt(): array
     {
+        $this->authenticate();
+
         $request = $this->client->SAA([
             'sAARequest' => [
                 'Applicant' => [

--- a/service-api/module/Application/src/Experian/IIQ/Soap/IIQClientFactory.php
+++ b/service-api/module/Application/src/Experian/IIQ/Soap/IIQClientFactory.php
@@ -5,12 +5,9 @@ declare(strict_types=1);
 namespace Application\Experian\IIQ\Soap;
 
 use Application\Aws\Secrets\AwsSecretsCache;
-use Application\Experian\IIQ\WaspService;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
-use SoapHeader;
-use SoapVar;
 
 class IIQClientFactory implements FactoryInterface
 {
@@ -46,28 +43,6 @@ class IIQClientFactory implements FactoryInterface
             $client->__setLocation($endpoint);
         }
 
-        $waspService = $container->get(WaspService::class);
-        $client->__setSoapHeaders([
-            $this->getSecurityHeader($waspService->loginWithCertificate()),
-        ]);
-
         return $client;
-    }
-
-    private function getSecurityHeader(string $token): SoapHeader
-    {
-        $wsseNamespace = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd';
-        $encType = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary';
-
-        return new SoapHeader($wsseNamespace, 'Security', new SoapVar(['
-            <wsse:Security xmlns:wsse="' . $wsseNamespace . '">
-                <wsse:BinarySecurityToken
-                    EncodingType="' . $encType . '"
-                    ValueType="ExperianWASP"
-                    wsu:Id="SecurityToken-9e855049-1dc9-477a-ab9a-7f7d164132ca"
-                    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
-                >' . $token . '</wsse:BinarySecurityToken>
-            </wsse:Security>
-        '], XSD_ANYXML));
     }
 }

--- a/service-api/module/Application/test/ApplicationTest/Experian/IIQ/AuthManagerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Experian/IIQ/AuthManagerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Experian\IIQ;
+
+use Application\Experian\IIQ\AuthManager;
+use Application\Experian\IIQ\WaspService;
+use GuzzleHttp\Exception\ClientException;
+use Laminas\Cache\Storage\StorageInterface;
+use PHPUnit\Framework\TestCase;
+
+class AuthManagerTest extends TestCase
+{
+    public function testAuthManagerGeneratesNewToken(): void
+    {
+        ClientException::class;
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->expects($this->once())
+            ->method('hasItem')
+            ->willReturn(false);
+        $storage->expects($this->never())
+            ->method('getItem');
+        $storage->expects($this->once())
+            ->method('setItem')
+            ->with($this->anything(), 'mytoken');
+
+        $waspService = $this->createMock(WaspService::class);
+        $waspService->expects($this->once())
+            ->method('loginWithCertificate')
+            ->willReturn('mytoken');
+
+        $authManager = new AuthManager($storage, $waspService);
+
+        $header = $authManager->buildSecurityHeader();
+
+        $this->assertStringContainsString('mytoken', $header->data->enc_value[0]);
+    }
+
+    public function testAuthManagerFetchesCachedToken(): void
+    {
+        ClientException::class;
+        $storage = $this->createMock(StorageInterface::class);
+        $storage->expects($this->once())
+            ->method('hasItem')
+            ->willReturn(true);
+        $storage->expects($this->once())
+            ->method('getItem')
+            ->willReturn('cachedtoken');
+        $storage->expects($this->never())
+            ->method('setItem');
+
+        $waspService = $this->createMock(WaspService::class);
+        $waspService->expects($this->never())
+            ->method('loginWithCertificate');
+
+        $authManager = new AuthManager($storage, $waspService);
+
+        $header = $authManager->buildSecurityHeader();
+
+        $this->assertStringContainsString('cachedtoken', $header->data->enc_value[0]);
+    }
+}

--- a/service-api/module/Application/test/ApplicationTest/Experian/IIQ/IIQServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Experian/IIQ/IIQServiceTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace ApplicationTest\Experian\IIQ;
 
+use Application\Experian\IIQ\AuthManager;
 use Application\Experian\IIQ\IIQService;
 use Application\Experian\IIQ\Soap\IIQClient;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use SoapHeader;
 
 class IIQServiceTest extends TestCase
 {
@@ -33,8 +36,22 @@ class IIQServiceTest extends TestCase
                 ],
             ]);
 
-        $sut = new IIQService($client);
+        $sut = new IIQService(
+            $this->getMockAuthManager(),
+            $client,
+        );
 
         $this->assertEquals($questions, $sut->startAuthenticationAttempt());
+    }
+
+    private function getMockAuthManager(): AuthManager&MockObject
+    {
+        $authManager = $this->createMock(AuthManager::class);
+
+        $authManager->expects($this->once())
+            ->method('buildSecurityHeader')
+            ->willReturn(new SoapHeader('placeholder', 'header'));
+
+        return $authManager;
     }
 }


### PR DESCRIPTION
## Purpose

Reduce how often we generate a new token from the IIQ auth API

Fixes ID-258 #patch

## Approach

Rather than generating an auth token in the factory, which means it's generated every time the dependency is injected (even if it's not used), do it explicitly when making a call to the API.

Also, cache the token for 25 minutes to avoid generating new ones unnecessarily.

## Learning

Not so much learning as a solemn reminder that factory chains can cause a lot of things to be constructed/generated that you don't really want.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A