### PR TITLE
Fix a few things highlighted by SonarCloud

### DIFF
--- a/docker/cypress/Dockerfile
+++ b/docker/cypress/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /root
 COPY e2e-tests/package.json .
 COPY e2e-tests/package-lock.json .
 
-RUN npm install
+RUN npm install --ignore-scripts
 
 ENV CYPRESS_VIDEO=false
 ENV CYPRESS_baseUrl=http://front-web

--- a/service-api/Dockerfile
+++ b/service-api/Dockerfile
@@ -3,9 +3,9 @@ FROM php:8.3-fpm-alpine AS app
 RUN apk --no-cache add fcgi icu-dev libxml2-dev $PHPIZE_DEPS \
   && docker-php-ext-install opcache \
   && docker-php-ext-install soap \
-  && docker-php-ext-enable sodium
-RUN pecl install apcu && docker-php-ext-enable apcu
-RUN pecl install opentelemetry-1.0.3 && docker-php-ext-enable opentelemetry
+  && docker-php-ext-enable sodium \
+  && pecl install apcu && docker-php-ext-enable apcu \
+  && pecl install opentelemetry-1.0.3 && docker-php-ext-enable opentelemetry
 
 # Patch Vulnerabilities
 RUN apk upgrade --no-cache openssl

--- a/service-api/bin/clear-config-cache.php
+++ b/service-api/bin/clear-config-cache.php
@@ -6,7 +6,7 @@ use Laminas\ModuleManager\Listener\ListenerOptions;
 
 chdir(__DIR__ . '/../');
 
-require 'vendor/autoload.php';
+require_once 'vendor/autoload.php';
 
 $config = include 'config/application.config.php';
 

--- a/service-api/docker/scripts/create-cert.php
+++ b/service-api/docker/scripts/create-cert.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Aws\SecretsManager\SecretsManagerClient;
 
-include '/var/www/vendor/autoload.php';
+include_once '/var/www/vendor/autoload.php';
 
 $prefix = getenv('SECRETS_MANAGER_PREFIX');
 if (!is_string($prefix)) {

--- a/service-api/module/Application/src/Aws/DynamoDbClientFactory.php
+++ b/service-api/module/Application/src/Aws/DynamoDbClientFactory.php
@@ -19,8 +19,6 @@ class DynamoDbClientFactory implements FactoryInterface
         /** @var array{"aws": array<string, string|bool>} $config */
         $config = $container->get('Config');
 
-        $dynamoDbClient = new DynamoDbClient($config['aws']);
-
-        return $dynamoDbClient;
+        return new DynamoDbClient($config['aws']);
     }
 }

--- a/service-api/module/Application/src/Aws/EventBridgeClientFactory.php
+++ b/service-api/module/Application/src/Aws/EventBridgeClientFactory.php
@@ -19,8 +19,6 @@ class EventBridgeClientFactory implements FactoryInterface
         /** @var array{"aws": array<string, string|bool>} $config */
         $config = $container->get('Config');
 
-        $eventBridgeClient = new EventBridgeClient($config['aws']);
-
-        return $eventBridgeClient;
+        return new EventBridgeClient($config['aws']);
     }
 }

--- a/service-api/module/Application/src/Aws/SsmClientFactory.php
+++ b/service-api/module/Application/src/Aws/SsmClientFactory.php
@@ -7,7 +7,6 @@ namespace Application\Aws;
 use Aws\Ssm\SsmClient;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
-use Telemetry\Middleware\Aws as MiddlewareAws;
 
 class SsmClientFactory implements FactoryInterface
 {
@@ -20,8 +19,6 @@ class SsmClientFactory implements FactoryInterface
         /** @var array{"aws": array<string, string|bool>} $config */
         $config = $container->get('Config');
 
-        $ssmClient = new SsmClient($config['aws']);
-
-        return $ssmClient;
+        return new SsmClient($config['aws']);
     }
 }

--- a/service-api/module/Application/src/Experian/Crosscore/FraudApi/FraudApiService.php
+++ b/service-api/module/Application/src/Experian/Crosscore/FraudApi/FraudApiService.php
@@ -94,7 +94,7 @@ class FraudApiService
         $personId = $this->makePersonId($experianCrosscoreFraudRequestDTO);
         $addressDTO = $experianCrosscoreFraudRequestDTO->address();
 
-        $body = [
+        return [
             'header' => [
                 "tenantId" => $this->config['tenantId'],
                 "requestType" => "FraudScore",
@@ -153,8 +153,6 @@ class FraudApiService
             ],
             'source' => 'WEB'
         ];
-
-        return $body;
     }
 
     private function makePersonId(

--- a/service-api/module/Application/src/Experian/IIQ/AuthManager.php
+++ b/service-api/module/Application/src/Experian/IIQ/AuthManager.php
@@ -39,8 +39,8 @@ class AuthManager
 
         $token = $this->getToken();
 
-        $wsseNamespace = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd';
-        $encType = 'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary';
+        $wsseNamespace = 'https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd';
+        $encType = 'https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary';
 
         return new SoapHeader($wsseNamespace, 'Security', new SoapVar(['
             <wsse:Security xmlns:wsse="' . $wsseNamespace . '">
@@ -48,7 +48,7 @@ class AuthManager
                     EncodingType="' . $encType . '"
                     ValueType="ExperianWASP"
                     wsu:Id="SecurityToken-9e855049-1dc9-477a-ab9a-7f7d164132ca"
-                    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+                    xmlns:wsu="https://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
                 >' . $token . '</wsse:BinarySecurityToken>
             </wsse:Security>
         '], XSD_ANYXML));

--- a/service-api/module/Application/src/Factories/EventSenderFactory.php
+++ b/service-api/module/Application/src/Factories/EventSenderFactory.php
@@ -20,11 +20,9 @@ class EventSenderFactory implements FactoryInterface
         /** @var array{eventbridge: array{sirius_event_bus_name: string}} $config */
         $config = $container->get('Config');
 
-        $eventBridgeClient = new EventSender(
+        return new EventSender(
             $container->get(EventBridgeClient::class),
             $config['eventbridge']['sirius_event_bus_name'],
         );
-
-        return $eventBridgeClient;
     }
 }

--- a/service-api/module/Application/src/Mock/KBV/KBVService.php
+++ b/service-api/module/Application/src/Mock/KBV/KBVService.php
@@ -35,9 +35,7 @@ class KBVService implements KBVServiceInterface
 
     public function fetchFormattedQuestions(string $uuid): array
     {
-        $questions = $this->getKBVQuestions();
-
-        return $questions;
+        return $this->getKBVQuestions();
     }
 
     public function checkAnswers(array $answers, string $uuid): AnswersOutcome

--- a/service-api/module/Application/src/Module.php
+++ b/service-api/module/Application/src/Module.php
@@ -16,10 +16,7 @@ class Module
 {
     public function getConfig(): array
     {
-        /** @var array $config */
-        $config = include __DIR__ . '/../config/module.config.php';
-
-        return $config;
+        return include __DIR__ . '/../config/module.config.php';
     }
 
     /**

--- a/service-api/module/Application/src/Yoti/SessionConfig.php
+++ b/service-api/module/Application/src/Yoti/SessionConfig.php
@@ -97,7 +97,6 @@ class SessionConfig
             ]
         ];
 
-        //@TODO client to save the $authToken back to $case
         return $sessionConfig;
     }
 
@@ -160,7 +159,7 @@ class SessionConfig
         if (! $address['line1'] || $address['line1'] == '') {
             throw new YotiException("Address line1 missing");
         }
-        //@TODO determine what address format we are sending, currently no country_iso, assuming all UK for now
+
         $addressFormat["address_format"] = "1";
         $addressFormat["building_number"] = substr($address['line1'], 0, 3);
         $addressFormat["address_line1"] = $address['line1'];

--- a/service-api/module/Application/src/Yoti/YotiService.php
+++ b/service-api/module/Application/src/Yoti/YotiService.php
@@ -353,10 +353,8 @@ class YotiService implements YotiServiceInterface
         } catch (YotiAuthException $e) {
             throw new YotiException("Request signing issue " . $e->getMessage());
         }
-        $headers = [
+        return [
             'X-Yoti-Auth-Digest' => $requestSignature
         ];
-
-        return $headers;
     }
 }

--- a/service-api/public/index.php
+++ b/service-api/public/index.php
@@ -21,7 +21,7 @@ if (php_sapi_name() === 'cli-server') {
 }
 
 // Composer autoloading
-include __DIR__ . '/../vendor/autoload.php';
+include_once __DIR__ . '/../vendor/autoload.php';
 
 if (! class_exists(Application::class)) {
     throw new RuntimeException(

--- a/service-front/Dockerfile
+++ b/service-front/Dockerfile
@@ -8,7 +8,7 @@ RUN mkdir -p public
 
 COPY package.json .
 COPY yarn.lock .
-RUN yarn
+RUN yarn --ignore-scripts
 
 COPY web web
 RUN yarn build
@@ -17,17 +17,15 @@ RUN wget -O /app/yoti-supported-documents.json https://api.yoti.com/idverify/v1/
 
 FROM php:8.3-fpm-alpine AS app
 
-RUN mkdir /app
-WORKDIR /var/www
-
 RUN apk --no-cache add fcgi icu-dev autoconf libffi-dev linux-headers $PHPIZE_DEPS \
     && docker-php-ext-install ffi intl opcache \
-    && docker-php-ext-enable sodium
-
-RUN pecl install opentelemetry-1.0.3 && docker-php-ext-enable opentelemetry
+    && docker-php-ext-enable sodium \
+    && pecl install opentelemetry-1.0.3 && docker-php-ext-enable opentelemetry
 
 # Patch Vulnerabilities
 RUN apk upgrade --no-cache openssl
+
+WORKDIR /var/www
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 COPY docker/php/memory_limit.ini /usr/local/etc/php/conf.d/memory-limit.ini

--- a/service-front/bin/clear-config-cache.php
+++ b/service-front/bin/clear-config-cache.php
@@ -6,7 +6,7 @@ use Laminas\ModuleManager\Listener\ListenerOptions;
 
 chdir(__DIR__ . '/../');
 
-require 'vendor/autoload.php';
+require_once 'vendor/autoload.php';
 
 $config = include 'config/application.config.php';
 

--- a/service-front/docker/yarn/Dockerfile
+++ b/service-front/docker/yarn/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache git
 
 COPY package.json .
 COPY yarn.lock .
-RUN yarn install
+RUN yarn install --ignore-scripts
 
 COPY web web
 RUN yarn build

--- a/service-front/module/Application/src/Module.php
+++ b/service-front/module/Application/src/Module.php
@@ -14,9 +14,7 @@ class Module
 {
     public function getConfig(): array
     {
-        /** @var array $config */
-        $config = include __DIR__ . '/../config/module.config.php';
-        return $config;
+        return include __DIR__ . '/../config/module.config.php';
     }
 
     /**

--- a/service-front/module/Application/src/Services/OpgApiService.php
+++ b/service-front/module/Application/src/Services/OpgApiService.php
@@ -161,9 +161,7 @@ class OpgApiService implements OpgApiServiceInterface
     public function checkIdCheckAnswers(string $uuid, array $answers): array
     {
         try {
-            $response = $this->makeApiRequest("/cases/$uuid/kbv-answers", 'POST', $answers);
-
-            return $response;
+            return $this->makeApiRequest("/cases/$uuid/kbv-answers", 'POST', $answers);
         } catch (OpgApiException $opgApiException) {
             throw $opgApiException;
         }

--- a/service-front/module/Application/test/Auth/ListenerTest.php
+++ b/service-front/module/Application/test/Auth/ListenerTest.php
@@ -40,12 +40,12 @@ class ListenerTest extends AbstractHttpControllerTestCase
     {
         $siriusApiMock = $this->createMock(SiriusApiService::class);
 
-        $sut = new Listener($siriusApiMock, "http://login-url");
+        $sut = new Listener($siriusApiMock, "https://login-url");
 
         $event = $this->createMock(MvcEvent::class);
 
         $request = new Request();
-        $request->setUri('http://somehost/my/page?type=somevalue');
+        $request->setUri('https://somehost/my/page?type=somevalue');
         $event->expects($this->once())->method("getRequest")->willReturn($request);
 
         $event->expects($this->once())->method("getResponse")->willReturn(new Response());
@@ -62,7 +62,7 @@ class ListenerTest extends AbstractHttpControllerTestCase
         $location = $response->getHeaders()->get('Location');
         assert($location instanceof Location);
 
-        $expectedUrl = "http://login-url/auth?redirect=%2Fmy%2Fpage%3Ftype%3Dsomevalue";
+        $expectedUrl = "https://login-url/auth?redirect=%2Fmy%2Fpage%3Ftype%3Dsomevalue";
         $this->assertEquals($expectedUrl, $location->getFieldValue());
     }
 }

--- a/service-front/module/Application/test/Controller/CPFlowControllerTest.php
+++ b/service-front/module/Application/test/Controller/CPFlowControllerTest.php
@@ -12,7 +12,6 @@ use Application\PostOffice\Country;
 use Application\PostOffice\DocumentType;
 use Application\PostOffice\DocumentTypeRepository;
 use Application\Services\SiriusApiService;
-use Laminas\Http\Request;
 use Laminas\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 

--- a/service-front/module/Application/test/Helpers/AddressProcessorHelperTest.php
+++ b/service-front/module/Application/test/Helpers/AddressProcessorHelperTest.php
@@ -5,17 +5,10 @@ declare(strict_types=1);
 namespace ApplicationTest\Helpers;
 
 use Application\Helpers\AddressProcessorHelper;
-use Application\Services\OpgApiService;
-use Application\Services\SiriusApiService;
 use PHPUnit\Framework\TestCase;
 
 class AddressProcessorHelperTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     /**
      * @dataProvider addressData
      */

--- a/service-front/module/Application/test/Helpers/DependencyCheckHelperTest.php
+++ b/service-front/module/Application/test/Helpers/DependencyCheckHelperTest.php
@@ -6,20 +6,10 @@ namespace ApplicationTest\Helpers;
 
 use Application\Helpers\DependencyCheck;
 use Application\Enums\IdMethod;
-use Laminas\Form\Annotation\AttributeBuilder;
-use Laminas\Form\FormInterface;
-use Laminas\Stdlib\Parameters;
 use PHPUnit\Framework\TestCase;
-
-use function Aws\flatmap;
 
 class DependencyCheckHelperTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     /**
      * @dataProvider statusData
      */

--- a/service-front/module/Application/test/Helpers/FormProcessorHelperTest.php
+++ b/service-front/module/Application/test/Helpers/FormProcessorHelperTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ApplicationTest\Helpers;
 
 use Application\Forms\DrivingLicenceNumber;
-use Application\Forms\LpaReferenceNumber;
 use Application\Forms\NationalInsuranceNumber;
 use Application\Forms\PassportNumber;
 use Application\Forms\PassportDate;
@@ -18,13 +17,6 @@ use PHPUnit\Framework\TestCase;
 
 class FormProcessorHelperTest extends TestCase
 {
-//    private OpgApiService|MockObject $opgApiService;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     /**
      * @dataProvider dlnData
      */

--- a/service-front/module/Application/test/Helpers/LpaFormHelperTest.php
+++ b/service-front/module/Application/test/Helpers/LpaFormHelperTest.php
@@ -13,11 +13,6 @@ use Application\Forms\LpaReferenceNumber;
 
 class LpaFormHelperTest extends TestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     /**
      * @dataProvider lpaData
      */
@@ -400,7 +395,7 @@ class LpaFormHelperTest extends TestCase
     {
         $lpaRef = $lpa ?? "M-NC49-MV4M-E7P8";
         return [
-            "type" => "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
+            "type" => "https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
             "title" => "Not Found",
             "status" => 404,
             "detail" => "Unable to load DigitalLpa with identifier: " . $lpaRef

--- a/service-front/module/Application/test/Services/OpgApiServiceTest.php
+++ b/service-front/module/Application/test/Services/OpgApiServiceTest.php
@@ -13,19 +13,11 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
 class OpgApiServiceTest extends TestCase
 {
-    private OpgApiService|MockObject $opgApiService;
-
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     /**
      * @dataProvider detailsData
      * @param class-string<Throwable>|null $expectedException
@@ -36,9 +28,9 @@ class OpgApiServiceTest extends TestCase
             $this->expectException($expectedException);
         }
 
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $response = $this->opgApiService->getDetailsData('uuid');
+        $response = $opgApiService->getDetailsData('uuid');
 
         $this->assertEquals($responseData, $response);
     }
@@ -109,9 +101,9 @@ class OpgApiServiceTest extends TestCase
             $this->expectException(OpgApiException::class);
         }
 
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $response = $this->opgApiService->checkNinoValidity($nino);
+        $response = $opgApiService->checkNinoValidity($nino);
 
         $this->assertEquals($responseData, $response);
     }
@@ -185,9 +177,9 @@ class OpgApiServiceTest extends TestCase
             $this->expectException(OpgApiException::class);
         }
 
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $response = $this->opgApiService->checkDlnValidity($dln);
+        $response = $opgApiService->checkDlnValidity($dln);
 
         $this->assertEquals($responseData, $response);
     }
@@ -260,9 +252,9 @@ class OpgApiServiceTest extends TestCase
             $this->expectException(OpgApiException::class);
         }
 
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $response = $this->opgApiService->checkPassportValidity($passport);
+        $response = $opgApiService->checkPassportValidity($passport);
 
         $this->assertEquals($responseData, $response);
     }
@@ -380,9 +372,9 @@ class OpgApiServiceTest extends TestCase
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(['handler' => $handlerStack]);
 
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $response = $this->opgApiService->getIdCheckQuestions($uuid);
+        $response = $opgApiService->getIdCheckQuestions($uuid);
 
         $this->assertEquals($mockResponseData, $response);
     }
@@ -398,9 +390,9 @@ class OpgApiServiceTest extends TestCase
         }
         $uuid = '49895f88-501b-4491-8381-e8aeeaef177d';
 
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $response = $this->opgApiService->checkIdCheckAnswers($uuid, $answers);
+        $response = $opgApiService->checkIdCheckAnswers($uuid, $answers);
 
         $this->assertEquals(true, $response['complete']);
         $this->assertEquals($passed, $response['passed']);
@@ -468,9 +460,9 @@ class OpgApiServiceTest extends TestCase
         if ($exception) {
             $this->expectException(OpgApiException::class);
         }
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $response = $this->opgApiService->createCase(
+        $response = $opgApiService->createCase(
             $postData['FirstName'],
             $postData['LastName'],
             $postData['DOB'],
@@ -553,9 +545,9 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $this->opgApiService->updateIdMethod($data['uuid'], $data['method']);
+        $opgApiService->updateIdMethod($data['uuid'], $data['method']);
     }
 
     public static function updateIdMethodData(): array
@@ -605,9 +597,9 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $this->opgApiService->updateCaseSetDocumentComplete($data['uuid']);
+        $opgApiService->updateCaseSetDocumentComplete($data['uuid']);
     }
 
     public static function setDocumentCompleteData(): array
@@ -657,9 +649,9 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $this->opgApiService->updateCaseSetDob($data['uuid'], $data['dob']);
+        $opgApiService->updateCaseSetDob($data['uuid'], $data['dob']);
     }
 
     public static function setDobData(): array
@@ -710,9 +702,9 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $this->opgApiService->updateCaseProgress($data['uuid'], $data);
+        $opgApiService->updateCaseProgress($data['uuid'], $data);
     }
 
     public static function setAbandonCaseData(): array
@@ -759,9 +751,9 @@ class OpgApiServiceTest extends TestCase
             $this->expectException(OpgApiException::class);
         }
 
-        $this->opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client);
 
-        $this->assertEquals($expected, $this->opgApiService->getServiceAvailability());
+        $this->assertEquals($expected, $opgApiService->getServiceAvailability());
     }
 
     public static function serviceAvailabilityData(): array

--- a/service-front/module/Application/test/Validators/DLNDateValidatorTest.php
+++ b/service-front/module/Application/test/Validators/DLNDateValidatorTest.php
@@ -23,7 +23,7 @@ class DLNDateValidatorTest extends TestCase
      */
     public function testValidator(mixed $dln, bool $valid): void
     {
-        $this->assertEquals($this->dlnDateValidator->isValid($dln), $valid);
+        $this->assertEquals($valid, $this->dlnDateValidator->isValid($dln));
     }
 
     public static function dlnData(): array

--- a/service-front/module/Application/test/Validators/DLNValidatorTest.php
+++ b/service-front/module/Application/test/Validators/DLNValidatorTest.php
@@ -23,7 +23,7 @@ class DLNValidatorTest extends TestCase
      */
     public function testValidator(string $dln, bool $valid): void
     {
-        $this->assertEquals($this->dlnValidator->isValid($dln), $valid);
+        $this->assertEquals($valid, $this->dlnValidator->isValid($dln));
     }
 
     public static function dlnData(): array

--- a/service-front/module/Application/test/Validators/LpaValidatorTest.php
+++ b/service-front/module/Application/test/Validators/LpaValidatorTest.php
@@ -23,7 +23,7 @@ class LpaValidatorTest extends TestCase
      */
     public function testValidator(string $lpa, bool $valid): void
     {
-        $this->assertEquals($this->lpaValidator->isValid($lpa), $valid);
+        $this->assertEquals($valid, $this->lpaValidator->isValid($lpa));
     }
 
     public static function lpaData(): array

--- a/service-front/module/Application/test/Validators/NinoValidatorTest.php
+++ b/service-front/module/Application/test/Validators/NinoValidatorTest.php
@@ -23,7 +23,7 @@ class NinoValidatorTest extends TestCase
      */
     public function testValidator(string $nino, bool $valid): void
     {
-        $this->assertEquals($this->ninoValidator->isValid($nino), $valid);
+        $this->assertEquals($valid, $this->ninoValidator->isValid($nino));
     }
 
     public static function ninoData(): array

--- a/service-front/module/Application/test/Validators/PassportInDateValidatorTest.php
+++ b/service-front/module/Application/test/Validators/PassportInDateValidatorTest.php
@@ -23,7 +23,7 @@ class PassportInDateValidatorTest extends TestCase
      */
     public function testValidator(mixed $passport, bool $valid): void
     {
-        $this->assertEquals($this->passportDateValidator->isValid($passport), $valid);
+        $this->assertEquals($valid, $this->passportDateValidator->isValid($passport));
     }
 
     public static function passportData(): array

--- a/service-front/module/Application/view/application/pages/cp/add_lpa.twig
+++ b/service-front/module/Application/view/application/pages/cp/add_lpa.twig
@@ -63,7 +63,7 @@
                     id="lpa"
                     name="lpa"
                     type="text"
-                    autocomplete="lpa"
+                    autocomplete="off"
                     value="{{ form.get('lpa').value }}"
                     aria-describedby="lpa-hint {% if form.get('lpa').messages %}lpa-error{% endif %}"
             />

--- a/service-front/module/Application/view/application/pages/driving_licence_number.twig
+++ b/service-front/module/Application/view/application/pages/driving_licence_number.twig
@@ -55,7 +55,7 @@
             {% if service_availability.data.DRIVING_LICENCE %}
                 <input
                         class="govuk-input govuk-!-width-one-third {% if form.get('dln').messages %}govuk-input--error{% endif %}"
-                        id="dln" name="dln" type="text" autocomplete="dln"
+                        id="dln" name="dln" type="text" autocomplete="off"
                         value="{{ form.get('dln').value }}"
                         aria-describedby="dln-hint {% if form.get('dln').messages %}dln-error{% endif %}"
                 />

--- a/service-front/module/Application/view/application/pages/national_insurance_number.twig
+++ b/service-front/module/Application/view/application/pages/national_insurance_number.twig
@@ -42,7 +42,7 @@
             {% if service_availability.data.NATIONAL_INSURANCE_NUMBER %}
                 <input
                         class="govuk-input govuk-!-width-one-third {% if form.get('nino').messages %}govuk-input--error{% endif %}"
-                        id="nino" name="nino" type="text" autocomplete="nino"
+                        id="nino" name="nino" type="text" autocomplete="off"
                         value="{{ form.get('nino').value }}"
                         aria-describedby="nino-hint {% if form.get('nino').messages %}nino-error{% endif %}"
                 />

--- a/service-front/module/Application/view/application/pages/passport_number.twig
+++ b/service-front/module/Application/view/application/pages/passport_number.twig
@@ -55,7 +55,7 @@
             {% if service_availability.data.PASSPORT %}
                 <input
                         class="govuk-input govuk-!-width-one-third {% if form.get('passport').messages %}govuk-input--error{% endif %}"
-                        id="passport" name="passport" type="text" autocomplete="passport"
+                        id="passport" name="passport" type="text" autocomplete="off"
                         value="{{ form.get('passport').value }}"
                         aria-describedby="passport-hint {% if form.get('passport').messages %}passport-error{% endif %}"
                 />


### PR DESCRIPTION
## Purpose

Fix a few issues identified by SonarCloud scans

#patch

## Approach

- Add `--ignore-scripts` to NPM/yarn installs
- Merge Docker RUN commands to produce fewer layers
- Use require_once/include_once when substituting files in (not for files that return something)
- Remove unnecessary variables (e.g. `$x = ...; return $x;` becomes `return ...;`)
- Remove old TODOs
- Remove `TestCase::setUp` overrides which don't add anything
- Use local variables in OpgApiServiceTest rather than a class property
- Fix order of expected/actual arguments in PHPUnit assertions
- Turn off autocomplete (existing values aren't valid, and users are going to enter _lots_ of numbers so autocompletion would just be annoying)
- Use https URLs

## Learning

I didn't realise there are fixed/standardised values for the `autocomplete` attribute
