### PR TITLE
Tidy up CrossCore classes

### DIFF
--- a/service-api/module/Application/src/Experian/Crosscore/AuthApi/AuthApiService.php
+++ b/service-api/module/Application/src/Experian/Crosscore/AuthApi/AuthApiService.php
@@ -42,7 +42,7 @@ class AuthApiService
      */
     public function authenticate(): ResponseDTO
     {
-        $credentials = $this->getCredentials();
+        $credentials = $this->experianCrosscoreAuthRequestDTO;
 
         $tokenResponse = $this->getToken($credentials);
 
@@ -81,18 +81,6 @@ class AuthApiService
             return $tokenResponse['access_token'];
         } else {
             return $this->authenticate()->accessToken();
-        }
-    }
-
-    /**
-     * @throws AuthApiException
-     */
-    public function getCredentials(): RequestDTO
-    {
-        try {
-            return $this->experianCrosscoreAuthRequestDTO;
-        } catch (\Exception $exception) {
-            throw new AuthApiException($exception->getMessage());
         }
     }
 

--- a/service-api/module/Application/src/Factories/ExperianCrosscoreFraudApiServiceFactory.php
+++ b/service-api/module/Application/src/Factories/ExperianCrosscoreFraudApiServiceFactory.php
@@ -27,15 +27,6 @@ class ExperianCrosscoreFraudApiServiceFactory implements FactoryInterface
         $requestedName,
         array $options = null
     ): FraudApiService {
-        $authBaseUri = getenv("EXPERIAN_CROSSCORE_AUTH_URL");
-        if (! is_string($authBaseUri) || empty($authBaseUri)) {
-            throw new AuthApiException("EXPERIAN_CROSSCORE_AUTH_URL is empty");
-        }
-
-        $guzzleAuthClient = new Client([
-            'base_uri' => $authBaseUri
-        ]);
-
         $baseUri = getenv("EXPERIAN_CROSSCORE_BASE_URL");
         if (! is_string($baseUri) || empty($baseUri)) {
             throw new FraudApiException("EXPERIAN_CROSSCORE_BASE_URL is empty");
@@ -45,31 +36,12 @@ class ExperianCrosscoreFraudApiServiceFactory implements FactoryInterface
             'base_uri' => $baseUri
         ]);
 
-        $apcHelper = new ApcHelper();
-
-        $username = (new AwsSecret('experian-crosscore/username'))->getValue();
-        $password = (new AwsSecret('experian-crosscore/password'))->getValue();
-        $clientId = (new AwsSecret('experian-crosscore/client-id'))->getValue();
-        $clientSecret = (new AwsSecret('experian-crosscore/client-secret'))->getValue();
         $domain = (new AwsSecret('experian-crosscore/domain'))->getValue();
         $tenantId = (new AwsSecret('experian-crosscore/tenant-id'))->getValue();
 
-        $experianCrosscoreAuthRequestDTO = new RequestDTO(
-            $username,
-            $password,
-            $clientId,
-            $clientSecret
-        );
-
-        $experianCrosscoreAuthApiService = new AuthApiService(
-            $guzzleAuthClient,
-            $apcHelper,
-            $experianCrosscoreAuthRequestDTO
-        );
-
         return new FraudApiService(
             $guzzleClient,
-            $experianCrosscoreAuthApiService,
+            $container->get(AuthApiService::class),
             [
                 'domain' => $domain,
                 'tenantId' => $tenantId

--- a/service-api/module/Application/test/ApplicationTest/Services/Experian/AuthApi/ExperianCrosscoreAuthApiServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Services/Experian/AuthApi/ExperianCrosscoreAuthApiServiceTest.php
@@ -57,13 +57,6 @@ class ExperianCrosscoreAuthApiServiceTest extends TestCase
         );
     }
 
-    public function testGetCredentials(): void
-    {
-        $credentials = $this->experianCrosscoreAuthApiService->getCredentials();
-
-        $this->assertInstanceOf(RequestDTO::class, $credentials);
-    }
-
     /**
      * @dataProvider tokenResponseData
      * @param class-string<Throwable>|null $expectedException

--- a/service-api/module/Application/test/ApplicationTest/Services/Experian/FraudApi/ExperianCrosscoreFraudApiServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Services/Experian/FraudApi/ExperianCrosscoreFraudApiServiceTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace ApplicationTest\ApplicationTest\Services\Experian\FraudApi;
 
-use Application\Experian\Crosscore\AuthApi\DTO\RequestDTO as AuthRequestDTO;
 use Application\Experian\Crosscore\AuthApi\AuthApiService;
 use Application\Experian\Crosscore\FraudApi\DTO\RequestDTO;
 use Application\Experian\Crosscore\FraudApi\FraudApiException;
@@ -13,6 +12,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
@@ -20,7 +20,7 @@ class ExperianCrosscoreFraudApiServiceTest extends TestCase
 {
     private array $config;
 
-    private AuthApiService $experianCrosscoreAuthApiService;
+    private AuthApiService&MockObject $experianCrosscoreAuthApiService;
 
     public function setUp(): void
     {
@@ -30,13 +30,6 @@ class ExperianCrosscoreFraudApiServiceTest extends TestCase
         ];
 
         $this->experianCrosscoreAuthApiService = $this->createMock(AuthApiService::class);
-    }
-
-    public function testGetCredentials(): void
-    {
-        $credentials = $this->experianCrosscoreAuthApiService->getCredentials();
-
-        $this->assertInstanceOf(AuthRequestDTO::class, $credentials);
     }
 
     /**
@@ -52,9 +45,6 @@ class ExperianCrosscoreFraudApiServiceTest extends TestCase
         if ($expectedException !== null) {
             $this->expectException($expectedException);
         } else {
-            /**
-             * @psalm-suppress UndefinedMethod
-             */
             $this->experianCrosscoreAuthApiService
                 ->expects($this->once())
                 ->method('retrieveCachedTokenResponse');


### PR DESCRIPTION
- Remove `AuthApiService->getCredentials()` to prevent secrets from leaking
- Use `Container->get()` rather than duplicating the AuthApiService build steps
- Type mocks correctly with MockObject for Psalm

#patch
