### PR TITLE
Do marhsalling inside DataWriteHandler

### DIFF
--- a/service-api/module/Application/src/Controller/IdentityController.php
+++ b/service-api/module/Application/src/Controller/IdentityController.php
@@ -160,7 +160,6 @@ class IdentityController extends AbstractActionController
             $this->dataHandler->updateCaseData(
                 $uuid,
                 'idMethod',
-                'S',
                 $data['idMethod']
             );
         } catch (\Exception $exception) {
@@ -194,10 +193,7 @@ class IdentityController extends AbstractActionController
             $this->dataHandler->updateCaseData(
                 $uuid,
                 'counterService',
-                'M',
-                array_map(fn (mixed $v) => [
-                    'S' => $v,
-                ], $counterServiceMap),
+                $counterServiceMap,
             );
         } catch (\Exception $exception) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_500);
@@ -235,10 +231,7 @@ class IdentityController extends AbstractActionController
             $this->dataHandler->updateCaseData(
                 $uuid,
                 'counterService',
-                'M',
-                array_map(fn (mixed $v) => [
-                    'S' => $v,
-                ], $counterServiceMap),
+                $counterServiceMap,
             );
         } catch (\Exception $exception) {
             $this->getResponse()->setStatusCode(Response::STATUS_CODE_500);
@@ -270,7 +263,6 @@ class IdentityController extends AbstractActionController
                 $this->dataHandler->updateCaseData(
                     $uuid,
                     'lpas',
-                    'SS',
                     $lpas
                 );
                 $response['result'] = "Updated";
@@ -310,7 +302,6 @@ class IdentityController extends AbstractActionController
                 $this->dataHandler->updateCaseData(
                     $uuid,
                     'lpas',
-                    'SS',
                     $keptLpas
                 );
                 $response['result'] = "Removed";
@@ -348,10 +339,7 @@ class IdentityController extends AbstractActionController
             $this->dataHandler->updateCaseData(
                 $uuid,
                 'alternateAddress',
-                'M',
-                array_map(fn (mixed $v) => [
-                    'S' => $v,
-                ], $data),
+                $data,
             );
         } catch (\Exception $exception) {
             $response['result'] = "Not Updated";
@@ -387,7 +375,6 @@ class IdentityController extends AbstractActionController
             $this->dataHandler->updateCaseData(
                 $uuid,
                 'documentComplete',
-                'BOOL',
                 true
             );
         } catch (\Exception $exception) {
@@ -435,7 +422,6 @@ class IdentityController extends AbstractActionController
             $this->dataHandler->updateCaseData(
                 $uuid,
                 'dob',
-                'S',
                 $dob
             );
         } catch (\Exception $exception) {
@@ -468,10 +454,7 @@ class IdentityController extends AbstractActionController
             $this->dataHandler->updateCaseData(
                 $uuid,
                 'idMethodIncludingNation',
-                'M',
-                array_map(fn (mixed $v) => [
-                    'S' => $v,
-                ], $data),
+                $data,
             );
         } catch (\Exception $exception) {
             $this->logger->error($exception->getMessage());
@@ -507,10 +490,7 @@ class IdentityController extends AbstractActionController
             $this->dataHandler->updateCaseData(
                 $uuid,
                 'caseProgress',
-                'M',
-                array_map(fn (mixed $v) => [
-                    'S' => $v,
-                ], $data),
+                $data,
             );
         } catch (\Exception $exception) {
             $this->logger->error($exception->getMessage());

--- a/service-api/module/Application/src/Controller/YotiController.php
+++ b/service-api/module/Application/src/Controller/YotiController.php
@@ -193,10 +193,9 @@ class YotiController extends AbstractActionController
             //authorize
             if ($caseData->counterService->notificationsAuthToken === $token) {
                 //now update counterService data
-                $this->dataHandler->updateCaseChildAttribute(
+                $this->dataHandler->updateCaseData(
                     $caseData->id,
                     'counterService.notificationState',
-                    'S',
                     $data['topic'],
                 );
                 $caseData->counterService->notificationState = $data['topic'];

--- a/service-api/module/Application/src/Experian/IIQ/KBVService.php
+++ b/service-api/module/Application/src/Experian/IIQ/KBVService.php
@@ -70,14 +70,12 @@ class KBVService implements KBVServiceInterface
         $this->writeHandler->updateCaseData(
             $caseData->id,
             'kbvQuestions',
-            'S',
             json_encode($formattedQuestions)
         );
 
         $this->writeHandler->updateCaseData(
             $caseData->id,
             'iiqControl',
-            'S',
             json_encode($questions['control'])
         );
 
@@ -129,7 +127,6 @@ class KBVService implements KBVServiceInterface
         $this->writeHandler->updateCaseData(
             $caseData->id,
             'kbvQuestions',
-            'S',
             json_encode($questions)
         );
 

--- a/service-api/module/Application/src/Fixtures/DataWriteHandler.php
+++ b/service-api/module/Application/src/Fixtures/DataWriteHandler.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Application\Fixtures;
 
 use Application\Model\Entity\CaseData;
-use Application\Model\Entity\CounterService;
 use Aws\DynamoDb\DynamoDbClient;
-use Aws\DynamoDb\Exception\DynamoDbException;
 use Aws\DynamoDb\Marshaler;
 use Aws\Exception\AwsException;
 use InvalidArgumentException;
 use Laminas\Form\Annotation\AttributeBuilder;
+use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputInterface;
 use Psr\Log\LoggerInterface;
 
@@ -30,28 +29,40 @@ class DataWriteHandler
         $encoded = $marsheler->marshalItem($item->jsonSerialize());
         $params = [
             'TableName' => $this->tableName,
-            'Item' => $encoded
+            'Item' => $encoded,
         ];
 
         try {
             $this->dynamoDbClient->putItem($params);
         } catch (AwsException $e) {
             $this->logger->error('Unable to save data [' . $e->getMessage() . '] to ' . $this->tableName, [
-                'data' => $item
+                'data' => $item,
             ]);
         }
     }
 
-    public function updateCaseData(string $uuid, string $attrName, string $attrType, mixed $attrValue): void
+    public function updateCaseData(string $uuid, string $attrName, mixed $attrValue): void
     {
-        if (! property_exists(CaseData::class, $attrName)) {
-            throw new InvalidArgumentException(sprintf('CaseData has no such property "%s"', $attrName));
+        $attributeChain = explode(".", $attrName);
+
+        if (! property_exists(CaseData::class, $attributeChain[0])) {
+            throw new InvalidArgumentException(sprintf('CaseData has no such property "%s"', $attributeChain[0]));
         }
 
         $inputFilter = (new AttributeBuilder())
             ->createForm(CaseData::class)
             ->getInputFilter();
-        $input = $inputFilter->get($attrName);
+
+        $input = $inputFilter->get($attributeChain[0]);
+        foreach (array_slice($attributeChain, 1) as $subAttr) {
+            if ($input instanceof InputFilterInterface) {
+                $input = $input->get($subAttr);
+            } else {
+                throw new InvalidArgumentException(
+                    sprintf('%s has no such property "%s"', $input->getName(), $subAttr)
+                );
+            }
+        }
 
         if ($input instanceof InputInterface) {
             $input->setValue($attrValue);
@@ -73,86 +84,26 @@ class DataWriteHandler
             ],
         ];
 
+        $marshaled = (new Marshaler())->marshalValue($attrValue);
+
+        $expressionAttributeNames = [];
+        foreach ($attributeChain as $i => $attr) {
+            $expressionAttributeNames['#AT' . $i] = $attr;
+        }
+
         try {
             $this->dynamoDbClient->updateItem([
                 'Key' => $idKey['key'],
                 'TableName' => $this->tableName,
-                'UpdateExpression' => "set #NV=:NV",
-                'ExpressionAttributeNames' => [
-                    '#NV' => $attrName,
-                ],
+                'UpdateExpression' => "set " . implode('.', array_keys($expressionAttributeNames)) . "=:NV",
+                'ExpressionAttributeNames' => $expressionAttributeNames,
                 'ExpressionAttributeValues' => [
-                    ':NV' => [
-                        $attrType => $attrValue
-                    ]
+                    ':NV' => $marshaled,
                 ],
             ]);
         } catch (AwsException $e) {
             $this->logger->error('Unable to update data [' . $e->getMessage() . '] for case' . $uuid, [
-                'data' => [$attrName => $attrValue]
-            ]);
-        }
-    }
-    /**
-     * Specifically for use cases to update map attributes passing in counterService.deadline etc
-     * @psalm-suppress ArgumentTypeCoercion
-     */
-    public function updateCaseChildAttribute(string $uuid, string $attrName, string $attrType, mixed $attrValue): void
-    {
-        $attributes = explode(".", $attrName);
-
-        $caseSubClass = '\\' . ucfirst($attributes[0]);
-
-        $fqnClass = "Application\Model\Entity" . $caseSubClass;
-
-        if (! property_exists($fqnClass, $attributes[1])) {
-            throw new InvalidArgumentException(
-                sprintf($caseSubClass . ' has no such property "%s"', $attributes[1])
-            );
-        }
-        $inputFilter = (new AttributeBuilder())
-            ->createForm($fqnClass)
-            ->getInputFilter();
-        $input = $inputFilter->get($attributes[1]);
-
-        if ($input instanceof InputInterface) {
-            $input->setValue($attrValue);
-
-            if (! $input->isValid()) {
-                throw new InvalidArgumentException(sprintf(
-                    '"%s" is not a valid value for %s',
-                    is_string($attrValue) ? $attrValue : json_encode($attrValue),
-                    $attributes[1]
-                ));
-            }
-        }
-
-        $idKey = [
-            'key' => [
-                'id' => [
-                    'S' => $uuid,
-                ],
-            ],
-        ];
-
-        try {
-            $this->dynamoDbClient->updateItem([
-                'Key' => $idKey['key'],
-                'TableName' => $this->tableName,
-                'UpdateExpression' => "set #CV.#NV=:NV",
-                'ExpressionAttributeNames' => [
-                    '#CV' => $attributes[0],
-                    '#NV' => $attributes[1],
-                ],
-                'ExpressionAttributeValues' => [
-                    ':NV' => [
-                        $attrType => $attrValue
-                    ]
-                ],
-            ]);
-        } catch (AwsException $e) {
-            $this->logger->error('Unable to update attributes [' . $e->getMessage() . '] for case' . $uuid, [
-                'data' => [$attrName => $attrValue]
+                'data' => [$attrName => $attrValue],
             ]);
         }
     }

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -91,7 +91,9 @@ class CaseData implements JsonSerializable
     #[Annotation\Validator(Uuid::class)]
     //Due to dynamodb quarks, due to index this always need to have a value
     public string $yotiSessionId = '00000000-0000-0000-0000-000000000000';
+
     #[Annotation\Required(false)]
+    #[Annotation\ComposedObject(CounterService::class)]
     public ?CounterService $counterService = null;
 
     /**

--- a/service-api/module/Application/test/ApplicationTest/Experian/IIQ/KBVServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Experian/IIQ/KBVServiceTest.php
@@ -106,10 +106,10 @@ class KBVServiceTest extends TestCase
             ->willReturnCallback(
                 /** @psalm-suppress MissingClosureParamType */
                 fn (...$params) => match (true) {
-                    $params[0] === $uuid && $params[1] === 'kbvQuestions' && $params[2] === 'S'
-                        && $params[3] === $storedQuestions => null,
-                    $params[0] === $uuid && $params[1] === 'iiqControl' && $params[2] === 'S'
-                        && $params[3] === '{"URN":"test UUID","AuthRefNo":"abc"}' => null,
+                    $params[0] === $uuid && $params[1] === 'kbvQuestions'
+                        && $params[2] === $storedQuestions => null,
+                    $params[0] === $uuid && $params[1] === 'iiqControl'
+                        && $params[2] === '{"URN":"test UUID","AuthRefNo":"abc"}' => null,
                     default => self::fail('Did not expect:' . print_r($params, true))
                 }
             );
@@ -233,7 +233,6 @@ class KBVServiceTest extends TestCase
             ->with(
                 $uuid,
                 'kbvQuestions',
-                'S',
                 json_encode($savedQuestions),
             );
 

--- a/service-api/module/Application/test/ApplicationTest/Fixtures/DataWriteHandlerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Fixtures/DataWriteHandlerTest.php
@@ -143,7 +143,7 @@ class DataWriteHandlerTest extends TestCase
                     $input = $params[0];
                     $this->assertEquals(['id' => ['S' => 'a9bc8ab8-389c-4367-8a9b-762ab3050491']], $input['Key']);
                     $this->assertArrayHasKey('UpdateExpression', $input);
-                    $this->assertEquals(['#NV' => 'kbvQuestions'], $input['ExpressionAttributeNames']);
+                    $this->assertEquals(['#AT0' => 'kbvQuestions'], $input['ExpressionAttributeNames']);
 
                     return true;
                 })
@@ -156,7 +156,6 @@ class DataWriteHandlerTest extends TestCase
         $this->sut->updateCaseData(
             'a9bc8ab8-389c-4367-8a9b-762ab3050491',
             'kbvQuestions',
-            'S',
             json_encode([
                 'one' => [
                     'question' => 'Who is your electricity provider?',
@@ -175,7 +174,7 @@ class DataWriteHandlerTest extends TestCase
      * @psalm-suppress UndefinedMagicMethod
      * @psalm-suppress PossiblyUndefinedMethod
      */
-    public function testUpdateCaseChildAttribute(): void
+    public function testUpdateCaseDataChildAttribute(): void
     {
         $this->dynamoDbClientMock->expects($this->once())
             ->method('__call')
@@ -187,7 +186,7 @@ class DataWriteHandlerTest extends TestCase
                     $this->assertEquals(['id' => ['S' => 'a9bc8ab8-389c-4367-8a9b-762ab3050491']], $input['Key']);
                     $this->assertArrayHasKey('UpdateExpression', $input);
                     $this->assertEquals(
-                        ['#CV' => 'counterService','#NV' => 'notificationState'],
+                        ['#AT0' => 'counterService','#AT1' => 'notificationState'],
                         $input['ExpressionAttributeNames']
                     );
                     return true;
@@ -198,10 +197,9 @@ class DataWriteHandlerTest extends TestCase
         $this->loggerMock->expects($this->never())->method('error');
 
         // Call the updateCaseData method with test data
-        $this->sut->updateCaseChildAttribute(
+        $this->sut->updateCaseData(
             'a9bc8ab8-389c-4367-8a9b-762ab3050491',
             'counterService.notificationState',
-            'S',
             'complete'
         );
     }
@@ -222,7 +220,7 @@ class DataWriteHandlerTest extends TestCase
                     $input = $params[0];
                     $this->assertEquals(['id' => ['S' => 'a9bc8ab8-389c-4367-8a9b-762ab3050491']], $input['Key']);
                     $this->assertArrayHasKey('UpdateExpression', $input);
-                    $this->assertEquals(['#NV' => 'idMethod'], $input['ExpressionAttributeNames']);
+                    $this->assertEquals(['#AT0' => 'idMethod'], $input['ExpressionAttributeNames']);
 
                     return true;
                 })
@@ -235,8 +233,7 @@ class DataWriteHandlerTest extends TestCase
         $this->sut->updateCaseData(
             'a9bc8ab8-389c-4367-8a9b-762ab3050491',
             'idMethod',
-            'S',
-            IdMethod::PassportNumber
+            IdMethod::PassportNumber->value
         );
     }
 
@@ -260,7 +257,6 @@ class DataWriteHandlerTest extends TestCase
         $this->sut->updateCaseData(
             'a9bc8ab8-389c-4367-8a9b-762ab3050491',
             'idMethod',
-            'S',
             'an invalid value'
         );
     }

--- a/service-api/module/Application/test/Controller/IdentityControllerTest.php
+++ b/service-api/module/Application/test/Controller/IdentityControllerTest.php
@@ -448,10 +448,7 @@ class IdentityControllerTest extends TestCase
             ->with(
                 $uuid,
                 "caseProgress",
-                "M",
-                array_map(fn (mixed $v) => [
-                    'S' => $v,
-                ], $data),
+                $data,
             );
 
         $path = sprintf('/cases/%s/save-case-progress', $uuid);

--- a/service-api/module/Application/test/Controller/YotiControllerTest.php
+++ b/service-api/module/Application/test/Controller/YotiControllerTest.php
@@ -235,7 +235,7 @@ class YotiControllerTest extends TestCase
             ]));
 
         $this->dataHandler
-            ->expects($this->never())->method('updateCaseChildAttribute');
+            ->expects($this->never())->method('updateCaseData');
 
         $this->dispatchJSON(
             '/counter-service/notification',
@@ -276,7 +276,12 @@ class YotiControllerTest extends TestCase
             ]));
 
         $this->dataHandler
-            ->expects($this->once())->method('updateCaseChildAttribute');
+            ->expects($this->once())->method('updateCaseData')
+            ->with(
+                '2b45a8c1-dd35-47ef-a00e-c7b6264bf1cc',
+                'counterService.notificationState',
+                'first_branch_visit',
+            );
 
         $this->dispatchJSON(
             '/counter-service/notification',
@@ -306,7 +311,7 @@ class YotiControllerTest extends TestCase
             ->willReturn(null);
 
         $this->dataHandler
-            ->expects($this->never())->method('updateCaseChildAttribute');
+            ->expects($this->never())->method('updateCaseData');
 
         $this->dispatchJSON(
             '/counter-service/notification',


### PR DESCRIPTION
## Purpose

Rather than calls to `updateCaseData` needing to specify their DynamoDB type (and therefore exposing the inner workings of DDB), marshall the data inside the method.

Fixes ID-350 #patch

## Approach

Added a marshall and remove the `attrType` argument. Also merged `updateCaseChildAttribute` into `updateCaseData` so there is a single method for this.

## Learning

- `updateItem` is more cost-effective than `putItem`
- `ComposedObject` lets you chain InputFilters
- Updating nested objects requires separation in the update expression (i.e. `#ARG1.#ARG2`, not `#ARG`=`counterService.notificationState`)

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A