### PR TITLE
Specify PHP version

### DIFF
--- a/service-api/composer.json
+++ b/service-api/composer.json
@@ -14,7 +14,7 @@
         "paper-id-api"
     ],
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-apcu": "*",
         "ext-openssl": "*",
         "ext-soap": "*",
@@ -95,6 +95,7 @@
             "tbachert/spi": false
         },
         "platform": {
+            "php": "8.3",
             "ext-apcu": "5.1.10"
         }
     }

--- a/service-api/composer.lock
+++ b/service-api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3091841d0b9b873906a3d919de6fc5f",
+    "content-hash": "ea23d08fcdfa7642bc465ac1a584d17f",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -8114,6 +8114,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
+        "php": "8.3",
         "ext-apcu": "5.1.10"
     },
     "plugin-api-version": "2.6.0"

--- a/service-front/composer.json
+++ b/service-front/composer.json
@@ -10,7 +10,7 @@
         "framework"
     ],
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "guzzlehttp/guzzle": "^7.8",
         "laminas/laminas-cli": "^1.8.0",
         "laminas/laminas-component-installer": "^3.4.0",
@@ -92,6 +92,9 @@
             "pact-foundation/composer-downloads-plugin": true,
             "php-http/discovery": false,
             "tbachert/spi": false
+        },
+        "platform": {
+            "php": "8.3"
         }
     }
 }

--- a/service-front/composer.lock
+++ b/service-front/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03071e05298b1cfd8a9459fed53b7ab0",
+    "content-hash": "6a674ab3bf64612b0524e6b464bb5771",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -10056,5 +10056,8 @@
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.3"
+    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
To ensure Renovate runs dependency checks against the correct version (rather than defaulting to latest, which doesn't work).

#patch