### PR TITLE
Properly handle IIQ thin file errors

### DIFF
--- a/docker/experian-iiq/iiq-response.js
+++ b/docker/experian-iiq/iiq-response.js
@@ -38,7 +38,7 @@ const saaEnvelopeNoKbv = `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/s
         <Results>
           <Outcome>Insufficient Questions (Unable to Authenticate)</Outcome>
           <NextTransId>
-            <string>RTQ</string>
+            <string>END</string>
           </NextTransId>
         </Results>
       </SAAResult>

--- a/service-api/module/Application/test/ApplicationTest/Experian/IIQ/IIQServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Experian/IIQ/IIQServiceTest.php
@@ -130,6 +130,37 @@ class IIQServiceTest extends TestCase
         $this->assertEquals('1234', $response['control']['AuthRefNo']);
     }
 
+    public function testStartAuthenticationAttemptFailure(): void
+    {
+        $this->authManager->expects($this->once())
+            ->method('buildSecurityHeader')
+            ->willReturn(new SoapHeader('placeholder', 'header'));
+
+
+        $this->iiqClient->expects($this->once())
+            ->method('__call')
+            ->willReturn((object)[
+                'SAAResult' => (object)[
+                    'Control' => (object)[
+                        'URN' => 'abcd',
+                        'AuthRefNo' => '1234',
+                    ],
+                    'Results' => (object)[
+                        'Outcome' => 'Insufficient Questions (Unable to Authenticate)',
+                        'NextTransId' => (object)[
+                            'string' => 'END',
+                        ],
+                    ],
+                ],
+            ]);
+
+        $response = $this->sut->startAuthenticationAttempt($this->getSaaRequest());
+
+        $this->assertEquals([], $response['questions']);
+        $this->assertEquals('abcd', $response['control']['URN']);
+        $this->assertEquals('1234', $response['control']['AuthRefNo']);
+    }
+
     public function testStartAuthenticationAttemptsOneRetry(): void
     {
         $soapFault = new SoapFault('0', 'Unauthorized');

--- a/service-front/module/Application/src/Helpers/FormProcessorHelper.php
+++ b/service-front/module/Application/src/Helpers/FormProcessorHelper.php
@@ -9,12 +9,10 @@ use Application\Exceptions\OpgApiException;
 use Application\Helpers\DTO\FormProcessorResponseDto;
 use Laminas\Form\FormInterface;
 use Laminas\Stdlib\Parameters;
-use Psr\Log\LoggerInterface;
 
 class FormProcessorHelper
 {
     public function __construct(
-        private LoggerInterface $logger,
         private OpgApiServiceInterface $opgApiService
     ) {
     }
@@ -249,10 +247,6 @@ class FormProcessorHelper
                 $template = $templates['thin_file'];
                 break;
             default:
-                $this->logger->error('Fraud check response', [
-                    'response' => json_encode($fraudCheck),
-                ]);
-
                 throw new OpgApiException('Unknown response received from fraud check service');
         }
         return $template;

--- a/service-front/module/Application/test/Helpers/FormProcessorHelperTest.php
+++ b/service-front/module/Application/test/Helpers/FormProcessorHelperTest.php
@@ -15,7 +15,6 @@ use Laminas\Form\Annotation\AttributeBuilder;
 use Laminas\Form\FormInterface;
 use Laminas\Stdlib\Parameters;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 
 class FormProcessorHelperTest extends TestCase
 {
@@ -29,9 +28,8 @@ class FormProcessorHelperTest extends TestCase
         FormInterface $form,
         array $templates,
     ): void {
-        $loggerMock = $this->createMock(LoggerInterface::class);
         $opgApiServiceMock = $this->createMock(OpgApiService::class);
-        $formProcessorHelper = new FormProcessorHelper($loggerMock, $opgApiServiceMock);
+        $formProcessorHelper = new FormProcessorHelper($opgApiServiceMock);
 
         $form->setData($formData);
 
@@ -116,9 +114,8 @@ class FormProcessorHelperTest extends TestCase
         array $templates,
         string $template,
     ): void {
-        $loggerMock = $this->createMock(LoggerInterface::class);
         $opgApiServiceMock = $this->createMock(OpgApiService::class);
-        $formProcessorHelper = new FormProcessorHelper($loggerMock, $opgApiServiceMock);
+        $formProcessorHelper = new FormProcessorHelper($opgApiServiceMock);
 
         $form->setData($formData);
 
@@ -205,9 +202,8 @@ class FormProcessorHelperTest extends TestCase
         array $templates,
         string $template,
     ): void {
-        $loggerMock = $this->createMock(LoggerInterface::class);
         $opgApiServiceMock = $this->createMock(OpgApiService::class);
-        $formProcessorHelper = new FormProcessorHelper($loggerMock, $opgApiServiceMock);
+        $formProcessorHelper = new FormProcessorHelper($opgApiServiceMock);
 
         $form->setData($formData);
 
@@ -294,9 +290,8 @@ class FormProcessorHelperTest extends TestCase
         string $template,
         bool $validDate,
     ): void {
-        $loggerMock = $this->createMock(LoggerInterface::class);
         $opgApiServiceMock = $this->createMock(OpgApiService::class);
-        $formProcessorHelper = new FormProcessorHelper($loggerMock, $opgApiServiceMock);
+        $formProcessorHelper = new FormProcessorHelper($opgApiServiceMock);
 
         $processed = $formProcessorHelper->processPassportDateForm($caseUuid, $formData, $form, $templates);
 
@@ -373,9 +368,8 @@ class FormProcessorHelperTest extends TestCase
      */
     public function testprocessDateForm(array $params, string $expected): void
     {
-        $loggerMock = $this->createMock(LoggerInterface::class);
         $opgApiServiceMock = $this->createMock(OpgApiService::class);
-        $formProcessorHelper = new FormProcessorHelper($loggerMock, $opgApiServiceMock);
+        $formProcessorHelper = new FormProcessorHelper($opgApiServiceMock);
 
         $actual = $formProcessorHelper->processDateForm($params);
 
@@ -432,9 +426,8 @@ class FormProcessorHelperTest extends TestCase
         if ($exception) {
             $this->expectException(OpgApiException::class);
         }
-        $loggerMock = $this->createMock(LoggerInterface::class);
         $opgApiServiceMock = $this->createMock(OpgApiService::class);
-        $formProcessorHelper = new FormProcessorHelper($loggerMock, $opgApiServiceMock);
+        $formProcessorHelper = new FormProcessorHelper($opgApiServiceMock);
 
         $actual = $formProcessorHelper->processTemplate($fraudCheck, $templates);
 


### PR DESCRIPTION
   
Previously, thin file errors caused generic failure message because `NextTransId` was always expected to be "RTQ". This now handles the two expected outcomes explicitly, and logs a more detailed error message if they're not met.
    
Also update the IIQ mock to return a representative response, and remove some debug logging added to FormProcessorHelper that isn't needed any more.
    
Fixes ID-458 #patch