### PR TITLE
Send KBV answers

### DIFF
--- a/service-api/module/Application/src/Controller/KbvController.php
+++ b/service-api/module/Application/src/Controller/KbvController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Application\Controller;
 
 use Application\Fixtures\DataQueryHandler;
-use Application\Fixtures\DataWriteHandler;
 use Application\KBV\KBVServiceInterface;
 use Application\Model\Entity\Problem;
 use Application\View\JsonModel;
@@ -22,7 +21,6 @@ class KbvController extends AbstractActionController
 {
     public function __construct(
         private readonly DataQueryHandler $dataQueryHandler,
-        private readonly DataWriteHandler $dataWriteHandler,
         private readonly KBVServiceInterface $KBVService,
     ) {
     }
@@ -50,21 +48,7 @@ class KbvController extends AbstractActionController
 
         $this->getResponse()->setStatusCode(Response::STATUS_CODE_200);
 
-        if (! is_null($case->kbvQuestions)) {
-            $questions = json_decode($case->kbvQuestions, true);
-
-            //revisit formatting here, special character outputs
-            return new JsonModel($questions);
-        }
-
         $questions = $this->KBVService->fetchFormattedQuestions($uuid);
-
-        $this->dataWriteHandler->updateCaseData(
-            $uuid,
-            'kbvQuestions',
-            'S',
-            json_encode($questions)
-        );
 
         return new JsonModel($questions);
     }
@@ -75,26 +59,26 @@ class KbvController extends AbstractActionController
         $data = json_decode($this->getRequest()->getContent(), true);
         $case = $this->dataQueryHandler->getCaseByUUID($uuid);
 
-        $result = 'pass';
-        $response = [];
-
         if (! $uuid || is_null($case)) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
 
             return new JsonModel(new Problem("Missing UUID or unable to find case"));
         }
 
-        $questions = json_decode($case->kbvQuestions, true);
-        //compare against all stored answers to ensure all answers passed
-        foreach ($questions as $key => $question) {
-            if (! isset($data['answers'][$key])) {
-                $result = 'fail';
-            } elseif ($data['answers'][$key] != $question['answer']) {
-                $result = 'fail';
-            }
+        $result = $this->KBVService->checkAnswers($data['answers'], $uuid);
+
+        if ($result->isComplete()) {
+            $response = [
+                'complete' => true,
+                'passed' => $result->isPass(),
+            ];
+        } else {
+            $response = [
+                'complete' => false,
+                'passed' => false,
+            ];
         }
 
-        $response['result'] = $result;
 
         $this->getResponse()->setStatusCode(Response::STATUS_CODE_200);
 

--- a/service-api/module/Application/src/Experian/IIQ/ConfigBuilder.php
+++ b/service-api/module/Application/src/Experian/IIQ/ConfigBuilder.php
@@ -9,12 +9,13 @@ use DateTime;
 use RuntimeException;
 
 /**
+ * @psalm-import-type Control from IIQService
  * @psalm-import-type SAARequest from IIQService
+ * @psalm-import-type RTQRequest from IIQService
  */
 class ConfigBuilder
 {
     /**
-     * @param CaseData $case
      * @psalm-return SAARequest
      */
     public function buildSAARequest(CaseData $case): array
@@ -56,5 +57,37 @@ class ConfigBuilder
         ];
 
         return $saaConfig;
+    }
+
+    /**
+     * @psalm-return RTQRequest
+     */
+    public function buildRTQRequest(array $answersArray, CaseData $case): array
+    {
+        /** @var string $json */
+        $json = $case->iiqControl;
+        /** @var Control */
+        $iiqControl = json_decode($json, true);
+
+        $rtqConfig = [
+            'Control' => [
+                'URN' => $iiqControl['URN'],
+                'AuthRefNo' => $iiqControl['AuthRefNo'],
+            ],
+            'Responses' => [
+                'Response' => [],
+            ],
+        ];
+
+        foreach ($answersArray as $answer) {
+            $rtqConfig['Responses']['Response'][] = [
+                'QuestionID' => $answer['experianId'],
+                'AnswerGiven' => $answer['answer'],
+                'CustResponseFlag' => $answer['flag'],
+                'AnswerActionFlag' => 'A',
+            ];
+        }
+
+        return $rtqConfig;
     }
 }

--- a/service-api/module/Application/src/KBV/AnswersOutcome.php
+++ b/service-api/module/Application/src/KBV/AnswersOutcome.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\KBV;
+
+enum AnswersOutcome: string
+{
+    case CompletePass = "COMPLETE_PASS";
+    case CompleteFail = "COMPLETE_FAIL";
+    case Incomplete = "INCOMPLETE";
+
+    public function isComplete(): bool
+    {
+        return in_array($this, [self::CompletePass, self::CompleteFail]);
+    }
+
+    public function isPass(): bool
+    {
+        return $this === self::CompletePass;
+    }
+}

--- a/service-api/module/Application/src/KBV/KBVServiceInterface.php
+++ b/service-api/module/Application/src/KBV/KBVServiceInterface.php
@@ -20,4 +20,9 @@ interface KBVServiceInterface
      * @return Question[]
      */
     public function fetchFormattedQuestions(string $uuid): array;
+
+    /**
+     * @param array<string, string> $answers
+     */
+    public function checkAnswers(array $answers, string $uuid): AnswersOutcome;
 }

--- a/service-api/module/Application/src/Mock/KBV/KBVService.php
+++ b/service-api/module/Application/src/Mock/KBV/KBVService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Application\Mock\KBV;
 
+use Application\KBV\AnswersOutcome;
 use Application\KBV\KBVServiceInterface;
 
 class KBVService implements KBVServiceInterface
@@ -38,6 +39,21 @@ class KBVService implements KBVServiceInterface
             ...$question,
             'answered' => false,
         ], $questions);
+    }
+
+    public function checkAnswers(array $answers, string $uuid): AnswersOutcome
+    {
+        $db = $this->getKBVQuestions();
+
+        foreach ($answers as $externalId => $answer) {
+            $question = array_filter($db, fn ($q) => $q['externalId'] === $externalId)[0];
+
+            if ($question['prompts'][0] !== $answer) {
+                return AnswersOutcome::CompleteFail;
+            }
+        }
+
+        return AnswersOutcome::CompletePass;
     }
 
     private function questionsList(): array

--- a/service-api/module/Application/test/ApplicationTest/Experian/IIQ/ConfigBuilderTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Experian/IIQ/ConfigBuilderTest.php
@@ -10,14 +10,9 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigBuilderTest extends TestCase
 {
-    private CaseData $caseMock;
-    private ConfigBuilder $sut;
-
-    public function setUp(): void
+    public function testSAAFormat(): void
     {
-        parent::setUp();
-
-        $this->caseMock = CaseData::fromArray([
+        $caseData = CaseData::fromArray([
             'id' => '2b45a8c1-dd35-47ef-a00e-c7b6264bf1cc',
             'firstName' => 'Maria',
             'lastName' => 'Williams',
@@ -30,19 +25,12 @@ class ConfigBuilderTest extends TestCase
                 'postcode' => 'NW1 1SP',
             ],
         ]);
-        // an instance of SUT
-        $this->sut = new ConfigBuilder();
-    }
-    public function testSAAFormat(): void
-    {
-        $saaConfig = $this->sut->buildSAARequest($this->caseMock);
 
-        $this->assertEquals($this->sAAFormatExpected(), $saaConfig);
-    }
+        $configBuilder = new ConfigBuilder();
 
-    public function sAAFormatExpected(): array
-    {
-        $saaConfig = [
+        $saaConfig = $configBuilder->buildSAARequest($caseData);
+
+        $this->assertEquals([
             'Applicant' => [
                 'ApplicantIdentifier' => '2b45a8c1-dd35-47ef-a00e-c7b6264bf1cc',
                 'Name' => [
@@ -69,8 +57,40 @@ class ConfigBuilderTest extends TestCase
                     'Postcode' => 'NW1 1SP',
                 ],
             ],
-        ];
+        ], $saaConfig);
+    }
 
-        return $saaConfig;
+    public function testRTQFormat(): void
+    {
+        $configBuilder = new ConfigBuilder();
+
+        $caseData = CaseData::fromArray([
+            'iiqControl' => '{"URN":"test UUID","AuthRefNo":"abc"}',
+        ]);
+
+        $rtqConfig = $configBuilder->buildRTQRequest([
+            [
+                'experianId' => 'QID21',
+                'answer' => 'BASINGSTOKE',
+                'flag' => 1,
+            ]
+        ], $caseData);
+
+        $this->assertEquals([
+            'Control' => [
+                'URN' => 'test UUID',
+                'AuthRefNo' => 'abc',
+            ],
+            'Responses' => [
+                'Response' => [
+                    [
+                        'QuestionID' => 'QID21',
+                        'AnswerGiven' => 'BASINGSTOKE',
+                        'CustResponseFlag' => 1,
+                        'AnswerActionFlag' => 'A',
+                    ],
+                ],
+            ],
+        ], $rtqConfig);
     }
 }

--- a/service-api/module/Application/test/ApplicationTest/Experian/IIQ/KBVServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Experian/IIQ/KBVServiceTest.php
@@ -9,9 +9,14 @@ use Application\Experian\IIQ\IIQService;
 use Application\Experian\IIQ\KBVService;
 use Application\Fixtures\DataQueryHandler;
 use Application\Fixtures\DataWriteHandler;
+use Application\KBV\AnswersOutcome;
 use Application\Model\Entity\CaseData;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
+/**
+ * @psalm-import-type Question from IIQService as IIQQuestion
+ */
 class KBVServiceTest extends TestCase
 {
     public function testFetchFormattedQuestions(): void
@@ -48,7 +53,7 @@ class KBVServiceTest extends TestCase
         ];
 
         $caseData = CaseData::fromArray([
-            'id' => '68f0bee7-5b05-41da-95c4-2f1d5952184d',
+            'id' => $uuid,
             'firstName' => 'Albert',
             'lastName' => 'Arkil',
             'dob' => '1951-02-18',
@@ -84,9 +89,34 @@ class KBVServiceTest extends TestCase
             ->with($saaRequest)
             ->willReturn($questionsFromIIQ);
 
-        $writeHandler = $this->createMock(DataWriteHandler::class);
+        $storedQuestions = json_encode([
+            [
+                'externalId' => 'QU18', 'question' => 'Question Eighteen',
+                'prompts' => ['A', 'B', 'C'], 'answered' => false,
+            ],
+            [
+                'externalId' => 'QU93', 'question' => 'Question Ninety-Three',
+                'prompts' => ['A', 'B'], 'answered' => false,
+            ],
+        ]);
 
-        $sut = new KBVService($iiqService, $configBuilder, $queryHandler, $writeHandler);
+        $writeHandler = $this->createMock(DataWriteHandler::class);
+        $writeHandler->expects($this->exactly(2))
+            ->method('updateCaseData')
+            ->willReturnCallback(
+                /** @psalm-suppress MissingClosureParamType */
+                fn (...$params) => match (true) {
+                    $params[0] === $uuid && $params[1] === 'kbvQuestions' && $params[2] === 'S'
+                        && $params[3] === $storedQuestions => null,
+                    $params[0] === $uuid && $params[1] === 'iiqControl' && $params[2] === 'S'
+                        && $params[3] === '{"URN":"test UUID","AuthRefNo":"abc"}' => null,
+                    default => self::fail('Did not expect:' . print_r($params, true))
+                }
+            );
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $sut = new KBVService($iiqService, $configBuilder, $queryHandler, $writeHandler, $logger);
 
         $this->assertEquals([
             [
@@ -109,5 +139,145 @@ class KBVServiceTest extends TestCase
                 'answered' => false,
             ],
         ], $sut->fetchFormattedQuestions($uuid));
+    }
+
+    /**
+     * @param IIQQuestion $newQuestion
+     * @dataProvider checkAnswersProvider
+     */
+    public function testCheckAnswers(
+        string $nextTransactionId,
+        ?string $authResult,
+        ?object $newQuestion,
+        AnswersOutcome $expectedOutcome
+    ): void {
+        $uuid = '5d6ee013-63fd-4e6f-81f2-961aca03b9b5';
+        $iiqService = $this->createMock(IIQService::class);
+        $configBuilder = $this->createMock(ConfigBuilder::class);
+        $queryHandler = $this->createMock(DataQueryHandler::class);
+        $writeHandler = $this->createMock(DataWriteHandler::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $questions = [
+            [
+                'externalId' => 'Q101',
+                'answered' => false,
+            ],
+            [
+                'externalId' => 'Q102',
+                'answered' => false,
+            ],
+        ];
+
+        $caseData = CaseData::fromArray([
+            'id' => $uuid,
+            'kbvQuestions' => json_encode($questions),
+        ]);
+
+        $queryHandler->expects($this->once())
+            ->method('getCaseByUUID')
+            ->with($uuid)
+            ->willReturn($caseData);
+
+        $configBuilder->expects($this->once())
+            ->method('buildRTQRequest')
+            ->with([
+                [
+                    'experianId' => 'Q101',
+                    'answer' => 'Correct Answer',
+                    'flag' => '0',
+                ],
+                [
+                    'experianId' => 'Q102',
+                    'answer' => 'Big Bank Inc',
+                    'flag' => '0',
+                ],
+            ], $caseData)
+            ->willReturn(['rtqConfig']);
+
+        $rtqResponse = [
+            'result' => [
+                'AuthenticationResult' => $authResult,
+                'NextTransId' => (object)['string' => $nextTransactionId],
+            ],
+        ];
+
+        $savedQuestions = [
+            [
+                'externalId' => 'Q101',
+                'answered' => true,
+            ],
+            [
+                'externalId' => 'Q102',
+                'answered' => true,
+            ],
+        ];
+
+        if ($newQuestion !== null) {
+            $rtqResponse['questions'] = [$newQuestion];
+            $savedQuestions[] = [
+                'externalId' => $newQuestion->QuestionID,
+                'question' => $newQuestion->Text,
+                'prompts' => $newQuestion->AnswerFormat->AnswerList,
+                'answered' => false,
+            ];
+        }
+
+        $iiqService->expects($this->once())
+            ->method('responseToQuestions')
+            ->with(['rtqConfig'])
+            ->willReturn($rtqResponse);
+
+        $writeHandler->expects($this->once())
+            ->method('updateCaseData')
+            ->with(
+                $uuid,
+                'kbvQuestions',
+                'S',
+                json_encode($savedQuestions),
+            );
+
+        $sut = new KBVService($iiqService, $configBuilder, $queryHandler, $writeHandler, $logger);
+
+        $outcome = $sut->checkAnswers([
+            'Q101' => 'Correct Answer',
+            'Q102' => 'Big Bank Inc',
+        ], $uuid);
+
+        $this->assertEquals($expectedOutcome, $outcome);
+    }
+
+    public static function checkAnswersProvider(): array
+    {
+        return [
+            [
+                'RTQ',
+                null,
+                (object)[
+                    'QuestionID' => 'Q103',
+                    'Text' => 'What are the last two characers on your licence plate?',
+                    'AnswerFormat' => (object)[
+                        'AnswerList' => [
+                            'SJ',
+                            'FL',
+                            'PE',
+                        ],
+                    ],
+                ],
+                AnswersOutcome::Incomplete,
+            ],
+            [
+                'END',
+                'Authenticated',
+                null,
+                AnswersOutcome::CompletePass,
+            ],
+            [
+                'END',
+                'Not Authenticated',
+                null,
+                AnswersOutcome::CompleteFail,
+            ],
+        ];
     }
 }

--- a/service-api/module/Application/test/Controller/KbvControllerTest.php
+++ b/service-api/module/Application/test/Controller/KbvControllerTest.php
@@ -6,7 +6,7 @@ namespace ApplicationTest\Controller;
 
 use Application\Controller\KbvController;
 use Application\Fixtures\DataQueryHandler;
-use Application\Fixtures\DataWriteHandler;
+use Application\KBV\AnswersOutcome;
 use Application\KBV\KBVServiceInterface;
 use Application\Model\Entity\CaseData;
 use ApplicationTest\TestCase;
@@ -19,7 +19,6 @@ class KbvControllerTest extends TestCase
 {
     private DataQueryHandler&MockObject $dataQueryHandlerMock;
     private KBVServiceInterface&MockObject $KBVServiceMock;
-    private DataWriteHandler&MockObject $dataImportHandler;
 
     public function setUp(): void
     {
@@ -36,7 +35,6 @@ class KbvControllerTest extends TestCase
 
         $this->dataQueryHandlerMock = $this->createMock(DataQueryHandler::class);
         $this->KBVServiceMock = $this->createMock(KBVServiceInterface::class);
-        $this->dataImportHandler = $this->createMock(DataWriteHandler::class);
 
 
         parent::setUp();
@@ -44,7 +42,6 @@ class KbvControllerTest extends TestCase
         $serviceManager = $this->getApplicationServiceLocator();
         $serviceManager->setAllowOverride(true);
         $serviceManager->setService(DataQueryHandler::class, $this->dataQueryHandlerMock);
-        $serviceManager->setService(DataWriteHandler::class, $this->dataImportHandler);
         $serviceManager->setService(KBVServiceInterface::class, $this->KBVServiceMock);
     }
 
@@ -54,15 +51,22 @@ class KbvControllerTest extends TestCase
     public function testKbvAnswers(
         string $uuid,
         array $provided,
-        CaseData $actual,
-        string $result,
+        ?CaseData $caseData,
+        ?AnswersOutcome $result,
         int $status
     ): void {
-        if ($result !== 'error') {
+        if ($caseData !== null) {
             $this->dataQueryHandlerMock
                 ->expects($this->once())->method('getCaseByUUID')
                 ->with($uuid)
-                ->willReturn($actual);
+                ->willReturn($caseData);
+        }
+
+        if ($result !== null) {
+            $this->KBVServiceMock->expects($this->once())
+                ->method('checkAnswers')
+                ->with($provided['answers'], $uuid)
+                ->willReturn($result);
         }
 
         $this->dispatchJSON(
@@ -76,11 +80,13 @@ class KbvControllerTest extends TestCase
         $this->assertControllerClass('KbvController');
         $this->assertMatchedRouteName('check_kbv_answers');
 
-        if ($result === "error") {
-            $response = json_decode($this->getResponse()->getContent(), true);
+        $response = json_decode($this->getResponse()->getContent(), true);
+
+        if ($caseData === null) {
             $this->assertEquals('Missing UUID or unable to find case', $response['title']);
         } else {
-            $this->assertEquals('{"result":"' . $result . '"}', $this->getResponse()->getContent());
+            $this->assertEquals($result?->isComplete(), $response['complete']);
+            $this->assertEquals($result?->isPass(), $response['passed']);
         }
     }
 
@@ -119,10 +125,10 @@ class KbvControllerTest extends TestCase
         ]);
 
         return [
-            [$uuid, $provided, $actual, 'pass', Response::STATUS_CODE_200],
-            [$uuid, $providedIncomplete, $actual, 'fail', Response::STATUS_CODE_200],
-            [$uuid, $providedIncorrect, $actual, 'fail', Response::STATUS_CODE_200],
-            [$invalidUUID, $provided, $actual, 'error', Response::STATUS_CODE_400],
+            [$uuid, $provided, $actual, AnswersOutcome::CompletePass, Response::STATUS_CODE_200],
+            [$uuid, $providedIncomplete, $actual, AnswersOutcome::Incomplete, Response::STATUS_CODE_200],
+            [$uuid, $providedIncorrect, $actual, AnswersOutcome::CompleteFail, Response::STATUS_CODE_200],
+            [$invalidUUID, $provided, null, null, Response::STATUS_CODE_400],
         ];
     }
 
@@ -166,41 +172,6 @@ class KbvControllerTest extends TestCase
             ->expects($this->once())->method('fetchFormattedQuestions')
             ->with('a9bc8ab8-389c-4367-8a9b-762ab3050999')
             ->willReturn($formattedQuestions);
-
-        $this->dispatch('/cases/a9bc8ab8-389c-4367-8a9b-762ab3050999/kbv-questions', 'GET');
-        $this->assertResponseStatusCode(200);
-        $this->assertStringContainsString('Who is your electricity supplier?', $this->getResponse()->getContent());
-        $this->assertModuleName('application');
-        $this->assertControllerName(KbvController::class);
-        $this->assertControllerClass('KbvController');
-        $this->assertMatchedRouteName('get_kbv_questions');
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testKBVQuestionsWithVerifiedDocsCaseAndExistingQuestions(): void
-    {
-        $caseData = CaseData::fromArray([
-            'personType' => '',
-            'firstName' => 'test',
-            'lastName' => 'name',
-            'dob' => '',
-            'lpas' => [],
-            'address' => [],
-        ]);
-
-        $caseData->kbvQuestions = json_encode($this->formattedQuestions());
-        $caseData->documentComplete = true;
-
-        $this->dataQueryHandlerMock
-            ->expects($this->once())->method('getCaseByUUID')
-            ->with('a9bc8ab8-389c-4367-8a9b-762ab3050999')
-            ->willReturn($caseData);
-
-        $this->KBVServiceMock
-            ->expects($this->never())->method('fetchFormattedQuestions')
-            ->with('a9bc8ab8-389c-4367-8a9b-762ab3050999');
 
         $this->dispatch('/cases/a9bc8ab8-389c-4367-8a9b-762ab3050999/kbv-questions', 'GET');
         $this->assertResponseStatusCode(200);

--- a/service-front/module/Application/src/Contracts/OpgApiServiceInterface.php
+++ b/service-front/module/Application/src/Contracts/OpgApiServiceInterface.php
@@ -26,7 +26,11 @@ interface OpgApiServiceInterface
      * @return Question[]|false
      */
     public function getIdCheckQuestions(string $uuid): array|bool;
-    public function checkIdCheckAnswers(string $uuid, array $answers): bool;
+
+    /**
+     * @return array{complete: bool, passed: bool}
+     */
+    public function checkIdCheckAnswers(string $uuid, array $answers): array;
     public function createCase(
         string $firstname,
         string $lastname,

--- a/service-front/module/Application/src/Controller/KbvController.php
+++ b/service-front/module/Application/src/Controller/KbvController.php
@@ -68,11 +68,15 @@ class KbvController extends AbstractActionController
             if ($nextQuestion === null) {
                 $check = $this->opgApiService->checkIdCheckAnswers($uuid, ['answers' => $formData->toArray()]);
 
-                if (! $check) {
-                    return $this->redirect()->toRoute($failRoute, ['uuid' => $uuid]);
+                if (! $check['complete']) {
+                    return $this->redirect()->refresh();
                 }
 
-                return $this->redirect()->toRoute($passRoute, ['uuid' => $uuid]);
+                if ($check['passed'] === true) {
+                    return $this->redirect()->toRoute($passRoute, ['uuid' => $uuid]);
+                }
+
+                return $this->redirect()->toRoute($failRoute, ['uuid' => $uuid]);
             }
             $form->setData($formData);
         }

--- a/service-front/module/Application/src/Services/OpgApiService.php
+++ b/service-front/module/Application/src/Services/OpgApiService.php
@@ -6,11 +6,11 @@ namespace Application\Services;
 
 use Application\Contracts\OpgApiServiceInterface;
 use Application\Exceptions\HttpException;
+use Application\Exceptions\OpgApiException;
 use Application\Helpers\AddressProcessorHelper;
 use GuzzleHttp\Client;
-use Laminas\Http\Response;
-use Application\Exceptions\OpgApiException;
 use GuzzleHttp\Exception\BadResponseException;
+use Laminas\Http\Response;
 
 /**
  * @psalm-import-type Question from OpgApiServiceInterface
@@ -38,7 +38,7 @@ class OpgApiService implements OpgApiServiceInterface
         try {
             $response = $this->httpClient->request($verb, $uri, [
                 'headers' => $headers,
-                'json' => $data
+                'json' => $data,
             ]);
 
             $this->responseStatus = Response::STATUS_CODE_200;
@@ -47,6 +47,7 @@ class OpgApiService implements OpgApiServiceInterface
             if ($response->getStatusCode() !== Response::STATUS_CODE_200) {
                 throw new OpgApiException($response->getReasonPhrase());
             }
+
             return $this->responseData;
         } catch (\GuzzleHttp\Exception\BadResponseException $exception) {
             throw new OpgApiException($exception->getMessage(), 0, $exception);
@@ -151,16 +152,14 @@ class OpgApiService implements OpgApiServiceInterface
         }
     }
 
-    public function checkIdCheckAnswers(string $uuid, array $answers): bool
+    public function checkIdCheckAnswers(string $uuid, array $answers): array
     {
         try {
             $response = $this->makeApiRequest("/cases/$uuid/kbv-answers", 'POST', $answers);
-            if ($response['result'] !== 'pass') {
-                return false;
-            }
-            return true;
+
+            return $response;
         } catch (OpgApiException $opgApiException) {
-            return false;
+            throw $opgApiException;
         }
     }
 
@@ -179,8 +178,9 @@ class OpgApiService implements OpgApiServiceInterface
             'dob' => $dob,
             'personType' => $personType,
             'lpas' => $lpas,
-            'address' => $address
+            'address' => $address,
         ];
+
         return $this->makeApiRequest("/cases/create", 'POST', $data);
     }
 
@@ -205,13 +205,15 @@ class OpgApiService implements OpgApiServiceInterface
     public function updateIdMethod(string $uuid, string $method): array
     {
         $data = [
-            'idMethod' => $method
+            'idMethod' => $method,
         ];
+
         try {
             $this->makeApiRequest("/cases/$uuid/update-method", 'POST', $data);
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData;
     }
 
@@ -225,13 +227,14 @@ class OpgApiService implements OpgApiServiceInterface
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData;
     }
 
     public function listPostOfficesByPostcode(string $uuid, string $location): array
     {
         $data = [
-            'search_string' => $location
+            'search_string' => $location,
         ];
 
         try {
@@ -239,6 +242,7 @@ class OpgApiService implements OpgApiServiceInterface
         } catch (OpgApiException $opgApiException) {
             throw new OpgApiException($opgApiException->getMessage());
         }
+
         return $this->responseData;
     }
 
@@ -246,26 +250,30 @@ class OpgApiService implements OpgApiServiceInterface
     public function addSearchPostcode(string $uuid, string $postcode): array
     {
         $data = [
-            'selected_postcode' => $postcode
+            'selected_postcode' => $postcode,
         ];
+
         try {
             $this->makeApiRequest("/cases/$uuid/add-search-postcode", 'POST', $data);
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData;
     }
 
     public function addSelectedPostOffice(string $uuid, string $postOffice): array
     {
         $data = [
-            'selected_postoffice' => $postOffice
+            'selected_postoffice' => $postOffice,
         ];
+
         try {
             $this->makeApiRequest("/cases/$uuid/add-selected-postoffice", 'POST', $data);
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData;
     }
 
@@ -273,13 +281,15 @@ class OpgApiService implements OpgApiServiceInterface
     public function confirmSelectedPostOffice(string $uuid, string $deadline): array
     {
         $data = [
-            'deadline' => $deadline
+            'deadline' => $deadline,
         ];
+
         try {
             $this->makeApiRequest("/cases/$uuid/confirm-selected-postoffice", 'POST', $data);
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData;
     }
 
@@ -292,6 +302,7 @@ class OpgApiService implements OpgApiServiceInterface
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData;
     }
 
@@ -304,6 +315,7 @@ class OpgApiService implements OpgApiServiceInterface
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData;
     }
 
@@ -316,6 +328,7 @@ class OpgApiService implements OpgApiServiceInterface
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData;
     }
 
@@ -342,6 +355,7 @@ class OpgApiService implements OpgApiServiceInterface
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData;
     }
 
@@ -354,6 +368,7 @@ class OpgApiService implements OpgApiServiceInterface
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData;
     }
     public function createYotiSession(string $uuid): array
@@ -365,6 +380,7 @@ class OpgApiService implements OpgApiServiceInterface
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData;
     }
 
@@ -377,6 +393,7 @@ class OpgApiService implements OpgApiServiceInterface
         } catch (\Exception $exception) {
             throw new OpgApiException($exception->getMessage());
         }
+
         return $this->responseData['deadline'];
     }
 }

--- a/service-front/module/Application/test/Services/OpgApiServiceTest.php
+++ b/service-front/module/Application/test/Services/OpgApiServiceTest.php
@@ -496,7 +496,7 @@ class OpgApiServiceTest extends TestCase
      * @dataProvider idCheckData
      * @return void
      */
-    public function testCheckIdCheckAnswers(array $answers, Client $client, bool $responseData, bool $exception): void
+    public function testCheckIdCheckAnswers(array $answers, Client $client, bool $passed, bool $exception): void
     {
         if ($exception) {
             $this->expectException(OpgApiException::class);
@@ -507,7 +507,8 @@ class OpgApiServiceTest extends TestCase
 
         $response = $this->opgApiService->checkIdCheckAnswers($uuid, $answers);
 
-        $this->assertEquals($responseData, $response);
+        $this->assertEquals(true, $response['complete']);
+        $this->assertEquals($passed, $response['passed']);
     }
 
     public static function idCheckData(): array
@@ -527,11 +528,13 @@ class OpgApiServiceTest extends TestCase
         ];
 
         $correctResponse = [
-            "result" => "pass",
+            'complete' => true,
+            'passed' => true,
         ];
 
         $failResponse = [
-            "result" => "fail",
+            'complete' => true,
+            'passed' => false,
         ];
 
         $successMock = new MockHandler([
@@ -541,7 +544,7 @@ class OpgApiServiceTest extends TestCase
         $successClient = new Client(['handler' => $handlerStack]);
 
         $failMock = new MockHandler([
-            new Response(400, ['X-Foo' => 'Bar'], json_encode($failResponse)),
+            new Response(200, ['X-Foo' => 'Bar'], json_encode($failResponse)),
         ]);
         $handlerStack = HandlerStack::create($failMock);
         $failClient = new Client(['handler' => $handlerStack]);


### PR DESCRIPTION
## Purpose

Submit KBV answers to IIQ API to check if they are correct.

Fixes ID-260 #minor

## Approach

When answers are submitted by the front-end, submit them via RTQ. Depending on the response, either return the KBV pass/fail result or add more questions to be answered.

In the front-end, either redirect to the pass/fail results screen or refresh the page if there are more questions to answer.

## Learning

I changed the internal API response from a boolean to an object to handle the additional complexity of whether the KBV check is incomplete.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
