### PR TITLE
Update IIQ mock

### DIFF
--- a/docker/experian-iiq/iiq-response.js
+++ b/docker/experian-iiq/iiq-response.js
@@ -1,3 +1,5 @@
+const iiqStore = stores.open("iiq");
+
 const req = context.request;
 
 const saaEnvelope = `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
@@ -5,7 +7,7 @@ const saaEnvelope = `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-e
     <SAAResponse xmlns="http://schema.uk.experian.com/Experian/IdentityIQ/Services/WebService">
       <SAAResult>
         <Control>
-          <URN>840c9ec2-b685-40e3-a4d8-d6b983297379</URN>
+          <URN>{{urn}}</URN>
           <AuthRefNo>6B3TGRWSKC</AuthRefNo>
         </Control>
         <Questions>
@@ -95,7 +97,7 @@ const questions = [
   },
   {
     QuestionID: "Q00007",
-    Text: "Who is your electricity supplier?",
+    Text: "Which company provides your car insurance?",
     Tooltip: "",
     AnswerFormat: {
       Identifier: "A00007",
@@ -153,47 +155,119 @@ function shuffle(a) {
 
 if (req.body.includes("SAA")) {
   const myQuestions = shuffle(questions)
-    .slice(0, 4)
+    .slice(0, 2)
     .map((x) => {
       x.AnswerFormat.AnswerList = shuffle(x.AnswerFormat.AnswerList);
       return { Question: x };
     });
 
+  const id = req.body.match(
+    /<([a-z0-9-]+):ApplicantIdentifier>(.*?)<\/\1:ApplicantIdentifier>/
+  )[2];
+  iiqStore.save(
+    id,
+    JSON.stringify({
+      questions: myQuestions.map((x) => ({
+        qid: x.Question.QuestionID,
+        correct: false,
+      })),
+    })
+  );
+
   respond().withContent(
-    saaEnvelope.replace("{{questions}}", myQuestions.map(toxml).join(""))
+    saaEnvelope
+      .replace("{{questions}}", myQuestions.map(toxml).join(""))
+      .replace("{{urn}}", id)
   );
 } else if (req.body.includes("RTQ")) {
   const answers = req.body.matchAll(
     /<([a-z0-9-]+):Response><\1:QuestionID>(.*?)<\/\1:QuestionID><\1:AnswerGiven>(.*?)<\/\1:AnswerGiven>/g
   );
 
-  let correct = 0;
+  const id = req.body.match(/<([a-z0-9-]+):URN>(.*?)<\/\1:URN>/)[2];
+  const iiqCase = JSON.parse(iiqStore.load(id));
+
   for (const [, , questionId, answer] of answers) {
+    const questionIndex = iiqCase.questions.findIndex(
+      (x) => x.qid === questionId
+    );
     const question = questions.find((x) => x.QuestionID === questionId);
-    if (question?.AnswerFormat.AnswerList[0] === answer) correct++;
+
+    iiqCase.questions[questionIndex].correct =
+      question?.AnswerFormat.AnswerList[0] === answer;
   }
 
-  respond()
-    .withContent(`<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <soap:Body>
-    <RTQResponse xmlns="http://schema.uk.experian.com/Experian/IdentityIQ/Services/WebService">
-      <RTQResult>
-        <Results>
-          <Outcome>${correct === 4 ? 'Authentication successful – capture SQ' : 'Authentication Unsuccessful'}</Outcome>
-          <AuthenticationResult>${correct === 4 ? 'Authenticated' : 'Not Authenticated'}</AuthenticationResult>
-          <Questions>
-            <Asked>4</Asked>
-            <Correct>${correct}</Correct>
-            <Incorrect>${4 - correct}</Incorrect>
-          </Questions>
-          <NextTransId>
-            <string>END</string>
-          </NextTransId>
-        </Results>
-      </RTQResult>
-    </RTQResponse>
-  </soap:Body>
-</soap:Envelope>`);
+  const asked = iiqCase.questions.length;
+  const correct = iiqCase.questions.filter((q) => q.correct === true).length;
+
+  if (correct >= 3 || asked - correct >= 2) {
+    iiqStore.save(id, JSON.stringify(iiqCase));
+
+    respond()
+      .withContent(`<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <soap:Body>
+        <RTQResponse xmlns="http://schema.uk.experian.com/Experian/IdentityIQ/Services/WebService">
+          <RTQResult>
+            <Results>
+              <Outcome>${
+                correct >= 3
+                  ? "Authentication successful – capture SQ"
+                  : "Authentication Unsuccessful"
+              }</Outcome>
+              <AuthenticationResult>${
+                correct >= 3 ? "Authenticated" : "Not Authenticated"
+              }</AuthenticationResult>
+              <Questions>
+                <Asked>${asked}</Asked>
+                <Correct>${correct}</Correct>
+                <Incorrect>${asked - correct}</Incorrect>
+              </Questions>
+              <NextTransId>
+                <string>END</string>
+              </NextTransId>
+            </Results>
+          </RTQResult>
+        </RTQResponse>
+      </soap:Body>
+    </soap:Envelope>`);
+  } else {
+    const newQuestions = shuffle(questions)
+      .filter(
+        (q) => iiqCase.questions.findIndex((x) => x.qid === q.QuestionID) === -1
+      )
+      .slice(0, correct >= 2 ? 1 : 2)
+      .map((x) => {
+        x.AnswerFormat.AnswerList = shuffle(x.AnswerFormat.AnswerList);
+        return { Question: x };
+      });
+
+    iiqCase.questions.push(
+      ...newQuestions.map((x) => ({
+        qid: x.Question.QuestionID,
+        correct: false,
+      }))
+    );
+
+    iiqStore.save(id, JSON.stringify(iiqCase));
+
+    respond()
+      .withContent(`<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+      <soap:Body>
+        <RTQResponse xmlns="http://schema.uk.experian.com/Experian/IdentityIQ/Services/WebService">
+          <RTQResult>
+            <Questions>
+              ${newQuestions.map(toxml).join("")}
+            </Questions>
+            <Results>
+              <NextTransId>
+                <string>RTQ</string>
+              </NextTransId>
+            </Results>
+          </RTQResult>
+        </RTQResponse>
+      </soap:Body>
+    </soap:Envelope>`);
+  }
 } else {
   respond();
 }

--- a/e2e-tests/cypress/e2e/certificate_provider/certificate-provider-journey.cy.ts
+++ b/e2e-tests/cypress/e2e/certificate_provider/certificate-provider-journey.cy.ts
@@ -28,5 +28,18 @@ describe("Identify a Certificate Provider", () => {
 
         cy.contains("Initial identity confirmation complete");
         cy.get(".govuk-button").contains("Continue").click();
+
+        cy.contains("Select answer");
+
+        cy.selectKBVAnswer({ correct: true });
+        cy.get(".govuk-button").contains("Continue").click();
+
+        cy.selectKBVAnswer({ correct: true });
+        cy.get(".govuk-button").contains("Continue").click();
+
+        cy.selectKBVAnswer({ correct: true });
+        cy.get(".govuk-button").contains("Continue").click();
+
+        cy.contains(".moj-banner", "Identity check passed");
     });
 });

--- a/e2e-tests/cypress/e2e/donor/donor-journey.cy.ts
+++ b/e2e-tests/cypress/e2e/donor/donor-journey.cy.ts
@@ -18,5 +18,49 @@ describe("Identify a Donor", () => {
 
     cy.contains("Initial identity confirmation complete");
     cy.get(".govuk-button").contains("Continue").click();
+
+    cy.contains("Select answer");
+
+    cy.selectKBVAnswer({ correct: true });
+    cy.get(".govuk-button").contains("Continue").click();
+
+    cy.selectKBVAnswer({ correct: true });
+    cy.get(".govuk-button").contains("Continue").click();
+
+    cy.selectKBVAnswer({ correct: true });
+    cy.get(".govuk-button").contains("Continue").click();
+
+    cy.contains(".moj-banner", "Identity check passed");
+  });
+
+  it("fails if you get KBVs wrong", () => {
+    cy.visit("/start?personType=donor&lpas[]=M-1234-1234-1234");
+
+    cy.contains("How will they confirm their identity?");
+    cy.contains("National Insurance number").click();
+    cy.get(".govuk-button").contains("Continue").click();
+
+    cy.contains("Do the details match the ID document?");
+    cy.get(".govuk-button").contains("Continue").click();
+
+    cy.contains("Which LPAs should this identity check apply to?");
+    cy.get(".govuk-button").contains("Continue").click();
+
+    cy.contains("National insurance number");
+    cy.getInputByLabel("National Insurance number").type("AA 12 34 56 A");
+    cy.get(".govuk-button").contains("Continue").click();
+
+    cy.contains("Initial identity confirmation complete");
+    cy.get(".govuk-button").contains("Continue").click();
+
+    cy.contains("Select answer");
+
+    cy.selectKBVAnswer({ correct: false });
+    cy.get(".govuk-button").contains("Continue").click();
+
+    cy.selectKBVAnswer({ correct: false });
+    cy.get(".govuk-button").contains("Continue").click();
+
+    cy.contains(".moj-banner", "Identity check failed");
   });
 });

--- a/e2e-tests/cypress/support/commands.ts
+++ b/e2e-tests/cypress/support/commands.ts
@@ -6,3 +6,48 @@ Cypress.Commands.add("getInputByLabel", (label) => {
       cy.get("#" + id);
     });
 });
+
+Cypress.Commands.add("selectKBVAnswer", ({ correct }) => {
+  const questions = {
+    "Who is your electricity supplier?": {
+      correct: "VoltWave",
+      incorrect: "Glow Electric",
+    },
+    "How much was your last phone bill?": {
+      correct: "£5.99",
+      incorrect: "£11",
+    },
+    "What is your mother’s maiden name?": {
+      correct: "Germanotta",
+      incorrect: "Gumm",
+    },
+    "What are the last two characters of your car number plate?": {
+      correct: "IF",
+      incorrect: "SJ",
+    },
+    "Name one of your current account providers": {
+      correct: "Liberty Trust Bank",
+      incorrect: "Heritage Horizon Bank",
+    },
+    "In what month did you move into your current house?": {
+      correct: "July",
+      incorrect: "September",
+    },
+    "Which company provides your car insurance?": {
+      correct: "SafeDrive Insurance",
+      incorrect: "Guardian Drive Assurance",
+    },
+    "What colour is your front door?": {
+      correct: "Pink",
+      incorrect: "Green",
+    },
+  };
+
+  cy.get("h1")
+    .invoke("text")
+    .then((question) => {
+      const answer = questions[question][correct ? "correct" : "incorrect"];
+
+      cy.contains(answer).click();
+    });
+});

--- a/e2e-tests/cypress/support/index.d.ts
+++ b/e2e-tests/cypress/support/index.d.ts
@@ -6,5 +6,11 @@ declare namespace Cypress {
      * Get an input element by its label text
      */
     getInputByLabel(string): Chainable<any>;
+
+    /**
+     *
+     * @param string
+     */
+    selectKBVAnswer({ correct: boolean }): Chainable<any>;
   }
 }


### PR DESCRIPTION
## Purpose

It now handles pass/fail and setting more questions, following the same logic as the real API. It continues to use the mock questions from ID-82.

Also adds KBV pages to the happy path end-to-end journeys and adds a KBV failure end-to-end journey.

Fixes ID-346 #patch

## Approach

Used Imposter's "stores" functionality to save data between requests based on the URN.

I added a `selectKBVAnswer` Cypress method to easily allow selecting a correct or incorrect answer based on the mock data set.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
