### PR TITLE
Bugfix/id 423 cp address lookup remote envs

### DIFF
--- a/service-front/module/Application/src/Controller/CPFlowController.php
+++ b/service-front/module/Application/src/Controller/CPFlowController.php
@@ -7,6 +7,7 @@ namespace Application\Controller;
 use Application\Contracts\OpgApiServiceInterface;
 use Application\Controller\Trait\FormBuilder;
 use Application\Enums\LpaTypes;
+use Application\Exceptions\PostcodeInvalidException;
 use Application\Forms\AddressJson;
 use Application\Forms\BirthDate;
 use Application\Forms\ConfirmAddress;
@@ -41,6 +42,7 @@ class CPFlowController extends AbstractActionController
     use FormBuilder;
 
     protected $plugins;
+    private const ERROR_POSTCODE_NOT_FOUND = 'The entered postcode could not be found. Please try a valid postcode.';
 
     public function __construct(
         private readonly OpgApiServiceInterface $opgApiService,
@@ -493,13 +495,27 @@ class CPFlowController extends AbstractActionController
         if ($this->getRequest()->isPost() && $form->isValid()) {
             $postcode = $this->formToArray($form)['postcode'];
 
-            return $this->redirect()->toRoute(
-                'root/cp_select_address',
-                [
-                    'uuid' => $uuid,
-                    'postcode' => $postcode,
-                ]
-            );
+            try {
+                $response = $this->siriusApiService->searchAddressesByPostcode($postcode, $this->getRequest());
+
+                if (empty($response)) {
+                    $form->setMessages([
+                        'postcode' => [self::ERROR_POSTCODE_NOT_FOUND],
+                    ]);
+                } else {
+                    return $this->redirect()->toRoute(
+                        'root/cp_select_address',
+                        [
+                            'uuid' => $uuid,
+                            'postcode' => $postcode,
+                        ]
+                    );
+                }
+            } catch (PostcodeInvalidException $e) {
+                $form->setMessages([
+                    'postcode' => [self::ERROR_POSTCODE_NOT_FOUND],
+                ]);
+            }
         }
 
         return $view->setTemplate('application/pages/cp/enter_address');

--- a/service-front/module/Application/src/Controller/CPFlowController.php
+++ b/service-front/module/Application/src/Controller/CPFlowController.php
@@ -42,7 +42,7 @@ class CPFlowController extends AbstractActionController
     use FormBuilder;
 
     protected $plugins;
-    private const ERROR_POSTCODE_NOT_FOUND = 'The entered postcode could not be found. Please try a valid postcode.';
+    public const ERROR_POSTCODE_NOT_FOUND = 'The entered postcode could not be found. Please try a valid postcode.';
 
     public function __construct(
         private readonly OpgApiServiceInterface $opgApiService,

--- a/service-front/module/Application/src/Exceptions/PostcodeInvalidException.php
+++ b/service-front/module/Application/src/Exceptions/PostcodeInvalidException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Exceptions;
+
+class PostcodeInvalidException extends \Exception
+{
+}

--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Application\Services;
 
+use Application\Exceptions\PostcodeInvalidException;
 use Application\Helpers\AddressProcessorHelper;
 use Application\Enums\SiriusDocument;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use Laminas\Http\Header\Cookie;
-use Laminas\Http\Header\Exception\RuntimeException;
 use Laminas\Http\Request;
 use Laminas\Stdlib\RequestInterface;
+use GuzzleHttp\Exception\ClientException;
 
 /**
  * @psalm-type Address = array{
@@ -131,9 +132,17 @@ class SiriusApiService
      */
     public function searchAddressesByPostcode(string $postcode, Request $request): array
     {
-        $response = $this->client->get('/api/v1/postcode-lookup?postcode=' . $postcode, [
-            'headers' => $this->getAuthHeaders($request),
-        ]);
+        try{
+            $response = $this->client->get('/api/v1/postcode-lookup?postcode=' . $postcode, [
+                'headers' => $this->getAuthHeaders($request)
+            ]);
+        } catch (ClientException $e) {
+            if ($e->getResponse()->getStatusCode() === 400) {
+                throw new PostcodeInvalidException(`Bad Request error returned from postcode lookup: ${e->getMessage()}`);
+            }
+
+            throw $e;
+        }
 
         return json_decode(strval($response->getBody()), true);
     }

--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -132,13 +132,14 @@ class SiriusApiService
      */
     public function searchAddressesByPostcode(string $postcode, Request $request): array
     {
-        try{
+        try {
             $response = $this->client->get('/api/v1/postcode-lookup?postcode=' . $postcode, [
                 'headers' => $this->getAuthHeaders($request)
             ]);
         } catch (ClientException $e) {
             if ($e->getResponse()->getStatusCode() === 400) {
-                throw new PostcodeInvalidException(sprintf('Bad Request error returned from postcode lookup: %s', $e->getMessage()));
+                $errorMessage = sprintf('Bad Request error returned from postcode lookup: %s', $e->getMessage());
+                throw new PostcodeInvalidException($errorMessage);
             }
 
             throw $e;

--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -138,7 +138,7 @@ class SiriusApiService
             ]);
         } catch (ClientException $e) {
             if ($e->getResponse()->getStatusCode() === 400) {
-                throw new PostcodeInvalidException(`Bad Request error returned from postcode lookup: ${e->getMessage()}`);
+                throw new PostcodeInvalidException(sprintf('Bad Request error returned from postcode lookup: %s', $e->getMessage()));
             }
 
             throw $e;

--- a/service-front/module/Application/test/Services/SiriusApiServiceTest.php
+++ b/service-front/module/Application/test/Services/SiriusApiServiceTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace ApplicationTest\Services;
 
+use Application\Exceptions\PostcodeInvalidException;
 use Application\Services\SiriusApiService;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Psr7\Response;
 use Laminas\Http\Headers;
 use Laminas\Http\Request;
 use PHPUnit\Framework\TestCase;
@@ -98,5 +101,99 @@ class SiriusApiServiceTest extends TestCase
 
         $ret = $sut->checkAuth($request);
         $this->assertFalse($ret);
+    }
+
+    public function testSearchAddressesByPostcodeSuccess(): void
+    {
+        $clientMock = $this->createMock(Client::class);
+        $sut = new SiriusApiService($clientMock);
+
+        $request = new Request();
+        $headers = $request->getHeaders();
+        assert($headers instanceof Headers);
+        $headers->addHeaderLine("cookie", "mycookie=1; XSRF-TOKEN=abcd");
+
+        $responseBody = json_encode([
+            [
+                'addressLine1' => '10 Downing Street',
+                'addressLine2' => '',
+                'addressLine3' => '',
+                'town' => 'London',
+                'postcode' => 'SW1A 2AA',
+            ],
+        ]);
+
+        $clientMock
+            ->expects($this->once())
+            ->method("get")
+            ->with('/api/v1/postcode-lookup?postcode=SW1A2AA', [
+                'headers' => [
+                    'Cookie' => 'mycookie=1; XSRF-TOKEN=abcd',
+                    'X-XSRF-TOKEN' => 'abcd',
+                ],
+            ])
+            ->willReturn(new Response(200, [], $responseBody));
+
+        $result = $sut->searchAddressesByPostcode('SW1A2AA', $request);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('10 Downing Street', $result[0]['addressLine1']);
+    }
+
+    public function testSearchAddressesByPostcodeThrowsPostcodeInvalidException(): void
+    {
+        $clientMock = $this->createMock(Client::class);
+        $sut = new SiriusApiService($clientMock);
+
+        $request = new Request();
+        $headers = $request->getHeaders();
+        assert($headers instanceof Headers);
+        $headers->addHeaderLine("cookie", "mycookie=1; XSRF-TOKEN=abcd");
+
+        $exception = $this->createMock(ClientException::class);
+        $exception
+            ->method('getResponse')
+            ->willReturn(new Response(400));
+
+        $clientMock
+            ->expects($this->once())
+            ->method("get")
+            ->with('/api/v1/postcode-lookup?postcode=INVALID', [
+                'headers' => [
+                    'Cookie' => 'mycookie=1; XSRF-TOKEN=abcd',
+                    'X-XSRF-TOKEN' => 'abcd',
+                ],
+            ])
+            ->willThrowException($exception);
+
+        $this->expectException(PostcodeInvalidException::class);
+        $sut->searchAddressesByPostcode('INVALID', $request);
+    }
+
+    public function testSearchAddressesByPostcodeThrowsGenericException(): void
+    {
+        $clientMock = $this->createMock(Client::class);
+        $sut = new SiriusApiService($clientMock);
+
+        $request = new Request();
+        $headers = $request->getHeaders();
+        assert($headers instanceof Headers);
+        $headers->addHeaderLine("cookie", "mycookie=1; XSRF-TOKEN=abcd");
+
+        $exception = $this->createMock(GuzzleException::class);
+
+        $clientMock
+            ->expects($this->once())
+            ->method("get")
+            ->with('/api/v1/postcode-lookup?postcode=SW1A2AA', [
+                'headers' => [
+                    'Cookie' => 'mycookie=1; XSRF-TOKEN=abcd',
+                    'X-XSRF-TOKEN' => 'abcd',
+                ],
+            ])
+            ->willThrowException($exception);
+
+        $this->expectException(GuzzleException::class);
+        $sut->searchAddressesByPostcode('SW1A2AA', $request);
     }
 }

--- a/service-front/module/Application/view/application/pages/cp/select_address.twig
+++ b/service-front/module/Application/view/application/pages/cp/select_address.twig
@@ -10,7 +10,7 @@
             What is the address on the ID document?
         {% endblock %}
     </h1>
-    <form method="POST" action="./select-address">
+    <form method="POST">
         <div class="govuk-form-group {% if form.get('address_json').messages %}govuk-form-group--error{% endif %}">
 
             {% if form.get('address_json').messages %}


### PR DESCRIPTION
## Purpose

https://opgtransform.atlassian.net/browse/ID-423

Fixes 

On remote environments:

If you enter a non-existent invalid postcode, you get a “there was a problem with this service” error page rather than a helpful error message

After selecting an address, you also get a “there was a problem with this service” error page

## Approach

Added postcode check (using postcode lookup) to enter postcode page to ensure that the postcode exists and display an error if it does not. It will not proceed to the next screen if the postcode does not return any results or the response is a 400 error.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have added tests to prove my work
* [ ] The team have tested these changes
