### PR TITLE
Use objects for CaseData model

### DIFF
--- a/service-api/module/Application/src/Controller/IdentityController.php
+++ b/service-api/module/Application/src/Controller/IdentityController.php
@@ -210,7 +210,6 @@ class IdentityController extends AbstractActionController
     public function confirmSelectedPostofficeAction(): JsonModel
     {
         $uuid = $this->params()->fromRoute('uuid');
-        $data = json_decode($this->getRequest()->getContent(), true);
         /** @var CaseData $caseData */
         $caseData = $this->dataQueryHandler->getCaseByUUID($uuid);
         $response = [];
@@ -225,7 +224,6 @@ class IdentityController extends AbstractActionController
         if ($caseData->counterService !== null) {
             $counterServiceMap["selectedPostOffice"] = $caseData->counterService->selectedPostOffice;
         }
-        $counterServiceMap["selectedPostOfficeDeadline"] = $data['deadline'];
 
         try {
             $this->dataHandler->updateCaseData(

--- a/service-api/module/Application/src/Experian/IIQ/ConfigBuilder.php
+++ b/service-api/module/Application/src/Experian/IIQ/ConfigBuilder.php
@@ -64,15 +64,14 @@ class ConfigBuilder
      */
     public function buildRTQRequest(array $answersArray, CaseData $case): array
     {
-        /** @var string $json */
-        $json = $case->iiqControl;
-        /** @var Control */
-        $iiqControl = json_decode($json, true);
+        if ($case->iiqControl === null) {
+            throw new RuntimeException('Cannot respond to questions without IIQ control data');
+        }
 
         $rtqConfig = [
             'Control' => [
-                'URN' => $iiqControl['URN'],
-                'AuthRefNo' => $iiqControl['AuthRefNo'],
+                'URN' => $case->iiqControl->urn,
+                'AuthRefNo' => $case->iiqControl->authRefNo,
             ],
             'Responses' => [
                 'Response' => [],

--- a/service-api/module/Application/src/KBV/KBVServiceInterface.php
+++ b/service-api/module/Application/src/KBV/KBVServiceInterface.php
@@ -4,20 +4,14 @@ declare(strict_types=1);
 
 namespace Application\KBV;
 
-/**
- * @psalm-type Question = array{
- *   externalId: string,
- *   question: string,
- *   prompts: string[],
- *   answered: bool,
- * }
- */
+use Application\Model\Entity\KBVQuestion;
+
 interface KBVServiceInterface
 {
     /**
      * Retrieves an array containing questions without answers and formatted questions with answers.
      *
-     * @return Question[]
+     * @return KBVQuestion[]
      */
     public function fetchFormattedQuestions(string $uuid): array;
 

--- a/service-api/module/Application/src/Model/Entity/CaseProgress.php
+++ b/service-api/module/Application/src/Model/Entity/CaseProgress.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Application\Model\Entity;
 
 use Exception;
-use JsonSerializable;
 use Laminas\Form\Annotation;
 use Laminas\Form\Annotation\Validator;
 use Laminas\Validator\NotEmpty;
@@ -16,7 +15,7 @@ use Laminas\Validator\NotEmpty;
  * Needed here due to false positive from Laminas’s uninitialised properties
  * @psalm-suppress UnusedProperty
  */
-class CaseProgress implements JsonSerializable
+class CaseProgress extends Entity
 {
     #[Annotation\Required(false)]
     #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
@@ -26,7 +25,7 @@ class CaseProgress implements JsonSerializable
     public string $timestamp;
 
     /**
-     * @param array<string, mixed> $data
+     * @param properties-of<self> $data
      */
     public static function fromArray(mixed $data): self
     {
@@ -39,26 +38,15 @@ class CaseProgress implements JsonSerializable
                 throw new Exception(sprintf('%s does not have property "%s"', $instance::class, $key));
             }
         }
+
         return $instance;
     }
 
     /**
-     * @returns array{
-     *     last_page: string,
-     *     timestamp: string,
-     * }
+     * @return properties-of<self>
      */
-    public function toArray(): array
-    {
-        $arr = [
-            'last_page' => $this->last_page,
-            'timestamp' => $this->timestamp,
-        ];
-        return $arr;
-    }
-
     public function jsonSerialize(): array
     {
-        return $this->toArray();
+        return get_object_vars($this);
     }
 }

--- a/service-api/module/Application/src/Model/Entity/CounterService.php
+++ b/service-api/module/Application/src/Model/Entity/CounterService.php
@@ -5,17 +5,14 @@ declare(strict_types=1);
 namespace Application\Model\Entity;
 
 use Application\Validators\IsType;
-use JsonSerializable;
 use Laminas\Form\Annotation;
 use Laminas\Validator\NotEmpty;
 use Laminas\Validator\Uuid;
 
-class CounterService implements JsonSerializable
+class CounterService extends Entity
 {
     #[Annotation\Required(false)]
     public string $selectedPostOffice = '';
-    #[Annotation\Required(false)]
-    public string $selectedPostOfficeDeadline = '';
 
     #[Annotation\Required(false)]
     public string $notificationState = '';
@@ -34,7 +31,7 @@ class CounterService implements JsonSerializable
     public bool $result = false;
 
     /**
-     * @param array<string, mixed> $data
+     * @param properties-of<self> $data
      */
     public static function fromArray(mixed $data): self
     {
@@ -52,29 +49,10 @@ class CounterService implements JsonSerializable
     }
 
     /**
-     * @returns array{
-     *     selectedPostOffice: string,
-     *     selectedPostOfficeDeadline: string,
-     *     notificationsAuthToken: string,
-     *     notificationState: string,
-     *     state: string,
-     *     result: bool
-     * }
+     * @return properties-of<self>
      */
-    public function toArray(): array
-    {
-        return [
-            'selectedPostOffice' => $this->selectedPostOffice,
-            'selectedPostOfficeDeadline' => $this->selectedPostOfficeDeadline,
-            'notificationsAuthToken' => $this->notificationsAuthToken,
-            'notificationState' => $this->notificationState,
-            'state' => $this->state,
-            'result' => $this->result
-        ];
-    }
-
     public function jsonSerialize(): array
     {
-        return $this->toArray();
+        return get_object_vars($this);
     }
 }

--- a/service-api/module/Application/src/Model/Entity/Entity.php
+++ b/service-api/module/Application/src/Model/Entity/Entity.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Model\Entity;
+
+use ArrayIterator;
+use IteratorAggregate;
+use JsonSerializable;
+use Traversable;
+
+/**
+ * @implements IteratorAggregate<string, mixed>
+ */
+abstract class Entity implements IteratorAggregate, JsonSerializable
+{
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->jsonSerialize());
+    }
+}

--- a/service-api/module/Application/src/Model/Entity/IIQControl.php
+++ b/service-api/module/Application/src/Model/Entity/IIQControl.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Model\Entity;
+
+use Laminas\Form\Annotation;
+
+class IIQControl extends Entity
+{
+    #[Annotation\Required(true)]
+    public string $urn = '';
+
+    #[Annotation\Required(true)]
+    public string $authRefNo = '';
+
+    /**
+     * @param properties-of<self> $data
+     */
+    public static function fromArray(mixed $data): self
+    {
+        $instance = new self();
+
+        foreach ($data as $key => $value) {
+            if (! property_exists($instance, $key)) {
+                throw new \Exception(sprintf('%s does not have property "%s"', $instance::class, $key));
+            }
+
+            $instance->{$key} = $value;
+        }
+
+        return $instance;
+    }
+
+    /**
+     * @return properties-of<self>
+     */
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/service-api/module/Application/src/Model/Entity/KBVQuestion.php
+++ b/service-api/module/Application/src/Model/Entity/KBVQuestion.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Model\Entity;
+
+use Laminas\Form\Annotation;
+
+/**
+ * @psalm-suppress PossiblyUnusedProperty
+ */
+class KBVQuestion extends Entity
+{
+    #[Annotation\Required(true)]
+    public string $externalId = '';
+
+    #[Annotation\Required(true)]
+    public string $question = '';
+
+    /**
+     * @var string[]
+     */
+    #[Annotation\Required(true)]
+    public array $prompts = [];
+
+    #[Annotation\Required(true)]
+    public bool $answered = false;
+
+    /**
+     * @param properties-of<self> $data
+     */
+    public static function fromArray(mixed $data): self
+    {
+        $instance = new self();
+
+        foreach ($data as $key => $value) {
+            if (! property_exists($instance, $key)) {
+                throw new \Exception(sprintf('%s does not have property "%s"', $instance::class, $key));
+            }
+
+            $instance->{$key} = $value;
+        }
+
+        return $instance;
+    }
+
+    /**
+     * @return properties-of<self>
+     */
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/service-api/module/Application/test/ApplicationTest/Experian/IIQ/ConfigBuilderTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Experian/IIQ/ConfigBuilderTest.php
@@ -6,6 +6,7 @@ namespace ApplicationTest\Experian\IIQ;
 
 use Application\Experian\IIQ\ConfigBuilder;
 use Application\Model\Entity\CaseData;
+use Application\Model\Entity\IIQControl;
 use PHPUnit\Framework\TestCase;
 
 class ConfigBuilderTest extends TestCase
@@ -65,7 +66,10 @@ class ConfigBuilderTest extends TestCase
         $configBuilder = new ConfigBuilder();
 
         $caseData = CaseData::fromArray([
-            'iiqControl' => '{"URN":"test UUID","AuthRefNo":"abc"}',
+            'iiqControl' => IIQControl::fromArray([
+                'urn' => 'test UUID',
+                'authRefNo' => 'abc',
+            ]),
         ]);
 
         $rtqConfig = $configBuilder->buildRTQRequest([
@@ -73,7 +77,7 @@ class ConfigBuilderTest extends TestCase
                 'experianId' => 'QID21',
                 'answer' => 'BASINGSTOKE',
                 'flag' => 1,
-            ]
+            ],
         ], $caseData);
 
         $this->assertEquals([

--- a/service-api/module/Application/test/ApplicationTest/Fixtures/DataWriteHandlerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Fixtures/DataWriteHandlerTest.php
@@ -156,7 +156,7 @@ class DataWriteHandlerTest extends TestCase
         $this->sut->updateCaseData(
             'a9bc8ab8-389c-4367-8a9b-762ab3050491',
             'kbvQuestions',
-            json_encode([
+            [
                 'one' => [
                     'question' => 'Who is your electricity provider?',
                     'prompts' => [
@@ -167,7 +167,7 @@ class DataWriteHandlerTest extends TestCase
                     ],
                     'answered' => false,
                 ],
-            ])
+            ]
         );
     }
     /**

--- a/service-api/module/Application/test/Controller/KbvControllerTest.php
+++ b/service-api/module/Application/test/Controller/KbvControllerTest.php
@@ -115,13 +115,12 @@ class KbvControllerTest extends TestCase
             'dob' => '',
             'lpas' => [],
             'address' => [],
-        ]);
-
-        $actual->kbvQuestions = json_encode([
-            'one' => ['answer' => 'VoltWave'],
-            'two' => ['answer' => 'Germanotta'],
-            'tree' => ['answer' => 'July'],
-            'four' => ['answer' => 'Pink'],
+            'kbvQuestions' => [
+                [],
+                [],
+                [],
+                [],
+            ],
         ]);
 
         return [

--- a/service-front/module/Application/src/Contracts/OpgApiServiceInterface.php
+++ b/service-front/module/Application/src/Contracts/OpgApiServiceInterface.php
@@ -35,7 +35,6 @@ namespace Application\Contracts;
  *   searchPostcode?: string,
  *   counterService?: array{
  *     selectedPostOffice: string,
- *     selectedPostOfficeDeadline: string,
  *     notificationState: string,
  *     notificationsAuthToken: string,
  *     state: string,

--- a/service-front/module/Application/test/Controller/CPFlowControllerTest.php
+++ b/service-front/module/Application/test/Controller/CPFlowControllerTest.php
@@ -61,7 +61,6 @@ class CPFlowControllerTest extends AbstractHttpControllerTestCase
             "documentComplete" => false,
             "alternateAddress" => [
             ],
-            "selectedPostOfficeDeadline" => null,
             "selectedPostOffice" => null,
             "searchPostcode" => null,
             "idMethod" => "nin",

--- a/service-front/module/Application/test/Controller/DonorFlowControllerTest.php
+++ b/service-front/module/Application/test/Controller/DonorFlowControllerTest.php
@@ -251,7 +251,6 @@ class DonorFlowControllerTest extends AbstractHttpControllerTestCase
             "documentComplete" => false,
             "alternateAddress" => [
             ],
-            "selectedPostOfficeDeadline" => null,
             "selectedPostOffice" => null,
             "searchPostcode" => null,
             "idMethod" => "nin"

--- a/service-front/module/Application/test/Controller/PostOfficeDonorFlowControllerTest.php
+++ b/service-front/module/Application/test/Controller/PostOfficeDonorFlowControllerTest.php
@@ -60,7 +60,6 @@ class PostOfficeDonorFlowControllerTest extends AbstractHttpControllerTestCase
             "documentComplete" => false,
             "alternateAddress" => [
             ],
-            "selectedPostOfficeDeadline" => null,
             "selectedPostOffice" => null,
             "searchPostcode" => null,
             "idMethod" => "nin",

--- a/service-front/module/Application/test/Helpers/LpaFormHelperTest.php
+++ b/service-front/module/Application/test/Helpers/LpaFormHelperTest.php
@@ -429,7 +429,6 @@ class LpaFormHelperTest extends TestCase
             "documentComplete" => false,
             "alternateAddress" => [
             ],
-            "selectedPostOfficeDeadline" => null,
             "selectedPostOffice" => null,
             "searchPostcode" => null,
             "idMethod" => null


### PR DESCRIPTION
## Purpose

Rather than store things as arrays, or as JSON encoded strings, store them as well-defined objects.

Fixes ID-352 #patch

## Approach

To play nice with DynamoDB, the subclasses need to be instances of Traversable, so I've introduced an `Entity` base class to handle that.

The introduce of a KBVQuestion entity means other classes can be more strictly typed, rather than relying on an array shape.

I also updated the type hints of CaseData to be more accurate, which led to the disposal of the now-unused field `selectedPostOfficeDeadline`.

## Learning

- DynamoDB's `marshalValue` is quite helpful when you meet its requirements (i.e. using Traversable)
- `properties-of<self>` is a helpful Psalm annotation for methods like `fromArray` and `toArray`

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A