### PR TITLE
Send event to Sirius when abandoning case

### DIFF
--- a/service-api/module/Application/config/module.config.php
+++ b/service-api/module/Application/config/module.config.php
@@ -461,6 +461,16 @@ return [
                     ],
                 ],
             ],
+            'abandon' => [
+                'type' => Segment::class,
+                'options' => [
+                    'route' => '/cases/:uuid/abandon',
+                    'defaults' => [
+                        'controller' => Controller\IdentityController::class,
+                        'action' => 'abandonCase',
+                    ],
+                ],
+            ],
         ],
     ],
     'controllers' => [

--- a/service-api/module/Application/test/Controller/IdentityControllerTest.php
+++ b/service-api/module/Application/test/Controller/IdentityControllerTest.php
@@ -11,15 +11,20 @@ use Application\Fixtures\DataQueryHandler;
 use Application\Fixtures\DataWriteHandler;
 use Application\Model\Entity\CaseData;
 use Application\Model\Entity\ClaimedIdentity;
+use Application\Sirius\EventSender;
 use Application\Yoti\SessionConfig;
 use Application\Yoti\YotiService;
 use Application\Yoti\YotiServiceInterface;
 use ApplicationTest\TestCase;
+use DateTimeImmutable;
+use Laminas\Cache\Storage\Event;
 use Laminas\Http\Headers;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Http\Response;
 use Laminas\Stdlib\ArrayUtils;
+use Lcobucci\Clock\FrozenClock;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Clock\ClockInterface;
 
 class IdentityControllerTest extends TestCase
 {
@@ -850,5 +855,74 @@ class IdentityControllerTest extends TestCase
                 $successMockResponseData,
             ],
         ];
+    }
+
+    public function testAbandonCaseAction(): void
+    {
+        $eventSenderMock = $this->createMock(EventSender::class);
+        $frozenClock = new FrozenClock(new DateTimeImmutable('2024-05-12T13:45:56Z'));
+        $serviceManager = $this->getApplicationServiceLocator();
+        $serviceManager->setAllowOverride(true);
+        $serviceManager->setService(EventSender::class, $eventSenderMock);
+        $serviceManager->setService(ClockInterface::class, $frozenClock);
+
+        $uuid = 'a9bc8ab8-389c-4367-8a9b-762ab3050999';
+
+        $caseData = CaseData::fromArray([
+            'id' => $uuid,
+            'personType' => 'donor',
+            'lpas' => [
+                'M-XYXY-YAGA-35G3',
+                'M-VGAS-OAGA-34G9',
+            ],
+        ]);
+
+        $this->dataQueryHandlerMock
+            ->expects($this->once())
+            ->method('getCaseByUUID')
+            ->with($uuid)
+            ->willReturn($caseData);
+
+        $eventSenderMock
+            ->expects($this->once())
+            ->method('send')
+            ->with(
+                'identity-check-resolved',
+                [
+                    'reference' => 'opg:' . $caseData->id,
+                    'actorType' => $caseData->personType,
+                    'lpaIds' => $caseData->lpas,
+                    'time' => '2024-05-12T13:45:56+00:00',
+                    'outcome' => 'exit',
+                ]
+            );
+
+        $this->dispatchJSON(
+            '/cases/' . $uuid . '/abandon',
+            'POST'
+        );
+
+        $this->assertResponseStatusCode(Response::STATUS_CODE_200);
+    }
+
+    public function testAbandonCaseActionWithMissingCase(): void
+    {
+        $uuid = 'a9bc8ab8-389c-4367-8a9b-762ab3050999';
+
+        $this->dataQueryHandlerMock
+            ->expects($this->once())
+            ->method('getCaseByUUID')
+            ->with($uuid)
+            ->willReturn(null);
+
+        $this->dispatchJSON(
+            '/cases/' . $uuid . '/abandon',
+            'POST'
+        );
+
+        $this->assertResponseStatusCode(Response::STATUS_CODE_404);
+        $body = json_decode($this->getResponse()->getContent(), true);
+
+        $this->assertEquals('Case not found', $body['title']);
     }
 }

--- a/service-api/module/Application/test/Controller/YotiControllerTest.php
+++ b/service-api/module/Application/test/Controller/YotiControllerTest.php
@@ -16,18 +16,18 @@ use ApplicationTest\TestCase;
 use Laminas\Http\Headers;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Stdlib\ArrayUtils;
+use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 
 class YotiControllerTest extends TestCase
 {
     private YotiService&MockObject $yotiServiceMock;
     private SessionStatusService&MockObject $statusService;
-
     private DataQueryHandler&MockObject $dataQueryHandlerMock;
-
     private DataWriteHandler&MockObject $dataHandler;
-
     private SessionConfig&MockObject $sessionConfigMock;
+    private LoggerInterface&MockObject $logger;
 
     public function setUp(): void
     {
@@ -47,7 +47,7 @@ class YotiControllerTest extends TestCase
         $this->dataQueryHandlerMock = $this->createMock(DataQueryHandler::class);
         $this->dataHandler = $this->createMock(DataWriteHandler::class);
         $this->sessionConfigMock = $this->createMock(SessionConfig::class);
-
+        $this->logger = $this->createMock(LoggerInterface::class);
 
         parent::setUp();
 
@@ -58,6 +58,7 @@ class YotiControllerTest extends TestCase
         $serviceManager->setService(SessionStatusService::class, $this->statusService);
         $serviceManager->setService(SessionConfig::class, $this->sessionConfigMock);
         $serviceManager->setService(DataWriteHandler::class, $this->dataHandler);
+        $serviceManager->setService(LoggerInterface::class, $this->logger);
     }
 
     public function testInvalidRouteDoesNotCrash(): void
@@ -246,6 +247,11 @@ class YotiControllerTest extends TestCase
 
         $this->dataHandler
             ->expects($this->never())->method('updateCaseData');
+
+        $this->logger
+            ->expects($this->once())
+            ->method('info')
+            ->with('Unauthorized notification for case: 2b45a8c1-dd35-47ef-a00e-c7b6264bf1cc: first_branch_visit');
 
         $this->dispatchJSON(
             '/counter-service/notification',

--- a/service-front/module/Application/config/module.config.php
+++ b/service-front/module/Application/config/module.config.php
@@ -8,7 +8,10 @@ use Application\Auth\Listener as AuthListener;
 use Application\Auth\ListenerFactory as AuthListenerFactory;
 use Application\Controller\Factory\CPFlowControllerFactory;
 use Application\Controller\Factory\DonorFlowControllerFactory;
+use Application\Controller\Factory\IndexControllerFactory;
 use Application\Controller\Factory\PostOfficeFlowControllerFactory;
+use Application\Controller\IndexController;
+use Application\Enums\IdMethod;
 use Application\Factories\LoggerFactory;
 use Application\Factories\OpgApiServiceFactory;
 use Application\Factories\SiriusApiServiceFactory;
@@ -18,7 +21,6 @@ use Application\Services\OpgApiService;
 use Application\Services\SiriusApiService;
 use Application\Views\TwigExtension;
 use Application\Views\TwigExtensionFactory;
-use Application\Enums\IdMethod;
 use Laminas\Mvc\Controller\LazyControllerAbstractFactory;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Segment;
@@ -658,7 +660,7 @@ return [
             Controller\CPFlowController::class => CPFlowControllerFactory::class,
             Controller\DonorFlowController::class => DonorFlowControllerFactory::class,
             Controller\VouchingFlowController::class => LazyControllerAbstractFactory::class,
-            Controller\IndexController::class => LazyControllerAbstractFactory::class,
+            Controller\IndexController::class => IndexControllerFactory::class,
             Controller\KbvController::class => LazyControllerAbstractFactory::class,
             Controller\PostOfficeFlowController::class => PostOfficeFlowControllerFactory::class,
         ],

--- a/service-front/module/Application/src/Contracts/OpgApiServiceInterface.php
+++ b/service-front/module/Application/src/Contracts/OpgApiServiceInterface.php
@@ -187,4 +187,6 @@ interface OpgApiServiceInterface
      * @return void
      */
     public function updateCaseAssistance(string $uuid, string $assistance, string $details = null): void;
+
+    public function abandonFlow(string $uuid): void;
 }

--- a/service-front/module/Application/src/Controller/Factory/IndexControllerFactory.php
+++ b/service-front/module/Application/src/Controller/Factory/IndexControllerFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Controller\Factory;
+
+use Application\Contracts\OpgApiServiceInterface;
+use Application\Controller\IndexController;
+use Application\Exceptions\StartupException;
+use Application\Helpers\LpaFormHelper;
+use Application\Helpers\SiriusDataProcessorHelper;
+use Application\Services\SiriusApiService;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
+
+class IndexControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ContainerInterface $container
+     * @param string $requestedName
+     * @param mixed[]|null $options
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null): IndexController
+    {
+        $siriusPublicUrl = getenv("SIRIUS_PUBLIC_URL");
+
+        if (! is_string($siriusPublicUrl)) {
+            throw new StartupException('SIRIUS_PUBLIC_URL environment variable not set');
+        }
+
+        return new IndexController(
+            $container->get(OpgApiServiceInterface::class),
+            $container->get(SiriusApiService::class),
+            $container->get(LpaFormHelper::class),
+            $container->get(SiriusDataProcessorHelper::class),
+            $siriusPublicUrl,
+        );
+    }
+}

--- a/service-front/module/Application/src/Exceptions/StartupException.php
+++ b/service-front/module/Application/src/Exceptions/StartupException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Exceptions;
+
+use RuntimeException;
+
+class StartupException extends RuntimeException
+{
+}

--- a/service-front/module/Application/src/Services/OpgApiService.php
+++ b/service-front/module/Application/src/Services/OpgApiService.php
@@ -452,4 +452,15 @@ class OpgApiService implements OpgApiServiceInterface
             throw new OpgApiException($exception->getMessage());
         }
     }
+
+    public function abandonFlow(string $uuid): void
+    {
+        $url = sprintf("/cases/%s/abandon", $uuid);
+
+        try {
+            $this->makeApiRequest($url, 'POST');
+        } catch (\Exception $exception) {
+            throw new OpgApiException($exception->getMessage());
+        }
+    }
 }

--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -214,29 +214,6 @@ class SiriusApiService
     }
 
     /**
-     * @param array{
-     *   reference: string,
-     *   actorType: string,
-     *   lpaIds: string[],
-     *   time: string,
-     *   outcome: string,
-     * } $data
-     * @return array{status: int, error: mixed}
-     */
-    public function abandonCase(array $data, Request $request): array
-    {
-        $response = $this->client->post('/api/v1/identity-check', [
-            'headers' => $this->getAuthHeaders($request),
-            'json' => $data
-        ]);
-
-        return [
-            'status' => $response->getStatusCode(),
-            'error' => json_decode(strval($response->getBody()), true)
-        ];
-    }
-
-    /**
      * @param array $caseDetails
      * @param SiriusDocument $systemType
      * @param Request $request

--- a/service-front/module/Application/test/Controller/IndexControllerTest.php
+++ b/service-front/module/Application/test/Controller/IndexControllerTest.php
@@ -8,6 +8,7 @@ use Application\Controller\IndexController;
 use Application\Services\OpgApiService;
 use Application\Services\SiriusApiService;
 use Laminas\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 
 /**
  * @psalm-import-type Lpa from SiriusApiService
@@ -57,7 +58,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
             'donor' => [
                 'firstname' => 'Lili', 'surname' => 'Laur', 'dob' => '18/02/2019',
                 'addressLine1' => '17 East Lane', 'addressLine2' => 'Wickerham',
-                'town' => '', 'postcode' => 'W1 3EJ', 'country' => 'GB'
+                'town' => '', 'postcode' => 'W1 3EJ', 'country' => 'GB',
             ],
             'caseSubtype' => 'property-and-affairs',
         ];
@@ -82,7 +83,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
             'draft, donor' => [
                 [
                     'opg.poas.sirius' => $siriusData,
-                    'opg.poas.lpastore' => null
+                    'opg.poas.lpastore' => null,
                 ],
                 'donor',
                 [
@@ -93,14 +94,14 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
                         'line3' => '',
                         'town' => '',
                         'postcode' => 'W1 3EJ',
-                        'country' => 'GB'
+                        'country' => 'GB',
                     ],
-                ]
+                ],
             ],
             'executed, donor' => [
                 [
                     'opg.poas.sirius' => $siriusData,
-                    'opg.poas.lpastore' => $lpaStoreData
+                    'opg.poas.lpastore' => $lpaStoreData,
                 ],
                 'donor',
                 [
@@ -111,14 +112,14 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
                         'line3' => '',
                         'town' => 'Edinburgh',
                         'postcode' => 'EH1 2EJ',
-                        'country' => 'GB'
+                        'country' => 'GB',
                     ],
-                ]
+                ],
             ],
             'executed, cp' => [
                 [
                     'opg.poas.sirius' => $siriusData,
-                    'opg.poas.lpastore' => $lpaStoreData
+                    'opg.poas.lpastore' => $lpaStoreData,
                 ],
                 'certificateProvider',
                 [
@@ -129,9 +130,9 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
                         'line3' => '',
                         'town' => '',
                         'postcode' => '',
-                        'country' => 'ES'
+                        'country' => 'ES',
                     ],
-                ]
+                ],
             ],
         ];
     }
@@ -178,7 +179,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $draftLpa = [
             'opg.poas.sirius' => [],
-            'opg.poas.lpastore' => null
+            'opg.poas.lpastore' => null,
         ];
 
         $siriusApiService->expects($this->once())
@@ -207,7 +208,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $draftLpa = [
             'opg.poas.sirius' => [],
-            'opg.poas.lpastore' => null
+            'opg.poas.lpastore' => null,
         ];
 
         $siriusApiService->expects($this->once())
@@ -250,5 +251,64 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch('/health-check/service', 'GET');
         $this->assertResponseStatusCode(200);
+    }
+
+    public function testAbandonAction(): void
+    {
+        $siriusApiService = $this->createMock(SiriusApiService::class);
+        $opgApiService = $this->createMock(OpgApiService::class);
+
+        $serviceManager = $this->getApplicationServiceLocator();
+        $serviceManager->setService(SiriusApiService::class, $siriusApiService);
+        $serviceManager->setService(OpgApiService::class, $opgApiService);
+
+        $lastPage = '/case-uuid/national-insurance-number';
+
+        $opgApiService->expects($this->once())
+            ->method('updateCaseProgress')
+            ->with('case-uuid', $this->callback(fn ($data) => $data['abandonedFlow']['last_page'] === $lastPage));
+
+        $this->dispatch(sprintf('/case-uuid/abandon-flow?last_page=%s', $lastPage), 'GET');
+        $this->assertResponseStatusCode(200);
+
+        $button = (new Crawler($this->getResponse()->getContent()))
+            ->filterXPath('//a[contains(., "No, continue identity check")]');
+
+        $this->assertEquals('/case-uuid/national-insurance-number', $button->attr('href'));
+    }
+
+    public function testAbandonActionSubmit(): void
+    {
+        $siriusApiService = $this->createMock(SiriusApiService::class);
+        $opgApiService = $this->createMock(OpgApiService::class);
+
+        $serviceManager = $this->getApplicationServiceLocator();
+        $serviceManager->setService(SiriusApiService::class, $siriusApiService);
+        $serviceManager->setService(OpgApiService::class, $opgApiService);
+
+        $lastPage = '/case-uuid/national-insurance-number';
+
+        $opgApiService->expects($this->once())
+            ->method('getDetailsData')
+            ->with('case-uuid')
+            ->willReturn([
+                'lpas' => ['case-uuid'],
+            ]);
+
+        $opgApiService->expects($this->once())
+            ->method('updateCaseProgress')
+            ->with('case-uuid', $this->callback(fn ($data) => $data['abandonedFlow']['last_page'] === $lastPage));
+
+        $opgApiService->expects($this->once())
+            ->method('abandonFlow')
+            ->with('case-uuid');
+
+        $this->dispatch(sprintf('/case-uuid/abandon-flow?last_page=%s', $lastPage), 'POST', [
+            'reason' => 'cd',
+            'notes' => 'Custom notes',
+        ]);
+
+        $this->assertResponseStatusCode(302);
+        $this->assertRedirectTo("SIRIUS_PUBLIC_URL/lpa/frontend/lpa/case-uuid");
     }
 }

--- a/service-front/module/Application/test/Services/SiriusApiServicePactTest.php
+++ b/service-front/module/Application/test/Services/SiriusApiServicePactTest.php
@@ -168,39 +168,6 @@ class SiriusApiServicePactTest extends TestCase
         $this->assertEquals('DE', $cpAddress['country'] ?? '');
     }
 
-    public function testAbandonCase(): void
-    {
-        $request = new ConsumerRequest();
-        $body = [
-            "reference" => "49895f88-501b-4491-8381-e8aeeaef177d",
-            "actorType" => "donor",
-            "lpaIds" => [
-                "M-1234-9876-4567",
-            ],
-            "time" => "2024-07-30T10:53:57+00:00",
-            "outcome" => "exit",
-        ];
-        $request
-            ->setMethod('POST')
-            ->setPath('/api/v1/identity-check')
-            ->setBody($body);
-
-        $response = new ProviderResponse();
-        $response
-            ->setStatus(204);
-
-        $this->builder
-            ->given('A digital LPA exists')
-            ->uponReceiving('A notification that case was exited')
-            ->with($request)
-            ->willRespondWith($response);
-
-        $response = $this->buildService()->abandonCase($body, new Request());
-
-        $this->assertEquals(204, $response['status']);
-        $this->assertEquals("", $response['error']);
-    }
-
     /**
      * Returns an example of a tiny PDF with visible content
      */

--- a/service-front/module/Application/view/application/pages/abandoned_flow.twig
+++ b/service-front/module/Application/view/application/pages/abandoned_flow.twig
@@ -68,7 +68,7 @@
                 class="govuk-button govuk-button--warning" data-module="govuk-button">
                 Yes, exit identity check
             </button>
-            <a href="javascript:history.back()" role="button" draggable="false"
+            <a href="{{ last_page }}" role="button" draggable="false"
                 class="govuk-button govuk-button--secondary" data-module="govuk-button">
                 No, continue identity check
             </a>


### PR DESCRIPTION
## Purpose

Rather than using an API request, use events for consistency with other results.

Fixes ID-442 #minor

## Approach

I added some more tests for the frontend and fixed the link of the "No" button.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [ ] The team have tested these changes
