### PR TITLE
Feature/id 426/replacement attorney source/#patch

### DIFF
--- a/docker/sirius/data/certificateProvider.json
+++ b/docker/sirius/data/certificateProvider.json
@@ -4,6 +4,7 @@
       {
         "dateOfBirth": "1917-04-22",
         "status": "removed",
+        "appointmentType": "original",
         "channel": "paper",
         "uid": "3171d3d4-0404-b83e-6f63-c207a3edea6f",
         "firstNames": "Keyon",

--- a/docker/sirius/data/certificateProviderNoDecision.json
+++ b/docker/sirius/data/certificateProviderNoDecision.json
@@ -4,6 +4,7 @@
       {
         "dateOfBirth": "1917-04-22",
         "status": "removed",
+        "appointmentType": "original",
         "channel": "paper",
         "uid": "3171d3d4-0404-b83e-6f63-c207a3edea6f",
         "firstNames": "Keyon",

--- a/docker/sirius/data/certificateProviderNoDecisionKBV.json
+++ b/docker/sirius/data/certificateProviderNoDecisionKBV.json
@@ -4,6 +4,7 @@
       {
         "dateOfBirth": "1917-04-22",
         "status": "removed",
+        "appointmentType": "original",
         "channel": "paper",
         "uid": "3171d3d4-0404-b83e-6f63-c207a3edea6f",
         "firstNames": "Keyon",

--- a/docker/sirius/data/certificateProviderStop.json
+++ b/docker/sirius/data/certificateProviderStop.json
@@ -4,6 +4,7 @@
       {
         "dateOfBirth": "1917-04-22",
         "status": "removed",
+        "appointmentType": "original",
         "channel": "paper",
         "uid": "3171d3d4-0404-b83e-6f63-c207a3edea6f",
         "firstNames": "Keyon",

--- a/docker/sirius/data/donor.json
+++ b/docker/sirius/data/donor.json
@@ -4,6 +4,7 @@
       {
         "dateOfBirth": "1960-09-18",
         "status": "active",
+        "appointmentType": "original",
         "channel": "online",
         "uid": "89121d57-1fb2-3bcb-b556-fe108b686bff",
         "firstNames": "Josephine",

--- a/docker/sirius/data/donorNoDecision.json
+++ b/docker/sirius/data/donorNoDecision.json
@@ -4,6 +4,7 @@
       {
         "dateOfBirth": "1960-09-18",
         "status": "active",
+        "appointmentType": "original",
         "channel": "online",
         "uid": "89121d57-1fb2-3bcb-b556-fe108b686bff",
         "firstNames": "Josephine",

--- a/docker/sirius/data/donorNoDecisionKBV.json
+++ b/docker/sirius/data/donorNoDecisionKBV.json
@@ -4,6 +4,7 @@
       {
         "dateOfBirth": "1960-09-18",
         "status": "active",
+        "appointmentType": "original",
         "channel": "online",
         "uid": "89121d57-1fb2-3bcb-b556-fe108b686bff",
         "firstNames": "Josephine",

--- a/docker/sirius/data/donorRefer.json
+++ b/docker/sirius/data/donorRefer.json
@@ -4,6 +4,7 @@
       {
         "dateOfBirth": "1960-09-18",
         "status": "active",
+        "appointmentType": "original",
         "channel": "online",
         "uid": "89121d57-1fb2-3bcb-b556-fe108b686bff",
         "firstNames": "Josephine",

--- a/docker/sirius/data/donorStop.json
+++ b/docker/sirius/data/donorStop.json
@@ -4,6 +4,7 @@
       {
         "dateOfBirth": "1960-09-18",
         "status": "active",
+        "appointmentType": "original",
         "channel": "online",
         "uid": "89121d57-1fb2-3bcb-b556-fe108b686bff",
         "firstNames": "Josephine",

--- a/service-front/module/Application/src/Helpers/VoucherMatchLpaActorHelper.php
+++ b/service-front/module/Application/src/Helpers/VoucherMatchLpaActorHelper.php
@@ -37,19 +37,19 @@ class VoucherMatchLpaActorHelper
                 "type" => LpaActorTypes::CP->value,
             ];
             foreach ($lpasData["opg.poas.lpastore"]["attorneys"] as $attorney) {
-                if (in_array($attorney["status"], ["active", "removed"])) {
-                    $actors[] = [
-                        "firstName" => $attorney["firstNames"],
-                        "lastName" => $attorney["lastName"],
-                        "dob" => $attorney["dateOfBirth"],
-                        "type" => LpaActorTypes::ATTORNEY->value,
-                    ];
-                } elseif ($attorney["status"] === "replacement") {
+                if ($attorney["appointmentType"] === "replacement") {
                     $actors[] = [
                         "firstName" => $attorney["firstNames"],
                         "lastName" => $attorney["lastName"],
                         "dob" => $attorney["dateOfBirth"],
                         "type" => LpaActorTypes::R_ATTORNEY->value,
+                    ];
+                } else {
+                    $actors[] = [
+                        "firstName" => $attorney["firstNames"],
+                        "lastName" => $attorney["lastName"],
+                        "dob" => $attorney["dateOfBirth"],
+                        "type" => LpaActorTypes::ATTORNEY->value,
                     ];
                 }
             }

--- a/service-front/module/Application/src/Helpers/VoucherMatchLpaActorHelper.php
+++ b/service-front/module/Application/src/Helpers/VoucherMatchLpaActorHelper.php
@@ -37,20 +37,22 @@ class VoucherMatchLpaActorHelper
                 "type" => LpaActorTypes::CP->value,
             ];
             foreach ($lpasData["opg.poas.lpastore"]["attorneys"] as $attorney) {
-                if ($attorney["appointmentType"] === "replacement") {
-                    $actors[] = [
-                        "firstName" => $attorney["firstNames"],
-                        "lastName" => $attorney["lastName"],
-                        "dob" => $attorney["dateOfBirth"],
-                        "type" => LpaActorTypes::R_ATTORNEY->value,
-                    ];
-                } else {
-                    $actors[] = [
-                        "firstName" => $attorney["firstNames"],
-                        "lastName" => $attorney["lastName"],
-                        "dob" => $attorney["dateOfBirth"],
-                        "type" => LpaActorTypes::ATTORNEY->value,
-                    ];
+                if ($attorney["status"] !== "removed") {
+                    if ($attorney["appointmentType"] === "replacement") {
+                        $actors[] = [
+                            "firstName" => $attorney["firstNames"],
+                            "lastName" => $attorney["lastName"],
+                            "dob" => $attorney["dateOfBirth"],
+                            "type" => LpaActorTypes::R_ATTORNEY->value,
+                        ];
+                    } else {
+                        $actors[] = [
+                            "firstName" => $attorney["firstNames"],
+                            "lastName" => $attorney["lastName"],
+                            "dob" => $attorney["dateOfBirth"],
+                            "type" => LpaActorTypes::ATTORNEY->value,
+                        ];
+                    }
                 }
             }
         } elseif (! empty($lpasData["opg.poas.sirius"])) {

--- a/service-front/module/Application/test/Helpers/VoucherMatchLpaActorHelperTest.php
+++ b/service-front/module/Application/test/Helpers/VoucherMatchLpaActorHelperTest.php
@@ -51,24 +51,35 @@ class VoucherMatchLpaActorHelperTest extends TestCase
             "attorneys" => [
                 [
                     "appointmentType" => "original",
+                    "status" => "active",
                     "firstNames" => "attorneyfirstname",
                     "lastName" => "attorneylastname",
                     "dateOfBirth" => "1980-01-05",
                 ],
                 [
                     "appointmentType" => "original",
+                    "status" => "removed",
+                    "firstNames" => "removedAttorney",
+                    "lastName" => "removedAttorney",
+                    "dateOfBirth" => "1980-01-01",
+                ],
+                [
+                    "appointmentType" => "original",
+                    "status" => "active",
                     "firstNames" => "attorneyfirstname",
                     "lastName" => "attorneylastname",
                     "dateOfBirth" => "1990-01-05",
                 ],
                 [
                     "appointmentType" => "original",
+                    "status" => "active",
                     "firstNames" => "differentAttorneyfirstname",
                     "lastName" => "differentAttorneylastname",
                     "dateOfBirth" => "1980-01-05",
                 ],
                 [
                     "appointmentType" => "replacement",
+                    "status" => "active",
                     "firstNames" => "replacementAttorneyfirstname",
                     "lastName" => "replacementAttorneylastname",
                     "dateOfBirth" => "1990-01-05",

--- a/service-front/module/Application/test/Helpers/VoucherMatchLpaActorHelperTest.php
+++ b/service-front/module/Application/test/Helpers/VoucherMatchLpaActorHelperTest.php
@@ -50,25 +50,25 @@ class VoucherMatchLpaActorHelperTest extends TestCase
             ],
             "attorneys" => [
                 [
-                    "status" => "active",
+                    "appointmentType" => "original",
                     "firstNames" => "attorneyfirstname",
                     "lastName" => "attorneylastname",
                     "dateOfBirth" => "1980-01-05",
                 ],
                 [
-                    "status" => "active",
+                    "appointmentType" => "original",
                     "firstNames" => "attorneyfirstname",
                     "lastName" => "attorneylastname",
                     "dateOfBirth" => "1990-01-05",
                 ],
                 [
-                    "status" => "active",
+                    "appointmentType" => "original",
                     "firstNames" => "differentAttorneyfirstname",
                     "lastName" => "differentAttorneylastname",
                     "dateOfBirth" => "1980-01-05",
                 ],
                 [
-                    "status" => "replacement",
+                    "appointmentType" => "replacement",
                     "firstNames" => "replacementAttorneyfirstname",
                     "lastName" => "replacementAttorneylastname",
                     "dateOfBirth" => "1990-01-05",


### PR DESCRIPTION
## Purpose

Change how replacement attorneys are identified and only check id-match on non-"removed" attorneys.

Fixes [ID-426](https://opgtransform.atlassian.net/browse/ID-426)

## Approach

_Explain how your code addresses the purpose of the change._

## Learning

_Any tips and tricks, blog posts or tools which helped you._

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
