### PR TITLE
ID-399 - CP page "How will they confirm identity" remove "other methods"

### DIFF
--- a/service-front/module/Application/view/application/pages/cp/how_will_the_cp_confirm.twig
+++ b/service-front/module/Application/view/application/pages/cp/how_will_the_cp_confirm.twig
@@ -187,29 +187,6 @@
                 </div>
             {% endif %}
         </div>
-                    <details class="govuk-details">
-                        <summary class="govuk-details__summary">
-                        <span class="govuk-details__summary-text">
-                          Other methods
-                        </span>
-                        </summary>
-                        <div class="govuk-details__text">
-                            <div class="govuk-radios" data-module="govuk-radios">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="OnBehalf" name="id_method" type="radio"
-                                           value="OnBehalf">
-                                    <label class="govuk-label govuk-radios__label" for="OnBehalf">Choose someone to prove their
-                                        identity on donor's behalf</label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="CourtOfProtection" name="id_method" type="radio"
-                                           value="cpr">
-                                    <label class="govuk-label govuk-radios__label" for="CourtOfProtection">Court of
-                                        protection</label>
-                                </div>
-                            </div>
-                        </div>
-                    </details>
         <input type="submit" class="govuk-button" value="Continue">
     </form>
 {% endblock %}


### PR DESCRIPTION
## Purpose

Remove "other methods" from CP page "How will they confirm identity"

Fixes ###-####

## Approach

Deleted the relevant code

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
