### PR TITLE
Don't upgrade PHP in packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,9 @@
         "PHP Exclusion",
         "Don't try to upgrade php to v8.4, since it isn't yet supported by many of our libraries"
       ],
-      "matchDatasources": [
-        "docker"
+      "matchManagers": [
+        "dockerfile",
+        "composer"
       ],
       "matchDepNames": [
         "php"


### PR DESCRIPTION
Otherwise, Renovate still tries to upgrade PHP when doing a Composer dependency update, which will always fail.

#patch
