### PR TITLE
vouching route - confirm vouching

### DIFF
--- a/service-api/module/Application/src/Controller/IdentityController.php
+++ b/service-api/module/Application/src/Controller/IdentityController.php
@@ -522,6 +522,11 @@ class IdentityController extends AbstractActionController
             return new JsonModel(new Problem('Case does not exist'));
         }
 
+        if (! $case->address) {
+            $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
+            return new JsonModel(new Problem('Case does not have an associated address'));
+        }
+
         $this->getResponse()->setStatusCode(Response::STATUS_CODE_200);
 
         $addressDto = new AddressDTO(

--- a/service-api/module/Application/src/Experian/IIQ/ConfigBuilder.php
+++ b/service-api/module/Application/src/Experian/IIQ/ConfigBuilder.php
@@ -48,7 +48,6 @@ class ConfigBuilder
         $saaConfig['LocationDetails'] = [
             'LocationIdentifier' => '1',
             'UKLocation' => [
-                // or de we want to trow an error if address is empty??
                 'HouseName' => $case->address["line1"] ?? '',
                 'Street' => $case->address["line2"] ?? '',
                 'District' => $case->address["line3"] ?? '',

--- a/service-api/module/Application/src/Experian/IIQ/ConfigBuilder.php
+++ b/service-api/module/Application/src/Experian/IIQ/ConfigBuilder.php
@@ -48,7 +48,8 @@ class ConfigBuilder
         $saaConfig['LocationDetails'] = [
             'LocationIdentifier' => '1',
             'UKLocation' => [
-                'HouseName' => $case->address["line1"],
+                // or de we want to trow an error if address is empty??
+                'HouseName' => $case->address["line1"] ?? '',
                 'Street' => $case->address["line2"] ?? '',
                 'District' => $case->address["line3"] ?? '',
                 'PostTown' => $case->address["town"] ?? '',

--- a/service-api/module/Application/src/Experian/IIQ/ConfigBuilder.php
+++ b/service-api/module/Application/src/Experian/IIQ/ConfigBuilder.php
@@ -45,6 +45,10 @@ class ConfigBuilder
         $saaConfig['ApplicationData'] = [
             'SearchConsent' => 'Y',
         ];
+
+        if (! isset($case->address)) {
+            throw new RuntimeException('Address has not been set');
+        }
         $saaConfig['LocationDetails'] = [
             'LocationIdentifier' => '1',
             'UKLocation' => [

--- a/service-api/module/Application/src/Experian/IIQ/IIQService.php
+++ b/service-api/module/Application/src/Experian/IIQ/IIQService.php
@@ -16,8 +16,8 @@ use SoapFault;
  *     ApplicantIdentifier: string,
  *     Name: array{
  *       Title: string,
- *       Forename: string,
- *       Surname: string,
+ *       Forename: string|null,
+ *       Surname: string|null,
  *     },
  *     DateOfBirth: array{
  *       CCYY: string,

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -41,13 +41,15 @@ class CaseData implements JsonSerializable
     #[Validator(Regex::class, options: ["pattern" => "/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/", "messages" => [
         Regex::NOT_MATCH => 'Please enter a valid date of birth in the format YYYY-MM-DD'
     ]])]
-    public ?string $dob;
+    public ?string $dob = null;
 
-    #[Validator(NotEmpty::class)]
-    public string $firstName;
+    #[Annotation\Required(false)]
+    #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
+    public ?string $firstName = null;
 
-    #[Validator(NotEmpty::class)]
-    public string $lastName;
+    #[Annotation\Required(false)]
+    #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
+    public ?string $lastName = null;
 
     /**
      * @var array{
@@ -59,8 +61,19 @@ class CaseData implements JsonSerializable
      *   country?: string,
      * }
      */
-    #[Validator(NotEmpty::class)]
-    public array $address;
+    #[Annotation\Required(false)]
+    #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
+    public ?array $address = [];
+
+    /**
+     * @var array{
+     *   firstName: string
+     *   lastName: string,
+     * }
+     */
+    #[Annotation\Required(false)]
+    #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
+    public ?array $vouchingFor = [];
 
     /**
      * @var string[]
@@ -161,6 +174,10 @@ class CaseData implements JsonSerializable
      *       postcode: string,
      *       country?: string,
      *     },
+     *     vouchingFor: array{
+     *        firstName: string,
+     *        lastName: string
+     *     }
      *     lpas: string[],
      *     kbvQuestions: KBVQuestion[],
      *     iiqControl?: IIQControl,
@@ -184,6 +201,7 @@ class CaseData implements JsonSerializable
             'lastName' => $this->lastName,
             'dob' => $this->dob,
             'address' => $this->address,
+            'vouchingFor' => $this->vouchingFor,
             'lpas' => $this->lpas,
             'documentComplete' => $this->documentComplete,
             'identityCheckPassed' => $this->identityCheckPassed,

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -41,14 +41,13 @@ class CaseData implements JsonSerializable
     #[Validator(Regex::class, options: ["pattern" => "/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/", "messages" => [
         Regex::NOT_MATCH => 'Please enter a valid date of birth in the format YYYY-MM-DD'
     ]])]
+    #[Validator(NotEmpty::class, options: [NotEmpty::STRING])]
     public ?string $dob = null;
 
-    #[Annotation\Required(false)]
-    #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
+    #[Validator(NotEmpty::class, options: [NotEmpty::STRING])]
     public ?string $firstName = null;
 
-    #[Annotation\Required(false)]
-    #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
+    #[Validator(NotEmpty::class, options: [NotEmpty::STRING])]
     public ?string $lastName = null;
 
     /**
@@ -59,21 +58,19 @@ class CaseData implements JsonSerializable
      *   town?: string,
      *   postcode: string,
      *   country?: string,
-     * }
+     * }|null
      */
     #[Annotation\Required(false)]
-    #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
-    public ?array $address = [];
+    #[Validator(NotEmpty::class)]
+    public ?array $address = null;
 
     /**
      * @var array{
-     *   firstName: string
+     *   firstName: string,
      *   lastName: string,
-     * }
+     * }|null
      */
-    #[Annotation\Required(false)]
-    #[Annotation\Validator(NotEmpty::class, options: [NotEmpty::NULL])]
-    public ?array $vouchingFor = [];
+    public ?array $vouchingFor = null;
 
     /**
      * @var string[]
@@ -163,10 +160,10 @@ class CaseData implements JsonSerializable
      * @return array{
      *     id: string,
      *     personType: "donor"|"certificateProvider",
-     *     firstName: string,
-     *     lastName: string,
+     *     firstName: ?string,
+     *     lastName: ?string,
      *     dob: ?string,
-     *     address: array{
+     *     address: ?array{
      *       line1: string,
      *       line2?: string,
      *       line3?: string,
@@ -174,10 +171,10 @@ class CaseData implements JsonSerializable
      *       postcode: string,
      *       country?: string,
      *     },
-     *     vouchingFor: array{
-     *        firstName: string,
-     *        lastName: string
-     *     }
+     *     vouchingFor: ?array{
+     *       firstName: string,
+     *       lastName: string,
+     *     },
      *     lpas: string[],
      *     kbvQuestions: KBVQuestion[],
      *     iiqControl?: IIQControl,

--- a/service-api/module/Application/src/Model/Entity/CaseData.php
+++ b/service-api/module/Application/src/Model/Entity/CaseData.php
@@ -18,6 +18,7 @@ use Laminas\Validator\NotEmpty;
 use Laminas\Validator\Regex;
 use Laminas\Validator\Uuid;
 use Application\Model\Entity\CaseProgress;
+use Application\Model\Entity\VouchingFor;
 
 /**
  * DTO for holding data required to make new case entry post
@@ -64,13 +65,12 @@ class CaseData implements JsonSerializable
     #[Validator(NotEmpty::class)]
     public ?array $address = null;
 
+
     /**
-     * @var array{
-     *   firstName: string,
-     *   lastName: string,
-     * }|null
+     * @var ?VouchingFor
      */
-    public ?array $vouchingFor = null;
+    #[Annotation\Required(false)]
+    public ?VouchingFor $vouchingFor = null;
 
     /**
      * @var string[]
@@ -146,6 +146,8 @@ class CaseData implements JsonSerializable
                 $instance->iiqControl = IIQControl::fromArray($value);
             } elseif ($key === 'idMethodIncludingNation') {
                 $instance->idMethodIncludingNation = IdMethodIncludingNation::fromArray($value);
+            } elseif ($key === 'vouchingFor') {
+                $instance->vouchingFor = VouchingFor::fromArray($value);
             } elseif (property_exists($instance, $key)) {
                 $instance->{$key} = $value;
             } else {
@@ -171,10 +173,7 @@ class CaseData implements JsonSerializable
      *       postcode: string,
      *       country?: string,
      *     },
-     *     vouchingFor: ?array{
-     *       firstName: string,
-     *       lastName: string,
-     *     },
+     *     vouchingFor?: VouchingFor,
      *     lpas: string[],
      *     kbvQuestions: KBVQuestion[],
      *     iiqControl?: IIQControl,
@@ -198,7 +197,6 @@ class CaseData implements JsonSerializable
             'lastName' => $this->lastName,
             'dob' => $this->dob,
             'address' => $this->address,
-            'vouchingFor' => $this->vouchingFor,
             'lpas' => $this->lpas,
             'documentComplete' => $this->documentComplete,
             'identityCheckPassed' => $this->identityCheckPassed,
@@ -226,6 +224,10 @@ class CaseData implements JsonSerializable
 
         if ($this->fraudScore !== null) {
             $arr['fraudScore'] = $this->fraudScore;
+        }
+
+        if ($this->vouchingFor !== null) {
+            $arr['vouchingFor'] = $this->vouchingFor;
         }
 
         return $arr;

--- a/service-api/module/Application/src/Model/Entity/VouchingFor.php
+++ b/service-api/module/Application/src/Model/Entity/VouchingFor.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Model\Entity;
+
+use Exception;
+use Laminas\Form\Annotation\Validator;
+use Laminas\Validator\NotEmpty;
+
+/**
+ * DTO for holding case progress data
+ * @psalm-suppress MissingConstructor
+ * Needed here due to false positive from Laminas’s uninitialised properties
+ * @psalm-suppress UnusedProperty
+ */
+class VouchingFor extends Entity
+{
+    #[Validator(NotEmpty::class, options: [NotEmpty::STRING])]
+    public string $firstName;
+
+    #[Validator(NotEmpty::class, options: [NotEmpty::STRING])]
+    public string $lastName;
+
+    /**
+     * @param properties-of<self> $data
+     */
+    public static function fromArray(mixed $data): self
+    {
+        $instance = new self();
+
+        foreach ($data as $key => $value) {
+            if (property_exists($instance, $key)) {
+                $instance->{$key} = $value;
+            } else {
+                throw new Exception(sprintf('%s does not have property "%s"', $instance::class, $key));
+            }
+        }
+
+        return $instance;
+    }
+
+    /**
+     * @return properties-of<self>
+     */
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/service-api/module/Application/src/Yoti/SessionConfig.php
+++ b/service-api/module/Application/src/Yoti/SessionConfig.php
@@ -153,10 +153,12 @@ class SessionConfig
     /**
      * @throws YotiException
      */
-    public function addressFormatted(array $address): array
+    public function addressFormatted(?array $address): array
     {
         $addressFormat = [];
-        if (! $address['line1'] || $address['line1'] == '') {
+        if (is_null($address)) {
+            throw new YotiException("Address is not set");
+        } elseif (! $address['line1'] || $address['line1'] == '') {
             throw new YotiException("Address line1 missing");
         }
 

--- a/service-front/module/Application/config/module.config.php
+++ b/service-front/module/Application/config/module.config.php
@@ -549,6 +549,16 @@ return [
                             ],
                         ],
                     ],
+                    'confirm_vouching' => [
+                        'type' => Segment::class,
+                        'options' => [
+                            'route' => '/:uuid/confirm-vouching',
+                            'defaults' => [
+                                'controller' => Controller\VouchingFlowController::class,
+                                'action' => 'confirmVouching',
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ],
@@ -557,6 +567,7 @@ return [
         'factories' => [
             Controller\CPFlowController::class => CPFlowControllerFactory::class,
             Controller\DonorFlowController::class => DonorFlowControllerFactory::class,
+            Controller\VouchingFlowController::class => LazyControllerAbstractFactory::class,
             Controller\IndexController::class => LazyControllerAbstractFactory::class,
             Controller\KbvController::class => LazyControllerAbstractFactory::class,
             Controller\PostOfficeFlowController::class => PostOfficeFlowControllerFactory::class,

--- a/service-front/module/Application/config/module.config.php
+++ b/service-front/module/Application/config/module.config.php
@@ -552,7 +552,7 @@ return [
                     'confirm_vouching' => [
                         'type' => Segment::class,
                         'options' => [
-                            'route' => '/:uuid/confirm-vouching',
+                            'route' => '/:uuid/vouching/confirm-vouching',
                             'defaults' => [
                                 'controller' => Controller\VouchingFlowController::class,
                                 'action' => 'confirmVouching',

--- a/service-front/module/Application/src/Controller/IndexController.php
+++ b/service-front/module/Application/src/Controller/IndexController.php
@@ -91,7 +91,7 @@ class IndexController extends AbstractActionController
      */
     private function processLpaResponse(string $type, array $data): array
     {
-        if (in_array($type, array('donor', 'voucher'))) {
+        if (in_array($type, ['donor', 'voucher'])) {
             if (! empty($data['opg.poas.lpastore'])) {
                 $address = (new AddressProcessorHelper())->processAddress(
                     $data['opg.poas.lpastore']['donor']['address'],

--- a/service-front/module/Application/src/Controller/IndexController.php
+++ b/service-front/module/Application/src/Controller/IndexController.php
@@ -57,10 +57,10 @@ class IndexController extends AbstractActionController
         if (! $this->lpaFormHelper->lpaIdentitiesMatch($lpas, $type)) {
             $personTypeDescription = [
                 'donor' => "Donors",
-                'certificateProvidor' => "Certificate Providers",
+                'certificateProvider' => "Certificate Providers",
                 'voucher' => "Vouchers"
             ];
-            throw new HttpException(400, "These LPAs are for different " . $personTypeDescription[$type]);
+            throw new HttpException(400, "These LPAs are for different {$personTypeDescription[$type]}");
         }
         /**
          * @psalm-suppress PossiblyUndefinedArrayOffset

--- a/service-front/module/Application/src/Controller/IndexController.php
+++ b/service-front/module/Application/src/Controller/IndexController.php
@@ -55,8 +55,12 @@ class IndexController extends AbstractActionController
         $type = $this->params()->fromQuery("personType");
 
         if (! $this->lpaFormHelper->lpaIdentitiesMatch($lpas, $type)) {
-            $personTypeDescription = $type === 'donor' ? "Donors" : " Certificate Providers";
-            throw new HttpException(400, "These LPAs are for different " . $personTypeDescription);
+            $personTypeDescription = [
+                'donor' => "Donors",
+                'certificateProvidor' => "Certificate Providers",
+                'voucher' => "Vouchers"
+            ];
+            throw new HttpException(400, "These LPAs are for different " . $personTypeDescription[$type]);
         }
         /**
          * @psalm-suppress PossiblyUndefinedArrayOffset
@@ -72,9 +76,13 @@ class IndexController extends AbstractActionController
             $detailsData['address']
         );
 
-        return $type === 'donor' ?
-            $this->redirect()->toRoute('root/how_donor_confirms', ['uuid' => $case['uuid']]) :
-            $this->redirect()->toRoute('root/cp_how_cp_confirms', ['uuid' => $case['uuid']]);
+        $route = [
+            'donor' => 'root/how_donor_confirms',
+            'certificateProvider' => 'root/cp_how_cp_confirms',
+            'voucher' => 'root/confirm_vouching'
+        ];
+
+        return $this->redirect()->toRoute($route[$type], ['uuid' => $case['uuid']]);
     }
 
     /**
@@ -83,7 +91,7 @@ class IndexController extends AbstractActionController
      */
     private function processLpaResponse(string $type, array $data): array
     {
-        if ($type === 'donor') {
+        if (in_array($type, array('donor', 'voucher'))) {
             if (! empty($data['opg.poas.lpastore'])) {
                 $address = (new AddressProcessorHelper())->processAddress(
                     $data['opg.poas.lpastore']['donor']['address'],

--- a/service-front/module/Application/src/Controller/VouchingFlowController.php
+++ b/service-front/module/Application/src/Controller/VouchingFlowController.php
@@ -26,7 +26,7 @@ class VouchingFlowController extends AbstractActionController
     {
         $view = new ViewModel();
         $uuid = $this->params()->fromRoute("uuid");
-        $donor_details =  $this->opgApiService->getDetailsData($uuid);
+        $donor_details = $this->opgApiService->getDetailsData($uuid);
         $form = $this->createForm(ConfirmVouching::class);
 
         $view->setVariable('details_data', $donor_details);
@@ -34,13 +34,12 @@ class VouchingFlowController extends AbstractActionController
 
         if ($this->getRequest()->isPost() && $form->isValid()) {
             $formData = $this->getRequest()->getPost();
-            if ($formData['eligibility'] == "eligibility_confirmed" && $formData['declaration'] == "declaration_confirmed") {
+            if (   $formData['eligibility'] == "eligibility_confirmed"
+                && $formData['declaration'] == "declaration_confirmed") {
                 // will need to update to route to vouching how-will-you-confirm page
                 return $this->redirect()->toRoute("root/confirm_vouching", ['uuid' => $uuid]);
             }
         }
-
         return $view->setTemplate('application/pages/vouching/confirm_vouching');
     }
-
 }

--- a/service-front/module/Application/src/Controller/VouchingFlowController.php
+++ b/service-front/module/Application/src/Controller/VouchingFlowController.php
@@ -34,8 +34,7 @@ class VouchingFlowController extends AbstractActionController
 
         if ($this->getRequest()->isPost() && $form->isValid()) {
             $formData = $this->getRequest()->getPost();
-            if (   $formData['eligibility'] == "eligibility_confirmed"
-                && $formData['declaration'] == "declaration_confirmed") {
+            if (isset($formData['eligibility']) && isset($formData['declaration'])) {
                 // will need to update to route to vouching how-will-you-confirm page
                 return $this->redirect()->toRoute("root/confirm_vouching", ['uuid' => $uuid]);
             }

--- a/service-front/module/Application/src/Controller/VouchingFlowController.php
+++ b/service-front/module/Application/src/Controller/VouchingFlowController.php
@@ -39,7 +39,7 @@ class VouchingFlowController extends AbstractActionController
         if ($this->getRequest()->isPost()) {
             $formData = $this->getRequest()->getPost();
 
-            if (isset($formData['try_different'])) {
+            if (isset($formData['tryDifferent'])) {
                 return $this->redirect()->toUrl(
                     "/start?personType=donor&lpas[]=" . implode("lpas[]=", $details_data['lpas'])
                 );

--- a/service-front/module/Application/src/Controller/VouchingFlowController.php
+++ b/service-front/module/Application/src/Controller/VouchingFlowController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Controller;
+
+use Application\Contracts\OpgApiServiceInterface;
+use Application\Controller\Trait\FormBuilder;
+use Application\Forms\ConfirmVouching;
+use Laminas\Http\Response;
+use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\View\Model\ViewModel;
+
+class VouchingFlowController extends AbstractActionController
+{
+    use FormBuilder;
+
+    protected $plugins;
+
+    public function __construct(
+        private readonly OpgApiServiceInterface $opgApiService,
+    ) {
+    }
+
+    public function confirmVouchingAction(): ViewModel|Response
+    {
+        $view = new ViewModel();
+        $uuid = $this->params()->fromRoute("uuid");
+        $donor_details =  $this->opgApiService->getDetailsData($uuid);
+        $form = $this->createForm(ConfirmVouching::class);
+
+        $view->setVariable('details_data', $donor_details);
+        $view->setVariable('form', $form);
+
+        if ($this->getRequest()->isPost() && $form->isValid()) {
+            $formData = $this->getRequest()->getPost();
+            if ($formData['eligibility'] == "eligibility_confirmed" && $formData['declaration'] == "declaration_confirmed") {
+                // will need to update to route to vouching how-will-you-confirm page
+                return $this->redirect()->toRoute("root/confirm_vouching", ['uuid' => $uuid]);
+            }
+        }
+
+        return $view->setTemplate('application/pages/vouching/confirm_vouching');
+    }
+
+}

--- a/service-front/module/Application/src/Controller/VouchingFlowController.php
+++ b/service-front/module/Application/src/Controller/VouchingFlowController.php
@@ -40,8 +40,9 @@ class VouchingFlowController extends AbstractActionController
             $formData = $this->getRequest()->getPost();
 
             if (isset($formData['tryDifferent'])) {
+                // start the donor journey instead
                 return $this->redirect()->toUrl(
-                    "/start?personType=donor&lpas[]=" . implode("lpas[]=", $details_data['lpas'])
+                    "/start?personType=donor&lpas[]=" . implode("&lpas[]=", $details_data['lpas'])
                 );
             }
 

--- a/service-front/module/Application/src/Controller/VouchingFlowController.php
+++ b/service-front/module/Application/src/Controller/VouchingFlowController.php
@@ -29,14 +29,24 @@ class VouchingFlowController extends AbstractActionController
         $details_data = $this->opgApiService->getDetailsData($uuid);
         $form = $this->createForm(ConfirmVouching::class);
 
-        $view->setVariable('vouching_for', $details_data["vouchingFor"]);
         $view->setVariable('details_data', $details_data);
+        /**
+         * @psalm-suppress InvalidArrayOffset
+         */
+        $view->setVariable('vouching_for', $details_data["vouchingFor"]);
         $view->setVariable('form', $form);
 
-        if ($this->getRequest()->isPost() && $form->isValid()) {
+        if ($this->getRequest()->isPost()) {
             $formData = $this->getRequest()->getPost();
-            if (isset($formData['eligibility']) && isset($formData['declaration'])) {
-                // will need to update to route to vouching how-will-you-confirm page
+
+            if (isset($formData['try_different'])) {
+                return $this->redirect()->toUrl(
+                    "/start?personType=donor&lpas[]=" . implode("lpas[]=", $details_data['lpas'])
+                );
+            }
+
+            if ($form->isValid()) {
+                // will need to update to route for vouching how-will-you-confirm page once built
                 return $this->redirect()->toRoute("root/confirm_vouching", ['uuid' => $uuid]);
             }
         }

--- a/service-front/module/Application/src/Controller/VouchingFlowController.php
+++ b/service-front/module/Application/src/Controller/VouchingFlowController.php
@@ -26,10 +26,11 @@ class VouchingFlowController extends AbstractActionController
     {
         $view = new ViewModel();
         $uuid = $this->params()->fromRoute("uuid");
-        $donor_details = $this->opgApiService->getDetailsData($uuid);
+        $details_data = $this->opgApiService->getDetailsData($uuid);
         $form = $this->createForm(ConfirmVouching::class);
 
-        $view->setVariable('details_data', $donor_details);
+        $view->setVariable('vouching_for', $details_data["vouchingFor"]);
+        $view->setVariable('details_data', $details_data);
         $view->setVariable('form', $form);
 
         if ($this->getRequest()->isPost() && $form->isValid()) {

--- a/service-front/module/Application/src/Forms/ConfirmVouching.php
+++ b/service-front/module/Application/src/Forms/ConfirmVouching.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Forms;
+
+use Laminas\Form\Annotation;
+use Laminas\Hydrator\ObjectPropertyHydrator;
+use Laminas\Validator\NotEmpty;
+
+/**
+ * @psalm-suppress MissingConstructor
+ * @implements FormTemplate<array{
+ *   reason: string,
+ *   notes: string,
+ * }>
+ */
+#[Annotation\Hydrator(ObjectPropertyHydrator::class)]
+class ConfirmVouching implements FormTemplate
+{
+     /**
+     * @psalm-suppress PossiblyUnusedProperty
+     */
+    #[Annotation\Validator(NotEmpty::class, options: [
+        "messages" => [
+            NotEmpty::IS_EMPTY  => "Confirm eligibility to continue"
+        ]
+    ])]
+    public mixed $eligibility = null;
+
+    /**
+     * @psalm-suppress PossiblyUnusedProperty
+     */
+    #[Annotation\Validator(NotEmpty::class, options: [
+        "messages" => [
+            NotEmpty::IS_EMPTY  => "Confirm declaration to continue"
+        ]
+    ])]
+    public mixed $declaration = null;
+}

--- a/service-front/module/Application/src/Forms/ConfirmVouching.php
+++ b/service-front/module/Application/src/Forms/ConfirmVouching.php
@@ -37,4 +37,14 @@ class ConfirmVouching implements FormTemplate
         ]
     ])]
     public mixed $declaration = null;
+
+    /**
+     * @psalm-suppress PossiblyUnusedProperty
+     */
+    public mixed $continue = null;
+
+    /**
+     * @psalm-suppress PossiblyUnusedProperty
+     */
+    public mixed $tryDifferent = null;
 }

--- a/service-front/module/Application/src/Services/OpgApiService.php
+++ b/service-front/module/Application/src/Services/OpgApiService.php
@@ -170,16 +170,31 @@ class OpgApiService implements OpgApiServiceInterface
         string $personType,
         array $lpas,
         array $address,
-    ): array {
+     ): array {
 
-        $data = [
-            'firstName' => $firstname,
-            'lastName' => $lastname,
-            'dob' => $dob,
-            'personType' => $personType,
-            'lpas' => $lpas,
-            'address' => $address,
-        ];
+        if ($personType == 'voucher') {
+            $data = [
+                // 'firstName' => 'firstname',
+                // 'lastName' => 'lastname',
+                // 'dob' => '0000-00-00',
+                // 'address' => [],
+                'personType' => $personType,
+                'lpas' => $lpas,
+                'vouchingFor' => [
+                    'firstName' => $firstname,
+                    'lastName' => $lastname,
+                ]
+            ];
+        } else {
+            $data = [
+                'firstName' => $firstname,
+                'lastName' => $lastname,
+                'dob' => $dob,
+                'personType' => $personType,
+                'lpas' => $lpas,
+                'address' => $address,
+            ];
+        }
 
         return $this->makeApiRequest("/cases/create", 'POST', $data);
     }

--- a/service-front/module/Application/src/Services/OpgApiService.php
+++ b/service-front/module/Application/src/Services/OpgApiService.php
@@ -73,7 +73,9 @@ class OpgApiService implements OpgApiServiceInterface
     {
         try {
             $response = $this->makeApiRequest('/identity/details?uuid=' . $uuid);
-            $response['address'] = (new AddressProcessorHelper())->getAddress($response['address']);
+            if ($response['address']) {
+                $response['address'] = (new AddressProcessorHelper())->getAddress($response['address']);
+            }
             if (
                 array_key_exists('alternateAddress', $response) &&
                 ! empty($response['alternateAddress'])

--- a/service-front/module/Application/src/Services/OpgApiService.php
+++ b/service-front/module/Application/src/Services/OpgApiService.php
@@ -172,14 +172,10 @@ class OpgApiService implements OpgApiServiceInterface
         string $personType,
         array $lpas,
         array $address,
-     ): array {
+    ): array {
 
         if ($personType == 'voucher') {
             $data = [
-                // 'firstName' => 'firstname',
-                // 'lastName' => 'lastname',
-                // 'dob' => '0000-00-00',
-                // 'address' => [],
                 'personType' => $personType,
                 'lpas' => $lpas,
                 'vouchingFor' => [

--- a/service-front/module/Application/test/Controller/VouchingFlowControllerTest.php
+++ b/service-front/module/Application/test/Controller/VouchingFlowControllerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Controller;
+
+use Application\Contracts\OpgApiServiceInterface;
+use Application\Controller\VouchingFlowController;
+use Application\Helpers\DependencyCheck;
+use Application\Helpers\FormProcessorHelper;
+use Application\PostOffice\Country;
+use Application\PostOffice\DocumentType;
+use Application\PostOffice\DocumentTypeRepository;
+use Application\Services\SiriusApiService;
+use Laminas\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class VouchingFlowControllerTest extends AbstractHttpControllerTestCase
+{
+    private OpgApiServiceInterface&MockObject $opgApiServiceMock;
+    private string $uuid;
+
+    public function setUp(): void
+    {
+        $this->setApplicationConfig(include __DIR__ . '/../../../../config/application.config.php');
+
+        $this->uuid = '49895f88-501b-4491-8381-e8aeeaef177d';
+
+        $this->opgApiServiceMock = $this->createMock(OpgApiServiceInterface::class);
+
+        parent::setUp();
+
+        $serviceManager = $this->getApplicationServiceLocator();
+        $serviceManager->setAllowOverride(true);
+        $serviceManager->setService(OpgApiServiceInterface::class, $this->opgApiServiceMock);
+    }
+
+    public function returnOpgResponseData(): array
+    {
+        return [
+            "id" => "49895f88-501b-4491-8381-e8aeeaef177d",
+            "personType" => "voucher",
+            "firstName" => null,
+            "lastName" => null,
+            "dob" => null,
+            "address" => [],
+            "vouchingFor" => [
+                "firstName" => "firstName",
+                "lastName" => "lastName",
+            ],
+            "lpas" => [
+                "M-XYXY-YAGA-35G3",
+            ],
+            "documentComplete" => false,
+            "alternateAddress" => [
+            ],
+            "selectedPostOffice" => null,
+            "searchPostcode" => null,
+            "idMethod" => "nin",
+            "yotiSessionId" => "00000000-0000-0000-0000-000000000000",
+            "idMethodIncludingNation" => [
+                "id_country" => "AUT",
+                "id_method" => "DRIVING_LICENCE",
+                'id_route' => 'POST_OFFICE'
+            ]
+        ];
+    }
+
+    public function testConfirmVouchingWithData(): void
+    {
+        $mockResponseDataIdDetails = $this->returnOpgResponseData();
+
+        $this
+            ->opgApiServiceMock
+            ->expects(self::once())
+            ->method('getDetailsData')
+            ->with($this->uuid)
+            ->willReturn($mockResponseDataIdDetails);
+
+        $this->dispatch("/$this->uuid/vouching/confirm-vouching", 'GET');
+        $this->assertResponseStatusCode(200);
+        $this->assertModuleName('application');
+        $this->assertControllerName(VouchingFlowController::class);
+        $this->assertControllerClass('VouchingFlowController');
+        $this->assertMatchedRouteName('root/confirm_vouching');
+    }
+
+    public function testConfirmVouchingWithError(): void
+    {
+        $mockResponseDataIdDetails = $this->returnOpgResponseData();
+
+        $this
+            ->opgApiServiceMock
+            ->expects(self::once())
+            ->method('getDetailsData')
+            ->with($this->uuid)
+            ->willReturn($mockResponseDataIdDetails);
+
+        $this->dispatch("/$this->uuid/vouching/confirm-vouching", 'POST', []);
+        $this->assertResponseStatusCode(200);
+        $this->assertModuleName('application');
+        $this->assertControllerName(VouchingFlowController::class);
+        $this->assertControllerClass('VouchingFlowController');
+        $this->assertMatchedRouteName('root/confirm_vouching');
+
+        $response = $this->getResponse()->getContent();
+        $this->assertStringContainsString('Confirm eligibility to continue', $response);
+        $this->assertStringContainsString('Confirm declaration to continue', $response);
+    }
+
+    public function testConfirmVouchingWithSuccess(): void
+    {
+        $mockResponseDataIdDetails = $this->returnOpgResponseData();
+
+        $this
+            ->opgApiServiceMock
+            ->expects(self::once())
+            ->method('getDetailsData')
+            ->with($this->uuid)
+            ->willReturn($mockResponseDataIdDetails);
+
+        $this->dispatch("/$this->uuid/vouching/confirm-vouching", 'POST', [
+            'eligibility' => "eligibility_confirmed",
+            'declaration' => "declaration_confirmed"
+        ]);
+        $this->assertResponseStatusCode(302);
+        $this->assertRedirectTo(sprintf('/%s/vouching/confirm-vouching', $this->uuid));
+    }
+
+    public function testConfirmVouchingTryDifferentRoute(): void
+    {
+        $mockResponseDataIdDetails = $this->returnOpgResponseData();
+
+        $this
+            ->opgApiServiceMock
+            ->expects(self::once())
+            ->method('getDetailsData')
+            ->with($this->uuid)
+            ->willReturn($mockResponseDataIdDetails);
+
+        $this->dispatch("/$this->uuid/vouching/confirm-vouching", 'POST', [
+            'tryDifferent' => "Try a different method",
+        ]);
+        $this->assertResponseStatusCode(302);
+        $this->assertRedirectTo("/start?personType=donor&lpas%5B%5D=M-XYXY-YAGA-35G3");
+    }
+}

--- a/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
+++ b/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
@@ -79,7 +79,7 @@
         <br>
         <div class="govuk-button-group">
             <input type="submit" class="govuk-button" value="Continue with vouching" name="continue">
-            <input type="submit" class="govuk-button govuk-button--secondary" value="Try a different method" name="tryDifferent">
+            <input type="submit" class="govuk-button govuk-button--secondary" value="Donor will ID another way" name="tryDifferent">
         </div>
     </form>
 {% endblock %}

--- a/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
+++ b/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
@@ -79,7 +79,7 @@
         <br>
         <div class="govuk-button-group">
             <input type="submit" class="govuk-button" value="Continue with vouching" name="continue">
-            <input type="submit" class="govuk-button govuk-button--secondary" value="Try a different method" name="try_different">
+            <input type="submit" class="govuk-button govuk-button--secondary" value="Try a different method" name="tryDifferent">
         </div>
     </form>
 {% endblock %}

--- a/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
+++ b/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
@@ -1,12 +1,13 @@
 {% extends "layout/layout" %}
 
 {% block beforeMain %}
-    {% include 'layout/id_check_banner.twig' with details_data %}
+    <! –– key/values in vouching_for overwrite details_data ––>
+    {% include 'layout/id_check_banner.twig' with details_data|merge(vouching_for) %}
 {% endblock %}
 
 {% block content %}
     <div class="govuk-!-width-two-thirds">
-        <h1 class="govuk-heading-xl">{% block title %}Vouching for  {{ details_data.firstName }} {{ details_data.lastName}}{% endblock %}</h1>
+        <h1 class="govuk-heading-xl">{% block title %}Vouching for  {{ vouching_for.firstName }} {{ vouching_for.lastName}}{% endblock %}</h1>
         <p class="govuk-body govuk-!-margin-bottom-6">
             To vouch for the donor, the person vouching must have been asked by the donor to vouch. They will need to complete an identity check over the phone,
             or alternatively at the Post Office. They should have details of what is required in the letter passed to them by the donor.
@@ -68,7 +69,7 @@
                         <input class="govuk-checkboxes__input" id="declaration_confirmed" name="declaration" type="checkbox" value="declaration_confirmed"
                         {% if form.get('declaration').value == "declaration_confirmed" %}checked{% endif %}>
                         <label class="govuk-label govuk-checkboxes__label" for="declaration">
-                        To the best of your knowledge, the person who asked you to vouch for them is {{ details_data.firstName }} {{ details_data.lastName }}
+                        To the best of your knowledge, the person who asked you to vouch for them is {{ vouching_for.firstName }} {{ vouching_for.lastName }}
                         and you have known them for at least 2 years.
                         </label>
                     </div>

--- a/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
+++ b/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
@@ -1,0 +1,85 @@
+{% extends "layout/layout" %}
+
+{% block beforeMain %}
+    {% include 'layout/id_check_banner.twig' with details_data %}
+{% endblock %}
+
+{% block content %}
+    <div class="govuk-!-width-two-thirds">
+        <h1 class="govuk-heading-xl">{% block title %}Vouching for  {{ details_data.firstName }} {{ details_data.lastName}}{% endblock %}</h1>
+        <p class="govuk-body govuk-!-margin-bottom-6">
+            To vouch for the donor, the person vouching must have been asked by the donor to vouch. They will need to complete an identity check over the phone,
+            or alternatively at the Post Office. They should have details of what is required in the letter passed to them by the donor.
+        </p>
+    </div>
+    <form method="POST">
+        <div class="govuk-!-width-two-thirds">
+            <fieldset class="govuk-fieldset" aria-describedby="eligibility">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h2 class="govuk-fieldset__heading">
+                    Eligibility
+                </h2>
+                </legend>
+                <p class="govuk-body">Have them confirm the following:</p>
+
+                <div class="govuk-form-group {% if form.get('eligibility').messages %}govuk-form-group--error{% endif %}">
+
+                    {% if form.get('eligibility').messages %}
+                        <p id="eligibility-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span>
+                            {{ form.get('eligibility').messages | join(', ', ' and ') }}
+                        </p>
+                    {% endif %}
+
+                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                    <div class="govuk-checkboxes__item">
+                        <input class="govuk-checkboxes__input" id="eligibility_confirmed" name="eligibility" type="checkbox" value="eligibility_confirmed"
+                        {% if form.get('eligibility').value == "eligibility_confirmed" %}checked{% endif %}>
+                        <label class="govuk-label govuk-checkboxes__label" for="eligibility">
+                        They are not:
+                        <ul class="govuk-list govuk-list--bullet">
+                            <li>under the age of 18</li>
+                            <li>named on the LPA</li>
+                            <li>in a relationship with the donor</li>
+                            <li>a member of the donor's familiy</li>
+                            <li>living at the same address as the donor</li>
+                        </ul>
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
+            <fieldset class="govuk-fieldset" aria-describedby="declaration">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h2 class="govuk-fieldset__heading">
+                    Declaration
+                </h2>
+                </legend>
+                <p class="govuk-body">Have them confirm the following:</p>
+
+                <div class="govuk-form-group {% if form.get('declaration').messages %}govuk-form-group--error{% endif %}">
+                    {% if form.get('declaration').messages %}
+                        <p id="declaration-error" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span>
+                            {{ form.get('declaration').messages | join(', ', ' and ') }}
+                        </p>
+                    {% endif %}
+                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                    <div class="govuk-checkboxes__item">
+                        <input class="govuk-checkboxes__input" id="declaration_confirmed" name="declaration" type="checkbox" value="declaration_confirmed"
+                        {% if form.get('declaration').value == "declaration_confirmed" %}checked{% endif %}>
+                        <label class="govuk-label govuk-checkboxes__label" for="declaration">
+                        To the best of your knowledge, the person who asked you to vouch for them is {{ details_data.firstName }} {{ details_data.lastName }}
+                        and you have known them for at least 2 years.
+                        </label>
+                    </div>
+                </div>
+            </fieldset>
+        </div>
+        <br>
+        <div class="govuk-button-group">
+            <input type="submit" class="govuk-button" value="Continue with vouching">
+            <! –– might need to move this to the action method as this is meant to be take them to the appropriate "how-will-you-confirm" page based on previous actions ––>
+            <a href="#" type="submit" class="govuk-button govuk-button--secondary">Try a different method</a>
+        </div>
+    </form>
+{% endblock %}

--- a/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
+++ b/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
@@ -78,9 +78,8 @@
         </div>
         <br>
         <div class="govuk-button-group">
-            <input type="submit" class="govuk-button" value="Continue with vouching">
-            <! –– might need to move this to the action method as this is meant to be take them to the appropriate "how-will-you-confirm" page based on previous actions ––>
-            <a href="#" type="submit" class="govuk-button govuk-button--secondary">Try a different method</a>
+            <input type="submit" class="govuk-button" value="Continue with vouching" name="continue">
+            <input type="submit" class="govuk-button govuk-button--secondary" value="Try a different method" name="try_different">
         </div>
     </form>
 {% endblock %}

--- a/service-front/module/Application/view/layout/id_check_banner.twig
+++ b/service-front/module/Application/view/layout/id_check_banner.twig
@@ -2,11 +2,14 @@
     <div class="moj-identity-bar">
         <div class="moj-identity-bar__container">
             <div class="moj-identity-bar__details">
-                <span class="moj-identity-bar__title">Identity Check: <b>{{ details_data.firstName }} {{ details_data.lastName }}</b>
+                <span class="moj-identity-bar__title">Identity Check: <b>{{ firstName }} {{ lastName }}</b>
                     {% if details_data.personType == 'certificateProvider' %}
                         (certificate provider)
                     {% else %}
                         (donor)
+                        {% if details_data.personType == 'voucher'%}
+                            <strong class="govuk-tag govuk-!-margin-left-2">vouching route</strong>
+                        {% endif %}
                     {% endif %}
                 </span>
             </div>


### PR DESCRIPTION
## Purpose

Create the start of the vouching route with the "confirm vouching" page

Fixes [ID-265](https://opgtransform.atlassian.net/browse/ID-265)

## Approach

Setup a `VouchingFlowController` and allow for a new personType (voucher). When the process is started with `personType === voucher` then you are directed to the "confirm vouching" page.

Have added a `vouchingFor` field to `CaseData` which is populated with the name of the donor linked to the LPA. I also needed to make the fields associated with the donor in the other journeys (dob, name, address) non-required, defaulting to null/empty as this is info which will be provided by the voucher later in the vouching journey. This has had some knock on impacts on some validation checks and tests.

## Learning

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes


[ID-265]: https://opgtransform.atlassian.net/browse/ID-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ