### PR TITLE
Improve typing of OpgApiServiceInterface

### DIFF
--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -23,7 +23,6 @@ use Application\Model\Entity\CaseProgress;
  * DTO for holding data required to make new case entry post
  * @psalm-suppress MissingConstructor
  * Needed here due to false positive from Laminas’s uninitialised properties
- * @psalm-suppress UnusedProperty
  */
 class CaseData implements JsonSerializable
 {
@@ -48,7 +47,14 @@ class CaseData implements JsonSerializable
     public string $lastName;
 
     /**
-     * @var string[]
+     * @var array{
+     *   line1: string,
+     *   line2?: string,
+     *   line3?: string,
+     *   town?: string,
+     *   postcode: string,
+     *   country?: string,
+     * }
      */
     #[Validator(NotEmpty::class)]
     public array $address;
@@ -88,6 +94,9 @@ class CaseData implements JsonSerializable
     #[Annotation\Required(false)]
     public ?CounterService $counterService = null;
 
+    /**
+     * @var ?array{country?: string, id_method?: string}
+     */
     #[Annotation\Required(false)]
     public ?array $idMethodIncludingNation = [];
 

--- a/service-api/module/Application/test/ApplicationTest/Yoti/SessionConfigTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Yoti/SessionConfigTest.php
@@ -7,7 +7,6 @@ namespace ApplicationTest\Yoti;
 use Application\Model\Entity\CaseData;
 use Application\Yoti\SessionConfig;
 use DateTime;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
@@ -152,12 +151,12 @@ class SessionConfigTest extends TestCase
                 "structured_postal_address" => [
                     "address_format" => "1",
                     "building_number" => "123",
-                    "address_line1" => $this->caseMock->address['line1'],
-                    "address_line2" => $this->caseMock->address['line2'],
+                    "address_line1" => '123 long street',
+                    "address_line2" => 'Kings Cross',
                     "town_city" => "London",
-                    "country" => $this->caseMock->address['country'],
+                    "country" => 'England',
                     "country_iso" => "GBR",
-                    "postal_code" => $this->caseMock->address['postcode'],
+                    "postal_code" => 'NW1 1SP',
                 ],
             ]
         ];

--- a/service-front/module/Application/src/Contracts/OpgApiServiceInterface.php
+++ b/service-front/module/Application/src/Contracts/OpgApiServiceInterface.php
@@ -11,13 +11,49 @@ namespace Application\Contracts;
  *   prompts: string[],
  *   answered: bool
  * }
+ *
+ * @psalm-type Address = array{
+ *   line1: string,
+ *   line2?: string,
+ *   line3?: string,
+ *   town?: string,
+ *   postcode: string,
+ *   country?: string,
+ * }
+ *
+ * @psalm-type CaseData = array{
+ *   lpas: string[],
+ *   personType: "donor"|"certificateProvider",
+ *   dob: string,
+ *   address: Address,
+ *   alternateAddress?: Address,
+ *   idMethod: string,
+ *   idMethodIncludingNation?: array{
+ *     country?: string,
+ *     id_method?: string,
+ *   },
+ *   searchPostcode?: string,
+ *   counterService?: array{
+ *     selectedPostOffice: string,
+ *     selectedPostOfficeDeadline: string,
+ *     notificationState: string,
+ *     notificationsAuthToken: string,
+ *     state: string,
+ *     result: bool,
+ *   },
+ * }
  */
 interface OpgApiServiceInterface
 {
-    public function makeApiRequest(string $uri, string $verb = 'get', array $data = [], array $headers = []): array;
+    /**
+     * @return CaseData
+     */
     public function getDetailsData(string $uuid): array;
+
     public function checkNinoValidity(string $nino): string;
+
     public function checkDlnValidity(string $dln): string;
+
     public function checkPassportValidity(string $passport): string;
 
     /**
@@ -29,6 +65,10 @@ interface OpgApiServiceInterface
      * @return array{complete: bool, passed: bool}
      */
     public function checkIdCheckAnswers(string $uuid, array $answers): array;
+
+    /**
+     * @return array{uuid: string}
+     */
     public function createCase(
         string $firstname,
         string $lastname,
@@ -38,27 +78,36 @@ interface OpgApiServiceInterface
         array $address,
     ): array;
 
-    public function findLpa(string $uuid, string $lpa): array;
+    public function updateIdMethod(string $uuid, string $method): void;
 
-    public function updateIdMethod(string $uuid, string $method): array;
-
+    /**
+     * @return array<string, array{
+     *   name: string,
+     *   address: string,
+     *   post_code: string,
+     * }>
+     */
     public function listPostOfficesByPostcode(string $uuid, string $location): array;
 
-    public function addSelectedPostOffice(string $uuid, string $postOffice): array;
-    public function confirmSelectedPostOffice(string $uuid, string $deadline): array;
+    public function addSelectedPostOffice(string $uuid, string $postOffice): void;
 
-    public function updateCaseWithLpa(string $uuid, string $lpa, bool $remove = false): array;
+    public function confirmSelectedPostOffice(string $uuid, string $deadline): void;
 
-    public function addSelectedAltAddress(string $uuid, array $data): array;
+    public function updateCaseWithLpa(string $uuid, string $lpa, bool $remove = false): void;
 
-    public function updateCaseSetDocumentComplete(string $uuid): array;
+    public function addSelectedAltAddress(string $uuid, array $data): void;
 
-    public function updateCaseSetDob(string $uuid, string $dob): array;
+    public function updateCaseSetDocumentComplete(string $uuid): void;
 
-    public function updateIdMethodWithCountry(string $uuid, array $data): array;
+    public function updateCaseSetDob(string $uuid, string $dob): void;
 
-    public function updateCaseProgress(string $uuid, array $data): array;
+    public function updateIdMethodWithCountry(string $uuid, array $data): void;
 
+    public function updateCaseProgress(string $uuid, array $data): void;
+
+    /**
+     * @return array{pdfBase64: string}
+     */
     public function createYotiSession(string $uuid): array;
 
     public function estimatePostofficeDeadline(string $uuid): string;

--- a/service-front/module/Application/src/Contracts/OpgApiServiceInterface.php
+++ b/service-front/module/Application/src/Contracts/OpgApiServiceInterface.php
@@ -95,14 +95,29 @@ interface OpgApiServiceInterface
 
     public function updateCaseWithLpa(string $uuid, string $lpa, bool $remove = false): void;
 
+    /**
+     * @param Address $data
+     */
     public function addSelectedAltAddress(string $uuid, array $data): void;
 
     public function updateCaseSetDocumentComplete(string $uuid): void;
 
     public function updateCaseSetDob(string $uuid, string $dob): void;
 
+    /**
+     * @param array{
+     *   country?: string,
+     *   id_method?: string,
+     * } $data
+     */
     public function updateIdMethodWithCountry(string $uuid, array $data): void;
 
+    /**
+     * @param array{
+     *   last_page: string,
+     *   timestamp: string,
+     * } $data
+     */
     public function updateCaseProgress(string $uuid, array $data): void;
 
     /**

--- a/service-front/module/Application/src/Controller/CPFlowController.php
+++ b/service-front/module/Application/src/Controller/CPFlowController.php
@@ -194,11 +194,9 @@ class CPFlowController extends AbstractActionController
 
                 return $view->setTemplate('application/pages/cp/add_lpa');
             } else {
-                $responseData = $this->opgApiService->updateCaseWithLpa($uuid, $formObject->get('add_lpa_number'));
+                $this->opgApiService->updateCaseWithLpa($uuid, $formObject->get('add_lpa_number'));
 
-                if ($responseData['result'] === 'Updated') {
-                    return $this->redirect()->toRoute('root/cp_confirm_lpas', ['uuid' => $uuid]);
-                }
+                return $this->redirect()->toRoute('root/cp_confirm_lpas', ['uuid' => $uuid]);
             }
         }
 
@@ -528,11 +526,9 @@ class CPFlowController extends AbstractActionController
                  */
                 $structuredAddress = json_decode($params->get('address_json'), true);
 
-                $response = $this->opgApiService->addSelectedAltAddress($uuid, $structuredAddress);
+                $this->opgApiService->addSelectedAltAddress($uuid, $structuredAddress);
 
-                if ($response) {
-                    return $this->redirect()->toRoute('root/cp_enter_address_manual', ['uuid' => $uuid]);
-                }
+                return $this->redirect()->toRoute('root/cp_enter_address_manual', ['uuid' => $uuid]);
             }
         }
 
@@ -546,7 +542,7 @@ class CPFlowController extends AbstractActionController
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 
         $form = (new AttributeBuilder())->createForm(CpAltAddress::class);
-        $form->setData($detailsData['alternateAddress']);
+        $form->setData($detailsData['alternateAddress'] ?? []);
 
         if (count($this->getRequest()->getPost())) {
             $params = $this->getRequest()->getPost();
@@ -557,10 +553,9 @@ class CPFlowController extends AbstractActionController
                 /**
                  * @psalm-suppress InvalidMethodCall
                  */
-                $response = $this->opgApiService->addSelectedAltAddress($uuid, $params->toArray());
-                if ($response) {
-                    return $this->redirect()->toRoute('root/cp_confirm_address', ['uuid' => $uuid]);
-                }
+                $this->opgApiService->addSelectedAltAddress($uuid, $params->toArray());
+
+                return $this->redirect()->toRoute('root/cp_confirm_address', ['uuid' => $uuid]);
             }
         }
 
@@ -638,10 +633,9 @@ class CPFlowController extends AbstractActionController
             $formData = $this->getRequest()->getPost()->toArray();
 
             if ($form->isValid()) {
-                $responseData = $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
-                if ($responseData['result'] === 'Updated') {
-                    return $this->redirect()->toRoute("root/cp_choose_country_id", ['uuid' => $uuid]);
-                }
+                $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
+
+                return $this->redirect()->toRoute("root/cp_choose_country_id", ['uuid' => $uuid]);
             }
         }
 

--- a/service-front/module/Application/src/Helpers/AddressProcessorHelper.php
+++ b/service-front/module/Application/src/Helpers/AddressProcessorHelper.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Application\Helpers;
 
 use Application\Contracts\OpgApiServiceInterface;
-use Application\Helpers\DTO\FormProcessorResponseDto;
-use Laminas\Form\FormInterface;
-use Laminas\Stdlib\Parameters;
 
+/**
+ * @psalm-import-type Address from OpgApiServiceInterface
+ */
 class AddressProcessorHelper
 {
     /**
@@ -20,7 +20,7 @@ class AddressProcessorHelper
         'line3' => 'line3',
         'town' => 'town',
         'postcode' => 'postcode',
-        'country' => 'country'
+        'country' => 'country',
     ];
 
     /**
@@ -32,13 +32,16 @@ class AddressProcessorHelper
         'line3' => 'addressLine3',
         'town' => 'town',
         'postcode' => 'postcode',
-        'country' => 'country'
+        'country' => 'country',
     ];
 
     public function __construct()
     {
     }
 
+    /**
+     * @return Address
+     */
     public function getAddress(array $address): array
     {
         return [
@@ -81,6 +84,7 @@ class AddressProcessorHelper
                         $str .= $line . ", ";
                     }
                 }
+
                 return $str;
             };
             $index = json_encode($arr);
@@ -93,6 +97,7 @@ class AddressProcessorHelper
                 strlen($arrString) - 2
             );
         }
+
         return $stringified;
     }
 }

--- a/service-front/module/Application/src/Helpers/FormProcessorHelper.php
+++ b/service-front/module/Application/src/Helpers/FormProcessorHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Helpers;
 
 use Application\Contracts\OpgApiServiceInterface;
+use Application\Exceptions\OpgApiException;
 use Application\Helpers\DTO\FormProcessorResponseDto;
 use Application\Services\SiriusApiService;
 use Laminas\Form\FormInterface;
@@ -175,10 +176,10 @@ class FormProcessorHelper
         } else {
             $form->setData($formData);
             if ($form->isValid()) {
-                $responseData = $this->opgApiService->addSelectedPostOffice($uuid, $formArray['postoffice']);
-                if ($responseData['result'] == 'Updated') {
+                try {
+                    $this->opgApiService->addSelectedPostOffice($uuid, $formArray['postoffice']);
                     $redirect = 'root/confirm_post_office';
-                } else {
+                } catch (OpgApiException) {
                     $form->setMessages(['Error saving Post Office to this case.']);
                 }
             } else {

--- a/service-front/module/Application/test/Services/OpgApiServiceTest.php
+++ b/service-front/module/Application/test/Services/OpgApiServiceTest.php
@@ -540,91 +540,20 @@ class OpgApiServiceTest extends TestCase
     }
 
     /**
-     * @dataProvider addLpaData
-     * @return void
-     */
-    public function testFindLpa(array $data, Client $client, array $responseData, bool $exception): void
-    {
-        $this->opgApiService = new OpgApiService($client);
-
-        $response = $this->opgApiService->findLpa(
-            $data['uuid'],
-            $data['lpa'],
-        );
-
-        if ($exception) {
-            $this->assertStringContainsString($responseData[0], json_encode($response));
-        } else {
-            $this->assertEquals($responseData, $response);
-        }
-    }
-
-    public static function addLpaData(): array
-    {
-        $data = [];
-        $data['uuid'] = '49895f88-501b-4491-8381-e8aeeaef177d';
-        $data['lpa'] = "PA M-XYXY-YAGA-35G3";
-
-        $successMockResponseData = [
-            "case_uuid" => "9130a21e-6e5e-4a30-8b27-76d21b747e60",
-            "lpa_number" => "M-0000-0000-0000",
-            "type_of_lpa" => "Personal welfare",
-            "donor" => "Mary Ann Chapman",
-            "lpa_status" => "Processing",
-            "cp_name" => "David Smith",
-            "cp_address" => [
-                "Line_1" => "82 Penny Street",
-                "Line_2" => "Lancaster",
-                "Town" => "Lancashire",
-                "Postcode" => "LA1 1XN",
-                "Country" => "United Kingdom",
-            ],
-            "message" => "Success",
-            "status" => 200,
-        ];
-        $successMock = new MockHandler([
-            new Response(200, ['X-Foo' => 'Bar'], json_encode($successMockResponseData)),
-        ]);
-        $handlerStack = HandlerStack::create($successMock);
-        $successClient = new Client(['handler' => $handlerStack]);
-
-        $failMockResponseData = ['Client error'];
-        $failMock = new MockHandler([
-            new Response(400, ['X-Foo' => 'Bar'], json_encode($failMockResponseData)),
-        ]);
-        $handlerStack = HandlerStack::create($failMock);
-        $failClient = new Client(['handler' => $handlerStack]);
-
-        return [
-            [
-                $data,
-                $successClient,
-                $successMockResponseData,
-                false,
-            ],
-            [
-                $data,
-                $failClient,
-                $failMockResponseData,
-                true,
-            ],
-        ];
-    }
-
-    /**
      * @dataProvider updateIdMethodData
      * @return void
      */
-    public function testUpdateIdMethod(array $data, Client $client, array $responseData, bool $exception): void
+    public function testUpdateIdMethod(array $data, Client $client, bool $exception): void
     {
         if ($exception) {
             $this->expectException(OpgApiException::class);
+        } else {
+            $this->expectNotToPerformAssertions();
         }
+
         $this->opgApiService = new OpgApiService($client);
 
-        $response = $this->opgApiService->updateIdMethod($data['uuid'], $data['method']);
-
-        $this->assertEquals($responseData, $response);
+        $this->opgApiService->updateIdMethod($data['uuid'], $data['method']);
     }
 
     public static function updateIdMethodData(): array
@@ -633,16 +562,14 @@ class OpgApiServiceTest extends TestCase
         $data['uuid'] = '49895f88-501b-4491-8381-e8aeeaef177d';
         $data['method'] = "nin";
 
-        $successMockResponseData = ["result" => "Updated"];
         $successMock = new MockHandler([
-            new Response(200, ['X-Foo' => 'Bar'], json_encode($successMockResponseData)),
+            new Response(200, ['X-Foo' => 'Bar'], ''),
         ]);
         $handlerStack = HandlerStack::create($successMock);
         $successClient = new Client(['handler' => $handlerStack]);
 
-        $failMockResponseData = ['Bad Request'];
         $failMock = new MockHandler([
-            new Response(400, ['X-Foo' => 'Bar'], json_encode($failMockResponseData)),
+            new Response(400, ['X-Foo' => 'Bar'], ''),
         ]);
         $handlerStack = HandlerStack::create($failMock);
         $failClient = new Client(['handler' => $handlerStack]);
@@ -651,13 +578,11 @@ class OpgApiServiceTest extends TestCase
             [
                 $data,
                 $successClient,
-                $successMockResponseData,
                 false,
             ],
             [
                 $data,
                 $failClient,
-                $failMockResponseData,
                 true,
             ],
         ];
@@ -670,21 +595,17 @@ class OpgApiServiceTest extends TestCase
     public function testSetDocumentCompleteMethod(
         array $data,
         Client $client,
-        array $responseData,
         bool $exception
     ): void {
         if ($exception) {
             $this->expectException(OpgApiException::class);
+        } else {
+            $this->expectNotToPerformAssertions();
         }
+
         $this->opgApiService = new OpgApiService($client);
 
-        $response = $this->opgApiService->updateCaseSetDocumentComplete($data['uuid']);
-
-        if ($exception) {
-            $this->assertStringContainsString('Client error:', json_encode($response));
-        } else {
-            $this->assertEquals($responseData, $response);
-        }
+        $this->opgApiService->updateCaseSetDocumentComplete($data['uuid']);
     }
 
     public static function setDocumentCompleteData(): array
@@ -692,18 +613,14 @@ class OpgApiServiceTest extends TestCase
         $data = [];
         $data['uuid'] = '49895f88-501b-4491-8381-e8aeeaef177d';
 
-        $successMockResponseData = ["result" => "Updated"];
         $successMock = new MockHandler([
-            new Response(200, ['X-Foo' => 'Bar'], json_encode($successMockResponseData)),
+            new Response(200, ['X-Foo' => 'Bar'], ''),
         ]);
         $handlerStack = HandlerStack::create($successMock);
         $successClient = new Client(['handler' => $handlerStack]);
 
-        $failMockResponseData = [
-            'Client error: `',
-        ];
         $failMock = new MockHandler([
-            new Response(400, ['X-Foo' => 'Bar'], json_encode($failMockResponseData)),
+            new Response(400, ['X-Foo' => 'Bar'], ''),
         ]);
         $handlerStack = HandlerStack::create($failMock);
         $failClient = new Client(['handler' => $handlerStack]);
@@ -712,13 +629,11 @@ class OpgApiServiceTest extends TestCase
             [
                 $data,
                 $successClient,
-                $successMockResponseData,
                 false,
             ],
             [
                 $data,
                 $failClient,
-                $failMockResponseData,
                 true,
             ],
         ];
@@ -733,21 +648,17 @@ class OpgApiServiceTest extends TestCase
     public function testSetDobMethod(
         array $data,
         Client $client,
-        array $responseData,
         bool $exception
     ): void {
         if ($exception) {
             $this->expectException(OpgApiException::class);
+        } else {
+            $this->expectNotToPerformAssertions();
         }
+
         $this->opgApiService = new OpgApiService($client);
 
-        $response = $this->opgApiService->updateCaseSetDob($data['uuid'], $data['dob']);
-
-        if ($exception) {
-            $this->assertStringContainsString('Client error:', json_encode($response));
-        } else {
-            $this->assertEquals($responseData, $response);
-        }
+        $this->opgApiService->updateCaseSetDob($data['uuid'], $data['dob']);
     }
 
     public static function setDobData(): array
@@ -756,18 +667,14 @@ class OpgApiServiceTest extends TestCase
         $data['uuid'] = '49895f88-501b-4491-8381-e8aeeaef177d';
         $data['dob'] = '1980-01-01';
 
-        $successMockResponseData = ["result" => "Updated"];
         $successMock = new MockHandler([
-            new Response(200, ['X-Foo' => 'Bar'], json_encode($successMockResponseData)),
+            new Response(200, ['X-Foo' => 'Bar'], ''),
         ]);
         $handlerStack = HandlerStack::create($successMock);
         $successClient = new Client(['handler' => $handlerStack]);
 
-        $failMockResponseData = [
-            'Client error: `',
-        ];
         $failMock = new MockHandler([
-            new Response(400, ['X-Foo' => 'Bar'], json_encode($failMockResponseData)),
+            new Response(400, ['X-Foo' => 'Bar'], ''),
         ]);
         $handlerStack = HandlerStack::create($failMock);
         $failClient = new Client(['handler' => $handlerStack]);
@@ -776,13 +683,11 @@ class OpgApiServiceTest extends TestCase
             [
                 $data,
                 $successClient,
-                $successMockResponseData,
                 false,
             ],
             [
                 $data,
                 $failClient,
-                $failMockResponseData,
                 true,
             ],
         ];
@@ -797,21 +702,17 @@ class OpgApiServiceTest extends TestCase
     public function testAbandonCaseMethod(
         array $data,
         Client $client,
-        array $responseData,
         bool $exception
     ): void {
         if ($exception) {
             $this->expectException(OpgApiException::class);
+        } else {
+            $this->expectNotToPerformAssertions();
         }
+
         $this->opgApiService = new OpgApiService($client);
 
-        $response = $this->opgApiService->updateCaseProgress($data['uuid'], $data);
-
-        if ($exception) {
-            $this->assertStringContainsString('Client error:', json_encode($response));
-        } else {
-            $this->assertEquals($responseData, $response);
-        }
+        $this->opgApiService->updateCaseProgress($data['uuid'], $data);
     }
 
     public static function setAbandonCaseData(): array
@@ -820,18 +721,14 @@ class OpgApiServiceTest extends TestCase
         $data['uuid'] = '49895f88-501b-4491-8381-e8aeeaef177d';
         $data['dob'] = '1980-01-01';
 
-        $successMockResponseData = ["result" => "Updated"];
         $successMock = new MockHandler([
-            new Response(200, ['X-Foo' => 'Bar'], json_encode($successMockResponseData)),
+            new Response(200, ['X-Foo' => 'Bar'], ''),
         ]);
         $handlerStack = HandlerStack::create($successMock);
         $successClient = new Client(['handler' => $handlerStack]);
 
-        $failMockResponseData = [
-            'Client error: `',
-        ];
         $failMock = new MockHandler([
-            new Response(400, ['X-Foo' => 'Bar'], json_encode($failMockResponseData)),
+            new Response(400, ['X-Foo' => 'Bar'], ''),
         ]);
         $handlerStack = HandlerStack::create($failMock);
         $failClient = new Client(['handler' => $handlerStack]);
@@ -840,13 +737,11 @@ class OpgApiServiceTest extends TestCase
             [
                 $data,
                 $successClient,
-                $successMockResponseData,
                 false,
             ],
             [
                 $data,
                 $failClient,
-                $failMockResponseData,
                 true,
             ],
         ];


### PR DESCRIPTION
To better document API and identify mistaken assumptions.

In a few places, replace `array` return types with `void` because we only use the array value to check the request was successful, but that's implicit from no exception being thrown.

#patch
