### PR TITLE
Add retry for IIQ auth

### DIFF
--- a/service-api/module/Application/src/Experian/IIQ/AuthManager.php
+++ b/service-api/module/Application/src/Experian/IIQ/AuthManager.php
@@ -31,8 +31,12 @@ class AuthManager
         return $token;
     }
 
-    public function buildSecurityHeader(): SoapHeader
+    public function buildSecurityHeader(bool $forceNewToken = false): SoapHeader
     {
+        if ($forceNewToken) {
+            $this->storage->removeItem(self::CACHE_KEY);
+        }
+
         $token = $this->getToken();
 
         $wsseNamespace = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd';

--- a/service-api/module/Application/src/Experian/IIQ/AuthManagerFactory.php
+++ b/service-api/module/Application/src/Experian/IIQ/AuthManagerFactory.php
@@ -16,8 +16,10 @@ class AuthManagerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): AuthManager
     {
+        $hourInSeconds = 60 * 60;
+
         $storage = new Apcu([
-          'ttl' => 25 * 60,
+           'ttl' => 4 * $hourInSeconds,
         ]);
 
         return new AuthManager($storage, $container->get(WaspService::class));

--- a/service-api/module/Application/src/Experian/IIQ/IIQService.php
+++ b/service-api/module/Application/src/Experian/IIQ/IIQService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Application\Experian\IIQ;
 
 use Application\Experian\IIQ\Soap\IIQClient;
+use Psr\Log\LoggerInterface;
+use SoapFault;
 
 class IIQService
 {
@@ -13,10 +15,16 @@ class IIQService
     public function __construct(
         private readonly AuthManager $authManager,
         private readonly IIQClient $client,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
-    public function authenticate(): void
+    /**
+     * @template T
+     * @param callable(): T $callback
+     * @return T
+     */
+    private function withAuthentication(callable $callback): mixed
     {
         if (! $this->isAuthenticated) {
             $this->client->__setSoapHeaders([
@@ -25,47 +33,63 @@ class IIQService
 
             $this->isAuthenticated = true;
         }
+
+        try {
+            return $callback();
+        } catch (SoapFault $e) {
+            if ($e->getMessage() === 'Unauthorized') {
+                $this->logger->info('IIQ API replied unauthorised, retrying with new token');
+
+                $this->client->__setSoapHeaders([
+                    $this->authManager->buildSecurityHeader(true),
+                ]);
+
+                return $callback();
+            } else {
+                throw $e;
+            }
+        }
     }
 
     public function startAuthenticationAttempt(): array
     {
-        $this->authenticate();
+        return $this->withAuthentication(function () {
+            $request = $this->client->SAA([
+                'sAARequest' => [
+                    'Applicant' => [
+                        'ApplicantIdentifier' => '1',
+                        'Name' => [
+                            'Title' => 'Mr',
+                            'Forename' => 'Albert',
+                            'Surname' => 'Arkil',
+                        ],
+                        'DateOfBirth' => [
+                            'CCYY' => '1951',
+                            'MM' => '02',
+                            'DD' => '18',
 
-        $request = $this->client->SAA([
-            'sAARequest' => [
-                'Applicant' => [
-                    'ApplicantIdentifier' => '1',
-                    'Name' => [
-                        'Title' => 'Mr',
-                        'Forename' => 'Albert',
-                        'Surname' => 'Arkil',
+                        ],
                     ],
-                    'DateOfBirth' => [
-                        'CCYY' => '1951',
-                        'MM' => '02',
-                        'DD' => '18',
+                    'ApplicationData' => [
+                        'SearchConsent' => 'Y',
+                    ],
+                    'Control' => [
+                        'TestDatabase' => 'A',
+                    ],
+                    'LocationDetails' => [
+                        'LocationIdentifier' => '1',
+                        'UKLocation' => [
+                            'HouseNumber' => '3',
+                            'Street' => 'STOCKS HILL',
+                            'District' => 'HIGH HARRINGTON',
+                            'PostTown' => 'WORKINGTON',
+                            'Postcode' => 'CA14 5PH',
+                        ],
+                    ],
+                ],
+            ]);
 
-                    ],
-                ],
-                'ApplicationData' => [
-                    'SearchConsent' => 'Y',
-                ],
-                'Control' => [
-                    'TestDatabase' => 'A',
-                ],
-                'LocationDetails' => [
-                    'LocationIdentifier' => '1',
-                    'UKLocation' => [
-                        'HouseNumber' => '3',
-                        'Street' => 'STOCKS HILL',
-                        'District' => 'HIGH HARRINGTON',
-                        'PostTown' => 'WORKINGTON',
-                        'Postcode' => 'CA14 5PH',
-                    ],
-                ],
-            ],
-          ]);
-
-        return (array)$request->SAAResult->Questions->Question;
+            return (array)$request->SAAResult->Questions->Question;
+        });
     }
 }


### PR DESCRIPTION
## Purpose

The IIQ token expires after several hours, or at midnight. Update the TTL of the token to keep it around for longer, and add a retry mechanism if the request fails.

For ID-257 #patch

## Approach

The `withAuthentication` wrapper will try to make the call a maximum of twice: if the first call fails specifically with an authorization error, it will force-generate a new token and try again. Otherwise it will fail first time.

## Learning

A re-learning of how to replace `withConsecutive` in PHPUnit.
