### PR TITLE
Use type templates on forms

### DIFF
--- a/service-front/module/Application/src/Controller/CPFlowController.php
+++ b/service-front/module/Application/src/Controller/CPFlowController.php
@@ -195,8 +195,6 @@ class CPFlowController extends AbstractActionController
         $view->setVariable('case_uuid', $uuid);
 
         if (count($this->getRequest()->getPost())) {
-            $formObject = $this->getRequest()->getPost();
-
             if (! $form->isValid()) {
                 $form->setMessages([
                     'lpa' => [
@@ -207,18 +205,18 @@ class CPFlowController extends AbstractActionController
                 return $view->setTemplate('application/pages/cp/add_lpa');
             }
 
-            if ($formObject->get('lpa')) {
+            $formArray = $this->formToArray($form);
+            if ($formArray['lpa']) {
                 $siriusCheck = $this->siriusApiService->getLpaByUid(
                     /**
                      * @psalm-suppress InvalidMethodCall
                      */
-                    $formObject->get('lpa'),
+                    $formArray['lpa'],
                     $this->getRequest()
                 );
 
                 $processed = $this->lpaFormHelper->findLpa(
                     $uuid,
-                    $this->getRequest()->getPost(),
                     $form,
                     $siriusCheck,
                     $detailsData,
@@ -229,7 +227,7 @@ class CPFlowController extends AbstractActionController
 
                 return $view->setTemplate('application/pages/cp/add_lpa');
             } else {
-                $this->opgApiService->updateCaseWithLpa($uuid, $formObject->get('add_lpa_number'));
+                $this->opgApiService->updateCaseWithLpa($uuid, $this->getRequest()->getPost()->get('add_lpa_number'));
 
                 return $this->redirect()->toRoute('root/cp_confirm_lpas', ['uuid' => $uuid]);
             }

--- a/service-front/module/Application/src/Controller/CPFlowController.php
+++ b/service-front/module/Application/src/Controller/CPFlowController.php
@@ -508,18 +508,16 @@ class CPFlowController extends AbstractActionController
         $form = $this->createForm(Postcode::class);
         $view->setVariable('form', $form);
 
-        if (count($this->getRequest()->getPost())) {
-            if ($form->isValid()) {
-                $postcode = $this->formToArray($form)['postcode'];
+        if ($this->getRequest()->isPost() && $form->isValid()) {
+            $postcode = $this->formToArray($form)['postcode'];
 
-                return $this->redirect()->toRoute(
-                    'root/cp_select_address',
-                    [
-                        'uuid' => $uuid,
-                        'postcode' => $postcode,
-                    ]
-                );
-            }
+            return $this->redirect()->toRoute(
+                'root/cp_select_address',
+                [
+                    'uuid' => $uuid,
+                    'postcode' => $postcode,
+                ]
+            );
         }
 
         return $view->setTemplate('application/pages/cp/enter_address');
@@ -554,16 +552,14 @@ class CPFlowController extends AbstractActionController
         $view->setVariable('addresses', $addressStrings);
         $view->setVariable('addresses_count', count($addressStrings));
 
-        if ($this->getRequest()->isPost()) {
-            if ($form->isValid()) {
-                $formData = $this->formToArray($form);
+        if ($this->getRequest()->isPost() && $form->isValid()) {
+            $formData = $this->formToArray($form);
 
-                $structuredAddress = json_decode($formData['address_json'], true);
+            $structuredAddress = json_decode($formData['address_json'], true);
 
-                $this->opgApiService->addSelectedAltAddress($uuid, $structuredAddress);
+            $this->opgApiService->addSelectedAltAddress($uuid, $structuredAddress);
 
-                return $this->redirect()->toRoute('root/cp_enter_address_manual', ['uuid' => $uuid]);
-            }
+            return $this->redirect()->toRoute('root/cp_enter_address_manual', ['uuid' => $uuid]);
         }
 
         return $view->setTemplate('application/pages/cp/select_address');
@@ -660,14 +656,12 @@ class CPFlowController extends AbstractActionController
 
         $form = $this->createForm(Country::class);
 
-        if (count($this->getRequest()->getPost())) {
-            if ($form->isValid()) {
-                $formData = $this->formToArray($form);
+        if ($this->getRequest()->isPost() && $form->isValid()) {
+            $formData = $this->formToArray($form);
 
-                $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
+            $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
 
-                return $this->redirect()->toRoute("root/cp_choose_country_id", ['uuid' => $uuid]);
-            }
+            return $this->redirect()->toRoute("root/cp_choose_country_id", ['uuid' => $uuid]);
         }
 
         $countriesData = PostOfficeCountry::cases();
@@ -702,14 +696,12 @@ class CPFlowController extends AbstractActionController
         $form = $this->createForm(CountryDocument::class);
         $view->setVariable('form', $form);
 
-        if ($this->getRequest()->isPost()) {
-            if ($form->isValid()) {
-                $formData = $this->formToArray($form);
+        if ($this->getRequest()->isPost() && $form->isValid()) {
+            $formData = $this->formToArray($form);
 
-                $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
+            $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
 
-                return $this->redirect()->toRoute("root/cp_name_match_check", ['uuid' => $uuid]);
-            }
+            return $this->redirect()->toRoute("root/cp_name_match_check", ['uuid' => $uuid]);
         }
 
         $view->setVariables([

--- a/service-front/module/Application/src/Controller/CPFlowController.php
+++ b/service-front/module/Application/src/Controller/CPFlowController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Controller;
 
 use Application\Contracts\OpgApiServiceInterface;
+use Application\Controller\Trait\FormBuilder;
 use Application\Enums\LpaTypes;
 use Application\Forms\AddressJson;
 use Application\Forms\BirthDate;
@@ -35,6 +36,8 @@ use Laminas\View\Model\ViewModel;
 
 class CPFlowController extends AbstractActionController
 {
+    use FormBuilder;
+
     protected $plugins;
 
     public function __construct(
@@ -56,8 +59,8 @@ class CPFlowController extends AbstractActionController
         ];
         $view = new ViewModel();
         $uuid = $this->params()->fromRoute("uuid");
-        $dateSubForm = (new AttributeBuilder())->createForm(PassportDateCp::class);
-        $form = (new AttributeBuilder())->createForm(IdMethod::class);
+        $dateSubForm = $this->createForm(PassportDateCp::class);
+        $form = $this->createForm(IdMethod::class);
         $view->setVariable('date_sub_form', $dateSubForm);
 
         $detailsData = $this->opgApiService->getDetailsData($uuid);
@@ -78,7 +81,6 @@ class CPFlowController extends AbstractActionController
         if (count($this->getRequest()->getPost())) {
             $formData = $this->getRequest()->getPost()->toArray();
             if (array_key_exists('check_button', $formData)) {
-                $dateSubForm->setData($this->getRequest()->getPost());
                 $formProcessorResponseDto = $this->formProcessorHelper->processPassportDateForm(
                     $uuid,
                     $this->getRequest()->getPost(),
@@ -87,7 +89,6 @@ class CPFlowController extends AbstractActionController
                 );
                 $view->setVariables($formProcessorResponseDto->getVariables());
             } else {
-                $form->setData($formData);
                 if ($form->isValid()) {
                     if ($formData['id_method'] == IdMethodEnum::PostOffice->value) {
                         $data = [
@@ -186,7 +187,7 @@ class CPFlowController extends AbstractActionController
         $uuid = $this->params()->fromRoute("uuid");
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 
-        $form = (new AttributeBuilder())->createForm(LpaReferenceNumber::class);
+        $form = $this->createForm(LpaReferenceNumber::class);
 
         $view = new ViewModel();
         $view->setVariable('details_data', $detailsData);
@@ -195,8 +196,6 @@ class CPFlowController extends AbstractActionController
 
         if (count($this->getRequest()->getPost())) {
             $formObject = $this->getRequest()->getPost();
-
-            $form->setData($formObject);
 
             if (! $form->isValid()) {
                 $form->setMessages([
@@ -207,9 +206,7 @@ class CPFlowController extends AbstractActionController
 
                 return $view->setTemplate('application/pages/cp/add_lpa');
             }
-            /**
-             * @psalm-suppress InvalidMethodCall
-             */
+
             if ($formObject->get('lpa')) {
                 $siriusCheck = $this->siriusApiService->getLpaByUid(
                     /**
@@ -248,7 +245,7 @@ class CPFlowController extends AbstractActionController
             'default' => 'application/pages/cp/confirm_dob',
         ];
         $uuid = $this->params()->fromRoute("uuid");
-        $form = (new AttributeBuilder())->createForm(BirthDate::class);
+        $form = $this->createForm(BirthDate::class);
 
 
         if (count($this->getRequest()->getPost())) {
@@ -280,7 +277,7 @@ class CPFlowController extends AbstractActionController
         $view = new ViewModel();
         $uuid = $this->params()->fromRoute("uuid");
         $detailsData = $this->opgApiService->getDetailsData($uuid);
-        $form = (new AttributeBuilder())->createForm(ConfirmAddress::class);
+        $form = $this->createForm(ConfirmAddress::class);
 
         $routes = [
             'NATIONAL_INSURANCE_NUMBER' => 'root/cp_national_insurance_number',
@@ -305,14 +302,13 @@ class CPFlowController extends AbstractActionController
         if ($this->getRequest()->isPost()) {
             $params = $this->getRequest()->getPost();
 
-            $form->setData($params);
-            $formArray = $this->getRequest()->getPost()->toArray();
-
-            if ($formArray['confirm_alt'] == 'confirmed') {
+            if ($params['confirm_alt'] == 'confirmed') {
                 return $this->redirect()->toRoute($nextRoute, ['uuid' => $uuid]);
             }
 
             if ($form->isValid()) {
+                $formArray = $this->formToArray($form);
+
                 if ($formArray['chosenAddress'] == 'yes') {
                     return $this->redirect()->toRoute($nextRoute, ['uuid' => $uuid]);
                 } elseif ($formArray['chosenAddress'] == 'no') {
@@ -335,7 +331,7 @@ class CPFlowController extends AbstractActionController
         $uuid = $this->params()->fromRoute("uuid");
         $view->setVariable('uuid', $uuid);
 
-        $form = (new AttributeBuilder())->createForm(NationalInsuranceNumber::class);
+        $form = $this->createForm(NationalInsuranceNumber::class);
         $detailsData = $this->opgApiService->getDetailsData($uuid);
         $serviceAvailability = $this->opgApiService->getServiceAvailability();
         $view->setVariable('service_availability', $serviceAvailability->toArray());
@@ -347,7 +343,6 @@ class CPFlowController extends AbstractActionController
         if (count($this->getRequest()->getPost())) {
             $formProcessorResponseDto = $this->formProcessorHelper->processNationalInsuranceNumberForm(
                 $uuid,
-                $this->getRequest()->getPost(),
                 $form,
                 $templates
             );
@@ -372,7 +367,7 @@ class CPFlowController extends AbstractActionController
         $uuid = $this->params()->fromRoute("uuid");
         $view->setVariable('uuid', $uuid);
 
-        $form = (new AttributeBuilder())->createForm(DrivingLicenceNumber::class);
+        $form = $this->createForm(DrivingLicenceNumber::class);
         $detailsData = $this->opgApiService->getDetailsData($uuid);
         $serviceAvailability = $this->opgApiService->getServiceAvailability();
         $view->setVariable('service_availability', $serviceAvailability->toArray());
@@ -384,7 +379,6 @@ class CPFlowController extends AbstractActionController
         if (count($this->getRequest()->getPost())) {
             $formProcessorResponseDto = $this->formProcessorHelper->processDrivingLicenceForm(
                 $uuid,
-                $this->getRequest()->getPost(),
                 $form,
                 $templates
             );
@@ -410,8 +404,8 @@ class CPFlowController extends AbstractActionController
         $uuid = $this->params()->fromRoute("uuid");
         $view->setVariable('uuid', $uuid);
 
-        $form = (new AttributeBuilder())->createForm(PassportNumber::class);
-        $dateSubForm = (new AttributeBuilder())->createForm(PassportDate::class);
+        $form = $this->createForm(PassportNumber::class);
+        $dateSubForm = $this->createForm(PassportDate::class);
         $detailsData = $this->opgApiService->getDetailsData($uuid);
         $serviceAvailability = $this->opgApiService->getServiceAvailability();
         $view->setVariable('service_availability', $serviceAvailability->toArray());
@@ -443,7 +437,6 @@ class CPFlowController extends AbstractActionController
                 );
                 $formProcessorResponseDto = $this->formProcessorHelper->processPassportForm(
                     $uuid,
-                    $this->getRequest()->getPost(),
                     $form,
                     $templates
                 );
@@ -514,18 +507,13 @@ class CPFlowController extends AbstractActionController
         $detailsData = $this->opgApiService->getDetailsData($uuid);
         $view = new ViewModel();
         $view->setVariable('details_data', $detailsData);
-        $form = (new AttributeBuilder())->createForm(Postcode::class);
+        $form = $this->createForm(Postcode::class);
         $view->setVariable('form', $form);
 
         if (count($this->getRequest()->getPost())) {
-            $params = $this->getRequest()->getPost();
-            $form->setData($params);
-            /**
-             * @psalm-suppress InvalidMethodCall
-             */
-            $postcode = $params->get('postcode');
-
             if ($form->isValid()) {
+                $postcode = $this->formToArray($form)['postcode'];
+
                 return $this->redirect()->toRoute(
                     'root/cp_select_address',
                     [
@@ -545,7 +533,7 @@ class CPFlowController extends AbstractActionController
         $postcode = $this->params()->fromRoute("postcode");
 
         $detailsData = $this->opgApiService->getDetailsData($uuid);
-        $form = (new AttributeBuilder())->createForm(AddressJson::class);
+        $form = $this->createForm(AddressJson::class);
 
         $view = new ViewModel();
         $view->setVariables([
@@ -569,14 +557,10 @@ class CPFlowController extends AbstractActionController
         $view->setVariable('addresses_count', count($addressStrings));
 
         if ($this->getRequest()->isPost()) {
-            $params = $this->getRequest()->getPost();
-            $form->setData($params);
-
             if ($form->isValid()) {
-                /**
-                 * @psalm-suppress InvalidMethodCall
-                 */
-                $structuredAddress = json_decode($params->get('address_json'), true);
+                $formData = $this->formToArray($form);
+
+                $structuredAddress = json_decode($formData['address_json'], true);
 
                 $this->opgApiService->addSelectedAltAddress($uuid, $structuredAddress);
 
@@ -593,7 +577,7 @@ class CPFlowController extends AbstractActionController
         $uuid = $this->params()->fromRoute("uuid");
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 
-        $form = (new AttributeBuilder())->createForm(CpAltAddress::class);
+        $form = $this->createForm(CpAltAddress::class);
         $form->setData($detailsData['alternateAddress'] ?? []);
 
         if ($this->getRequest()->isPost()) {
@@ -602,10 +586,7 @@ class CPFlowController extends AbstractActionController
             $form->setData($params);
 
             if ($form->isValid()) {
-                /**
-                 * @psalm-suppress InvalidMethodCall
-                 */
-                $this->opgApiService->addSelectedAltAddress($uuid, $params->toArray());
+                $this->opgApiService->addSelectedAltAddress($uuid, $this->formToArray($form));
 
                 return $this->redirect()->toRoute('root/cp_confirm_address', ['uuid' => $uuid]);
             }
@@ -631,15 +612,14 @@ class CPFlowController extends AbstractActionController
     {
         $templates = ['default' => 'application/pages/cp/post_office_documents'];
         $uuid = $this->params()->fromRoute("uuid");
-        $dateSubForm = (new AttributeBuilder())->createForm(PassportDatePo::class);
-        $form = (new AttributeBuilder())->createForm(IdMethod::class);
+        $dateSubForm = $this->createForm(PassportDatePo::class);
+        $form = $this->createForm(IdMethod::class);
         $view = new ViewModel();
 
         if (count($this->getRequest()->getPost())) {
             $formData = $this->getRequest()->getPost()->toArray();
 
             if (array_key_exists('check_button', $formData)) {
-                $dateSubForm->setData($formData);
                 $view->setVariable('date_sub_form', $dateSubForm);
                 $formProcessorResponseDto = $this->formProcessorHelper->processPassportDateForm(
                     $uuid,
@@ -649,7 +629,6 @@ class CPFlowController extends AbstractActionController
                 );
                 $view->setVariables($formProcessorResponseDto->getVariables());
             } else {
-                $form->setData($this->getRequest()->getPost());
                 $view->setVariable('form', $form);
                 if ($form->isValid()) {
                     if ($formData['id_method'] == 'NONUKID') {
@@ -681,13 +660,12 @@ class CPFlowController extends AbstractActionController
         $view = new ViewModel();
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 
-        $form = (new AttributeBuilder())->createForm(Country::class);
+        $form = $this->createForm(Country::class);
 
         if (count($this->getRequest()->getPost())) {
-            $form->setData($this->getRequest()->getPost());
-            $formData = $this->getRequest()->getPost()->toArray();
-
             if ($form->isValid()) {
+                $formData = $this->formToArray($form);
+
                 $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
 
                 return $this->redirect()->toRoute("root/cp_choose_country_id", ['uuid' => $uuid]);
@@ -723,14 +701,13 @@ class CPFlowController extends AbstractActionController
 
         $docs = $this->documentTypeRepository->getByCountry($country);
 
-        $form = (new AttributeBuilder())->createForm(CountryDocument::class);
+        $form = $this->createForm(CountryDocument::class);
         $view->setVariable('form', $form);
 
         if ($this->getRequest()->isPost()) {
-            $form->setData($this->getRequest()->getPost());
-            $formData = $this->getRequest()->getPost()->toArray();
-
             if ($form->isValid()) {
+                $formData = $this->formToArray($form);
+
                 $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
 
                 return $this->redirect()->toRoute("root/cp_name_match_check", ['uuid' => $uuid]);

--- a/service-front/module/Application/src/Controller/DonorFlowController.php
+++ b/service-front/module/Application/src/Controller/DonorFlowController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Controller;
 
 use Application\Contracts\OpgApiServiceInterface;
+use Application\Controller\Trait\FormBuilder;
 use Application\Enums\IdMethod;
 use Application\Forms\IdMethod as IdMethodForm;
 use Application\Forms\DrivingLicenceNumber;
@@ -22,6 +23,8 @@ use Application\Enums\LpaTypes;
 
 class DonorFlowController extends AbstractActionController
 {
+    use FormBuilder;
+
     protected $plugins;
 
     public function __construct(
@@ -38,8 +41,8 @@ class DonorFlowController extends AbstractActionController
         $templates = ['default' => 'application/pages/how_will_the_donor_confirm'];
         $uuid = $this->params()->fromRoute("uuid");
         $view = new ViewModel();
-        $dateSubForm = (new AttributeBuilder())->createForm(PassportDate::class);
-        $form = (new AttributeBuilder())->createForm(IdMethodForm::class);
+        $dateSubForm = $this->createForm(PassportDate::class);
+        $form = $this->createForm(IdMethodForm::class);
 
         $serviceAvailability = $this->opgApiService->getServiceAvailability();
 
@@ -64,7 +67,6 @@ class DonorFlowController extends AbstractActionController
         if ($this->getRequest()->isPost()) {
             $formData = $this->getRequest()->getPost()->toArray();
             if (array_key_exists('check_button', $formData)) {
-                $dateSubForm->setData($this->getRequest()->getPost());
                 $formProcessorResponseDto = $this->formProcessorHelper->processPassportDateForm(
                     $uuid,
                     $this->getRequest()->getPost(),
@@ -73,7 +75,6 @@ class DonorFlowController extends AbstractActionController
                 );
                 $view->setVariables($formProcessorResponseDto->getVariables());
             } else {
-                $form->setData($formData);
                 if ($form->isValid()) {
                     if ($formData['id_method'] == IdMethod::PostOffice->value) {
                         $data = [
@@ -235,7 +236,7 @@ class DonorFlowController extends AbstractActionController
         $view->setVariable('uuid', $uuid);
         $view->setVariable('service_availability', $serviceAvailability->toArray());
 
-        $form = (new AttributeBuilder())->createForm(NationalInsuranceNumber::class);
+        $form = $this->createForm(NationalInsuranceNumber::class);
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 
         $view->setVariable('details_data', $detailsData);
@@ -244,7 +245,6 @@ class DonorFlowController extends AbstractActionController
         if (count($this->getRequest()->getPost())) {
             $formProcessorResponseDto = $this->formProcessorHelper->processNationalInsuranceNumberForm(
                 $uuid,
-                $this->getRequest()->getPost(),
                 $form,
                 $templates
             );
@@ -269,7 +269,7 @@ class DonorFlowController extends AbstractActionController
         $view->setVariable('uuid', $uuid);
         $view->setVariable('service_availability', $serviceAvailability->toArray());
 
-        $form = (new AttributeBuilder())->createForm(DrivingLicenceNumber::class);
+        $form = $this->createForm(DrivingLicenceNumber::class);
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 
         $view->setVariable('details_data', $detailsData);
@@ -278,7 +278,6 @@ class DonorFlowController extends AbstractActionController
         if (count($this->getRequest()->getPost())) {
             $formProcessorResponseDto = $this->formProcessorHelper->processDrivingLicenceForm(
                 $uuid,
-                $this->getRequest()->getPost(),
                 $form,
                 $templates
             );
@@ -304,8 +303,8 @@ class DonorFlowController extends AbstractActionController
         $view->setVariable('uuid', $uuid);
         $view->setVariable('service_availability', $serviceAvailability->toArray());
 
-        $form = (new AttributeBuilder())->createForm(PassportNumber::class);
-        $dateSubForm = (new AttributeBuilder())->createForm(PassportDate::class);
+        $form = $this->createForm(PassportNumber::class);
+        $dateSubForm = $this->createForm(PassportDate::class);
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 
         $view->setVariable('details_data', $detailsData);
@@ -329,7 +328,6 @@ class DonorFlowController extends AbstractActionController
             } else {
                 $formProcessorResponseDto = $this->formProcessorHelper->processPassportForm(
                     $uuid,
-                    $formData,
                     $form,
                     $templates
                 );

--- a/service-front/module/Application/src/Controller/IndexController.php
+++ b/service-front/module/Application/src/Controller/IndexController.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Application\Controller;
 
 use Application\Contracts\OpgApiServiceInterface;
+use Application\Controller\Trait\FormBuilder;
 use Application\Exceptions\HttpException;
 use Application\Forms\AbandonFlow;
 use Application\Helpers\AddressProcessorHelper;
 use Application\Helpers\LpaFormHelper;
 use Application\Services\SiriusApiService;
-use Laminas\Form\Annotation\AttributeBuilder;
 use DateTime;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
@@ -24,6 +24,8 @@ use Laminas\View\Model\ViewModel;
  */
 class IndexController extends AbstractActionController
 {
+    use FormBuilder;
+
     protected $plugins;
 
     public function __construct(
@@ -141,12 +143,10 @@ class IndexController extends AbstractActionController
         $saveProgressData['timestamp'] = date("Y-m-d\TH:i:s\Z", time());
         $this->opgApiService->updateCaseProgress($uuid, $saveProgressData);
 
-        $form = (new AttributeBuilder())->createForm(AbandonFlow::class);
+        $form = $this->createForm(AbandonFlow::class);
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 
         if (count($this->getRequest()->getPost())) {
-            $formData = $this->getRequest()->getPost();
-            $form->setData($formData);
             if ($form->isValid()) {
                 $siriusData = [
                     "reference" => $uuid,

--- a/service-front/module/Application/src/Controller/IndexController.php
+++ b/service-front/module/Application/src/Controller/IndexController.php
@@ -146,18 +146,16 @@ class IndexController extends AbstractActionController
         $form = $this->createForm(AbandonFlow::class);
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 
-        if (count($this->getRequest()->getPost())) {
-            if ($form->isValid()) {
-                $siriusData = [
-                    "reference" => $uuid,
-                    "actorType" => $detailsData['personType'],
-                    "lpaIds" => $detailsData['lpas'],
-                    "time" => (new \DateTime('NOW'))->format('c'),
-                    "outcome" => "exit"
-                ];
+        if ($this->getRequest()->isPost() && $form->isValid()) {
+            $siriusData = [
+                "reference" => $uuid,
+                "actorType" => $detailsData['personType'],
+                "lpaIds" => $detailsData['lpas'],
+                "time" => (new \DateTime('NOW'))->format('c'),
+                "outcome" => "exit"
+            ];
 
-                $this->siriusApiService->abandonCase($siriusData, $this->getRequest());
-            }
+            $this->siriusApiService->abandonCase($siriusData, $this->getRequest());
         }
 
         $view->setVariable('details_data', $detailsData);

--- a/service-front/module/Application/src/Controller/PostOfficeFlowController.php
+++ b/service-front/module/Application/src/Controller/PostOfficeFlowController.php
@@ -138,8 +138,6 @@ class PostOfficeFlowController extends AbstractActionController
                 );
             }
 
-
-
             if (! is_null($processed->getRedirect())) {
                 return $this->redirect()->toRoute($processed->getRedirect(), ['uuid' => $uuid]);
             }
@@ -283,14 +281,12 @@ class PostOfficeFlowController extends AbstractActionController
         $detailsData = $this->opgApiService->getDetailsData($uuid);
         $form = $this->createForm(Country::class);
 
-        if (count($this->getRequest()->getPost())) {
-            if ($form->isValid()) {
-                $formData = $this->formToArray($form);
+        if ($this->getRequest()->isPost() && $form->isValid()) {
+            $formData = $this->formToArray($form);
 
-                $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
+            $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
 
-                return $this->redirect()->toRoute("root/donor_choose_country_id", ['uuid' => $uuid]);
-            }
+            return $this->redirect()->toRoute("root/donor_choose_country_id", ['uuid' => $uuid]);
         }
 
         $countriesData = PostOfficeCountry::cases();
@@ -323,13 +319,11 @@ class PostOfficeFlowController extends AbstractActionController
 
         $form = $this->createForm(CountryDocument::class);
 
-        if ($this->getRequest()->isPost()) {
-            if ($form->isValid()) {
-                $formData = $this->formToArray($form);
-                $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
+        if ($this->getRequest()->isPost() && $form->isValid()) {
+            $formData = $this->formToArray($form);
+            $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
 
-                return $this->redirect()->toRoute("root/donor_details_match_check", ['uuid' => $uuid]);
-            }
+            return $this->redirect()->toRoute("root/donor_details_match_check", ['uuid' => $uuid]);
         }
 
         $view = new ViewModel([

--- a/service-front/module/Application/src/Controller/PostOfficeFlowController.php
+++ b/service-front/module/Application/src/Controller/PostOfficeFlowController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Controller;
 
 use Application\Contracts\OpgApiServiceInterface;
+use Application\Controller\Trait\FormBuilder;
 use Application\Enums\LpaTypes;
 use Application\Forms\Country;
 use Application\Forms\CountryDocument;
@@ -17,13 +18,15 @@ use Application\PostOffice\Country as PostOfficeCountry;
 use Application\PostOffice\DocumentType;
 use Application\PostOffice\DocumentTypeRepository;
 use Application\Services\SiriusApiService;
-use Laminas\Form\Annotation\AttributeBuilder;
+use Laminas\Form\FormInterface;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
 class PostOfficeFlowController extends AbstractActionController
 {
+    use FormBuilder;
+
     protected $plugins;
 
     public function __construct(
@@ -40,18 +43,12 @@ class PostOfficeFlowController extends AbstractActionController
     {
         $templates = ['default' => 'application/pages/post_office/post_office_documents'];
         $uuid = $this->params()->fromRoute("uuid");
-        $dateSubForm = (new AttributeBuilder())->createForm(PassportDatePo::class);
-        $form = (new AttributeBuilder())->createForm(IdMethod::class);
+        $dateSubForm = $this->createForm(PassportDatePo::class);
+        $form = $this->createForm(IdMethod::class);
         $view = new ViewModel();
 
         if (count($this->getRequest()->getPost())) {
-            $formObject = $this->getRequest()->getPost()->toArray();
-            $formData = $this->getRequest()->getPost()->toArray();
-
-            $form->setData($formObject);
-
             if (array_key_exists('check_button', $this->getRequest()->getPost()->toArray())) {
-                $dateSubForm->setData($formData);
                 $view->setVariable('date_sub_form', $dateSubForm);
                 $formProcessorResponseDto = $this->formProcessorHelper->processPassportDateForm(
                     $uuid,
@@ -62,6 +59,9 @@ class PostOfficeFlowController extends AbstractActionController
                 $view->setVariables($formProcessorResponseDto->getVariables());
             } else {
                 if ($form->isValid()) {
+                    $formData = $this->formToArray($form);
+                    $this->opgApiService->updateIdMethod($uuid, $formData['id_method']);
+
                     if ($formData['id_method'] == 'NONUKID') {
                         $this->opgApiService->updateIdMethodWithCountry($uuid, ['id_method' => $formData['id_method']]);
                         return $this->redirect()->toRoute("root/donor_choose_country", ['uuid' => $uuid]);
@@ -108,8 +108,8 @@ class PostOfficeFlowController extends AbstractActionController
         $uuid = $this->params()->fromRoute("uuid");
 
         $detailsData = $this->opgApiService->getDetailsData($uuid);
-        $form = (new AttributeBuilder())->createForm(PostOfficeAddress::class);
-        $locationForm = (new AttributeBuilder())->createForm(PostOfficeSearchLocation::class);
+        $form = $this->createForm(PostOfficeAddress::class);
+        $locationForm = $this->createForm(PostOfficeSearchLocation::class);
 
         if (! isset($detailsData['searchPostcode'])) {
             $searchString = $detailsData['address']['postcode'];
@@ -278,13 +278,12 @@ class PostOfficeFlowController extends AbstractActionController
         $uuid = $this->params()->fromRoute("uuid");
         $view = new ViewModel();
         $detailsData = $this->opgApiService->getDetailsData($uuid);
-        $form = (new AttributeBuilder())->createForm(Country::class);
+        $form = $this->createForm(Country::class);
 
         if (count($this->getRequest()->getPost())) {
-            $form->setData($this->getRequest()->getPost());
-            $formData = $this->getRequest()->getPost()->toArray();
-
             if ($form->isValid()) {
+                $formData = $this->formToArray($form);
+
                 $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
 
                 return $this->redirect()->toRoute("root/donor_choose_country_id", ['uuid' => $uuid]);
@@ -319,13 +318,11 @@ class PostOfficeFlowController extends AbstractActionController
 
         $docs = $this->documentTypeRepository->getByCountry($country);
 
-        $form = (new AttributeBuilder())->createForm(CountryDocument::class);
+        $form = $this->createForm(CountryDocument::class);
 
         if ($this->getRequest()->isPost()) {
-            $form->setData($this->getRequest()->getPost());
-            $formData = $this->getRequest()->getPost()->toArray();
-
             if ($form->isValid()) {
+                $formData = $form->getData(FormInterface::VALUES_AS_ARRAY);
                 $this->opgApiService->updateIdMethodWithCountry($uuid, $formData);
 
                 return $this->redirect()->toRoute("root/donor_details_match_check", ['uuid' => $uuid]);

--- a/service-front/module/Application/src/Controller/Trait/FormBuilder.php
+++ b/service-front/module/Application/src/Controller/Trait/FormBuilder.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Controller\Trait;
+
+use Application\Forms\FormTemplate;
+use Laminas\Form\Annotation\AttributeBuilder;
+use Laminas\Form\FormInterface;
+
+trait FormBuilder
+{
+    /**
+     * @template U
+     * @template T of FormTemplate<U>
+     * @param class-string<T> $form
+     * @return FormInterface<U>
+     */
+    protected function createForm($form)
+    {
+        $form = (new AttributeBuilder())->createForm($form);
+        $form->setData($this->getRequest()->getPost());
+
+        return $form;
+    }
+
+    /**
+     * @template T
+     * @param FormInterface<T> $form
+     * @return T
+     */
+    protected function formToArray($form)
+    {
+        return $form->getData(FormInterface::VALUES_AS_ARRAY);
+    }
+}

--- a/service-front/module/Application/src/Forms/AbandonFlow.php
+++ b/service-front/module/Application/src/Forms/AbandonFlow.php
@@ -4,23 +4,20 @@ declare(strict_types=1);
 
 namespace Application\Forms;
 
-use Application\Validators\CountryDocumentValidator;
-use Application\Validators\CountryValidator;
 use Laminas\Form\Annotation;
 use Laminas\Hydrator\ObjectPropertyHydrator;
 use Laminas\Validator\NotEmpty;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{
+ *   reason: string,
+ *   notes: string,
+ * }>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class AbandonFlow
+class AbandonFlow implements FormTemplate
 {
-    /**
-     * @psalm-suppress PossiblyUnusedProperty
-     */
-    public string $route;
-
     /**
      * @psalm-suppress PossiblyUnusedProperty
      */

--- a/service-front/module/Application/src/Forms/AddressJson.php
+++ b/service-front/module/Application/src/Forms/AddressJson.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Application\Forms;
 
-use Application\Validators\PostcodeValidator;
 use Laminas\Form\Annotation;
 use Laminas\Hydrator\ObjectPropertyHydrator;
 use Laminas\Validator\NotEmpty;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{address_json: string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class AddressJson
+class AddressJson implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/ConfirmAddress.php
+++ b/service-front/module/Application/src/Forms/ConfirmAddress.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Application\Forms;
 
-use Application\Validators\PostcodeValidator;
 use Laminas\Form\Annotation;
 use Laminas\Hydrator\ObjectPropertyHydrator;
 use Laminas\Validator\NotEmpty;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{chosenAddress: string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class ConfirmAddress
+class ConfirmAddress implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/Country.php
+++ b/service-front/module/Application/src/Forms/Country.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Application\Forms;
 
-use Application\Validators\CountryDocumentValidator;
 use Application\Validators\CountryValidator;
 use Laminas\Form\Annotation;
 use Laminas\Hydrator\ObjectPropertyHydrator;
@@ -12,9 +11,10 @@ use Laminas\Validator\NotEmpty;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{id_country: string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class Country
+class Country implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/CountryDocument.php
+++ b/service-front/module/Application/src/Forms/CountryDocument.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Application\Forms;
 
 use Application\Validators\CountryDocumentValidator;
-use Application\Validators\CountryValidator;
 use Laminas\Form\Annotation;
 use Laminas\Hydrator\ObjectPropertyHydrator;
 use Laminas\Validator\NotEmpty;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{id_method: string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class CountryDocument
+class CountryDocument implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/CpAltAddress.php
+++ b/service-front/module/Application/src/Forms/CpAltAddress.php
@@ -6,14 +6,23 @@ namespace Application\Forms;
 
 use Application\Validators\PostcodeValidator;
 use Application\Validators\AddressFieldValidator;
+use Application\Validators\CountryValidator;
 use Laminas\Form\Annotation;
 use Laminas\Hydrator\ObjectPropertyHydrator;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{
+ *   line1: string,
+ *   line2: string,
+ *   line3: string,
+ *   town: string,
+ *   postcode: string,
+ *   country: string,
+ * }>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class CpAltAddress
+class CpAltAddress implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty
@@ -40,6 +49,7 @@ class CpAltAddress
      */
     #[Annotation\Validator(PostcodeValidator::class)]
     public mixed $postcode;
+
     /**
      * @psalm-suppress PossiblyUnusedProperty
      */

--- a/service-front/module/Application/src/Forms/DrivingLicenceNumber.php
+++ b/service-front/module/Application/src/Forms/DrivingLicenceNumber.php
@@ -12,9 +12,10 @@ use Laminas\Validator\NotEmpty;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{dln: string, inDate: ?string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class DrivingLicenceNumber
+class DrivingLicenceNumber implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/FormTemplate.php
+++ b/service-front/module/Application/src/Forms/FormTemplate.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Forms;
+
+/**
+ * @template T
+ */
+interface FormTemplate
+{
+}

--- a/service-front/module/Application/src/Forms/IdMethod.php
+++ b/service-front/module/Application/src/Forms/IdMethod.php
@@ -10,9 +10,10 @@ use Laminas\Validator\NotEmpty;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{id_method: string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class IdMethod
+class IdMethod implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/LpaReferenceNumber.php
+++ b/service-front/module/Application/src/Forms/LpaReferenceNumber.php
@@ -10,9 +10,10 @@ use Laminas\Hydrator\ObjectPropertyHydrator;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{lpa: string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class LpaReferenceNumber
+class LpaReferenceNumber implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/NationalInsuranceNumber.php
+++ b/service-front/module/Application/src/Forms/NationalInsuranceNumber.php
@@ -10,9 +10,10 @@ use Laminas\Hydrator\ObjectPropertyHydrator;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{nino: string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class NationalInsuranceNumber
+class NationalInsuranceNumber implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/PassportDate.php
+++ b/service-front/module/Application/src/Forms/PassportDate.php
@@ -10,9 +10,15 @@ use Laminas\Hydrator\ObjectPropertyHydrator;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{
+ *   passport_issued_year: string,
+ *   passport_issued_month: string,
+ *   passport_issued_day: string,
+ *   passport_date?: string
+ * }>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class PassportDate
+class PassportDate implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/PassportDateCp.php
+++ b/service-front/module/Application/src/Forms/PassportDateCp.php
@@ -10,9 +10,15 @@ use Laminas\Hydrator\ObjectPropertyHydrator;
 
 /**
  * @psalm-suppress MissingConstructor
+* @implements FormTemplate<array{
+ *   passport_issued_year: string,
+ *   passport_issued_month: string,
+ *   passport_issued_day: string,
+ *   passport_date?: string
+ * }>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class PassportDateCp
+class PassportDateCp implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/PassportDatePo.php
+++ b/service-front/module/Application/src/Forms/PassportDatePo.php
@@ -10,9 +10,15 @@ use Laminas\Hydrator\ObjectPropertyHydrator;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{
+ *   passport_issued_year: string,
+ *   passport_issued_month: string,
+ *   passport_issued_day: string,
+ *   passport_date?: string
+ * }>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class PassportDatePo
+class PassportDatePo implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/PassportNumber.php
+++ b/service-front/module/Application/src/Forms/PassportNumber.php
@@ -11,9 +11,10 @@ use Laminas\Hydrator\ObjectPropertyHydrator;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{passport: string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class PassportNumber
+class PassportNumber implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/PostOfficeAddress.php
+++ b/service-front/module/Application/src/Forms/PostOfficeAddress.php
@@ -10,9 +10,10 @@ use Laminas\Validator\NotEmpty;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{postoffice: string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class PostOfficeAddress
+class PostOfficeAddress implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/PostOfficeSearchLocation.php
+++ b/service-front/module/Application/src/Forms/PostOfficeSearchLocation.php
@@ -10,9 +10,10 @@ use Laminas\Validator\NotEmpty;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{location: string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class PostOfficeSearchLocation
+class PostOfficeSearchLocation implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Forms/Postcode.php
+++ b/service-front/module/Application/src/Forms/Postcode.php
@@ -10,9 +10,10 @@ use Laminas\Hydrator\ObjectPropertyHydrator;
 
 /**
  * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{postcode: string}>
  */
 #[Annotation\Hydrator(ObjectPropertyHydrator::class)]
-class Postcode
+class Postcode implements FormTemplate
 {
     /**
      * @psalm-suppress PossiblyUnusedProperty

--- a/service-front/module/Application/src/Helpers/LpaFormHelper.php
+++ b/service-front/module/Application/src/Helpers/LpaFormHelper.php
@@ -5,27 +5,27 @@ declare(strict_types=1);
 namespace Application\Helpers;
 
 use Application\Helpers\DTO\LpaFormHelperResponseDto;
-use Application\Services\SiriusApiService;
 use Laminas\Form\FormInterface;
-use Laminas\Stdlib\Parameters;
-use Laminas\Http\Response;
 
 class LpaFormHelper
 {
+    /**
+     * @param FormInterface<array{lpa: string}> $form
+     */
     public function findLpa(
         string $uuid,
-        Parameters $formData,
         FormInterface $form,
         array $siriusCheck,
         array $detailsData,
     ): LpaFormHelperResponseDto {
-        $form->setData($formData);
         $result = [
             'status' => "",
             'message' => ""
         ];
 
         if ($form->isValid()) {
+            $formData = $form->getData(FormInterface::VALUES_AS_ARRAY);
+
             if (
                 ! array_key_exists('opg.poas.lpastore', $siriusCheck) ||
                 empty($siriusCheck['opg.poas.lpastore'])
@@ -52,7 +52,7 @@ class LpaFormHelper
                     'address_match' => $idCheck['address_match'],
                     'error' => $idCheck['error']
                 ];
-            } elseif (! $this->checkLpaNotAdded($form->get('lpa')->getValue(), $detailsData)) {
+            } elseif (! $this->checkLpaNotAdded($formData['lpa'], $detailsData)) {
                 $result['status'] = 'error';
                 $result['message'] = "This LPA has already been added to this identity check.";
             } elseif ($statusCheck['error'] === true) {
@@ -67,7 +67,7 @@ class LpaFormHelper
             }
             $result['data'] = [
                 "case_uuid" => $uuid,
-                "lpa_number" => $form->get('lpa')->getValue(),
+                "lpa_number" => $formData['lpa'],
                 "type_of_lpa" => $this->getLpaTypeFromSiriusResponse($siriusCheck),
                 "donor" => $this->getDonorNameFromSiriusResponse($siriusCheck),
                 "lpa_status" => $statusCheck['status'],

--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -8,6 +8,7 @@ use Application\Helpers\AddressProcessorHelper;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Laminas\Http\Header\Cookie;
+use Laminas\Http\Header\Exception\RuntimeException;
 use Laminas\Http\Request;
 use Laminas\Stdlib\RequestInterface;
 
@@ -136,6 +137,16 @@ class SiriusApiService
         return json_decode(strval($response->getBody()), true);
     }
 
+    /**
+     * @param array{
+     *   reference: string,
+     *   actorType: string,
+     *   lpaIds: string[],
+     *   time: string,
+     *   outcome: string,
+     * } $data
+     * @return array{status: int, error: mixed}
+     */
     public function abandonCase(array $data, Request $request): array
     {
         $response = $this->client->post('/api/v1/identity-check', [

--- a/service-front/module/Application/test/Helpers/FormProcessorHelperTest.php
+++ b/service-front/module/Application/test/Helpers/FormProcessorHelperTest.php
@@ -31,6 +31,8 @@ class FormProcessorHelperTest extends TestCase
         $opgApiServiceMock = $this->createMock(OpgApiService::class);
         $formProcessorHelper = new FormProcessorHelper($opgApiServiceMock);
 
+        $form->setData($formData);
+
         if ($formData['inDate'] == 'yes') {
             $opgApiServiceMock
                 ->expects(self::once())
@@ -38,7 +40,7 @@ class FormProcessorHelperTest extends TestCase
                 ->with($formData->toArray()['dln'])
                 ->willReturn($responseData['status']);
         }
-        $processed = $formProcessorHelper->processDrivingLicenceForm($caseUuid, $formData, $form, $templates);
+        $processed = $formProcessorHelper->processDrivingLicenceForm($caseUuid, $form, $templates);
         $this->assertEquals($caseUuid, $processed->getUuid());
         $this->assertEquals($templates[$template], $processed->getTemplate());
     }
@@ -114,6 +116,8 @@ class FormProcessorHelperTest extends TestCase
         $opgApiServiceMock = $this->createMock(OpgApiService::class);
         $formProcessorHelper = new FormProcessorHelper($opgApiServiceMock);
 
+        $form->setData($formData);
+
         if ($template !== 'default') {
             $opgApiServiceMock
                 ->expects(self::once())
@@ -122,7 +126,7 @@ class FormProcessorHelperTest extends TestCase
                 ->willReturn($responseData['status']);
         }
 
-        $processed = $formProcessorHelper->processNationalInsuranceNumberForm($caseUuid, $formData, $form, $templates);
+        $processed = $formProcessorHelper->processNationalInsuranceNumberForm($caseUuid, $form, $templates);
         $this->assertEquals($caseUuid, $processed->getUuid());
         $this->assertEquals($templates[$template], $processed->getTemplate());
     }
@@ -198,6 +202,8 @@ class FormProcessorHelperTest extends TestCase
         $opgApiServiceMock = $this->createMock(OpgApiService::class);
         $formProcessorHelper = new FormProcessorHelper($opgApiServiceMock);
 
+        $form->setData($formData);
+
         if ($template !== 'default') {
             $opgApiServiceMock
                 ->expects(self::once())
@@ -206,7 +212,7 @@ class FormProcessorHelperTest extends TestCase
                 ->willReturn($responseData['status']);
         }
 
-        $processed = $formProcessorHelper->processPassportForm($caseUuid, $formData, $form, $templates);
+        $processed = $formProcessorHelper->processPassportForm($caseUuid, $form, $templates);
         $this->assertEquals($caseUuid, $processed->getUuid());
         $this->assertEquals($templates[$template], $processed->getTemplate());
     }

--- a/service-front/module/Application/test/Helpers/LpaFormHelperTest.php
+++ b/service-front/module/Application/test/Helpers/LpaFormHelperTest.php
@@ -25,10 +25,10 @@ class LpaFormHelperTest extends TestCase
         array $opgCaseResponse,
     ): void {
         $lpaFormHelper = new LpaFormHelper();
+        $form->setData($formData);
 
         $processed = $lpaFormHelper->findLpa(
             $caseUuid,
-            $formData,
             $form,
             $siriusLpaResponse,
             $opgCaseResponse,


### PR DESCRIPTION
Forms define the shape of the data model they represent in a top-level annotation.

This allows downstream code to call `$form->getData()` and know exactly what data it's getting.

As well as improving type-handling through the application, this prevents passing POST data directly to the API.

#patch
