### PR TITLE
ID-398 - Fix Paper ID "Exit ID" not working

### DIFF
--- a/service-front/module/Application/view/layout/id_check_banner.twig
+++ b/service-front/module/Application/view/layout/id_check_banner.twig
@@ -13,7 +13,7 @@
             <div class="moj-identity-bar__actions">
                 <div class="govuk-!-static-margin-top-2">
                     <a
-                        href="{{ ('./abandon-flow?last_page=' ~ path()) | basepath }}"
+                        href="{{ ('/' ~ details_data['id'] ~ '/abandon-flow?last_page=' ~ path()) | basepath }}"
                         role="button"
                         draggable="false"
                         class="govuk-link govuk-!-font-size-16"

--- a/service-front/module/Application/view/layout/id_check_banner.twig
+++ b/service-front/module/Application/view/layout/id_check_banner.twig
@@ -13,7 +13,7 @@
             <div class="moj-identity-bar__actions">
                 <div class="govuk-!-static-margin-top-2">
                     <a
-                        href="/{{ (details_data['id'] ~ '/abandon-flow?last_page=' ~ path()) | basepath }}"
+                        href="{{ ('./abandon-flow?last_page=' ~ path()) | basepath }}"
                         role="button"
                         draggable="false"
                         class="govuk-link govuk-!-font-size-16"

--- a/service-front/module/Application/view/layout/id_check_banner.twig
+++ b/service-front/module/Application/view/layout/id_check_banner.twig
@@ -13,7 +13,7 @@
             <div class="moj-identity-bar__actions">
                 <div class="govuk-!-static-margin-top-2">
                     <a
-                        href="/{{ details_data['id'] }}/abandon-flow?last_page={{ path() }}"
+                        href="/{{ (details_data['id'] ~ '/abandon-flow?last_page=' ~ path()) | basepath }}"
                         role="button"
                         draggable="false"
                         class="govuk-link govuk-!-font-size-16"


### PR DESCRIPTION
## Purpose

Exit ID link was not taking into account the base path: `/lpa/identity-check`

Fixes https://opgtransform.atlassian.net/browse/ID-398

## Approach

Using twig filter `basepath` which grabs it from the environment variable `PREFIX`

Tested locally and on an isolated deployment at https://id-398.development.sirius.opg.service.justice.gov.uk/
