### PR TITLE
fallback to sirius when no lpastore, vouching add-donor pages

### DIFF
--- a/service-front/module/Application/src/Controller/VouchingFlowController.php
+++ b/service-front/module/Application/src/Controller/VouchingFlowController.php
@@ -399,7 +399,7 @@ class VouchingFlowController extends AbstractActionController
         return $view->setTemplate('application/pages/vouching/enter_address_manual');
     }
 
-    public function confirmDonorsAction(): ViewModel
+    public function confirmDonorsAction(): ViewModel|Response
     {
         $uuid = $this->params()->fromRoute("uuid");
 
@@ -412,7 +412,9 @@ class VouchingFlowController extends AbstractActionController
             $lpaData = $this->siriusApiService->getLpaByUid($lpa, $this->request);
 
             $donorName = AddDonorFormHelper::getDonorNameFromSiriusResponse($lpaData);
-            $type = LpaTypes::fromName($lpaData['opg.poas.lpastore']['lpaType'] ?? '');
+            $type = LpaTypes::fromName(
+                $lpaData['opg.poas.lpastore']['lpaType'] ?? $lpaData['opg.poas.sirius']['caseSubtype']
+            );
 
             $lpaDetails[$lpa] = [
                 'name' => $donorName,

--- a/service-front/module/Application/src/Helpers/AddDonorFormHelper.php
+++ b/service-front/module/Application/src/Helpers/AddDonorFormHelper.php
@@ -119,9 +119,10 @@ class AddDonorFormHelper
             "problem" => false,
             "message" => ""
         ];
-        /** @psalm-suppress PossiblyNullArgument */
+
         if (
             array_key_exists('opg.poas.lpastore', $lpaData) &&
+            ! is_null($lpaData['opg.poas.lpastore']) &&
             array_key_exists('status', $lpaData['opg.poas.lpastore'])
         ) {
             $status = $lpaData['opg.poas.lpastore']['status'];

--- a/service-front/module/Application/test/Controller/VouchingFlowControllerTest.php
+++ b/service-front/module/Application/test/Controller/VouchingFlowControllerTest.php
@@ -923,8 +923,10 @@ class VouchingFlowControllerTest extends AbstractHttpControllerTestCase
                     'opg.poas.lpastore' => ['lpaType' => 'personal-welfare']
                 ],
                 $lpa === 'M-AAAA-1234-5678' => [
-                    'opg.poas.sirius' => ['donor' => ['firstname' => 'another', 'surname' => 'name']],
-                    'opg.poas.lpastore' => ['lpaType' => 'property-and-affairs']
+                    'opg.poas.sirius' => [
+                        'donor' => ['firstname' => 'another', 'surname' => 'name'],
+                        'caseSubtype' => 'property-and-affairs'
+                    ],
                 ],
             });
 
@@ -935,7 +937,9 @@ class VouchingFlowControllerTest extends AbstractHttpControllerTestCase
         $this->assertControllerClass('VouchingFlowController');
         $this->assertMatchedRouteName('root/voucher_confirm_donors');
 
+        $this->assertQueryContentContains('span[id=lpaType]', 'PW');
         $this->assertQueryContentContains('span[id=lpaId]', 'M-XYXY-YAGA-35G3');
+        $this->assertQueryContentContains('span[id=lpaType]', 'PA');
         $this->assertQueryContentContains('span[id=lpaId]', 'M-AAAA-1234-5678');
     }
 

--- a/service-front/module/Application/test/Helpers/AddDonorFormHelperTest.php
+++ b/service-front/module/Application/test/Helpers/AddDonorFormHelperTest.php
@@ -110,7 +110,7 @@ class AddDonorFormHelperTest extends TestCase
     /**
      * @dataProvider statusData
      */
-    public function testCheckLpaStatus(array $lpaStoreData, array $expectedResult): void
+    public function testCheckLpaStatus(?array $lpaStoreData, array $expectedResult): void
     {
         $lpaData = self::getLpa([
             'opg.poas.lpastore' => $lpaStoreData
@@ -122,6 +122,10 @@ class AddDonorFormHelperTest extends TestCase
     public static function statusData(): array
     {
         return [
+            [
+                null,
+                ['problem' => true, 'message' => 'No LPA Found.']
+            ],
             [
                 [],
                 ['problem' => true, 'message' => 'No LPA Found.']

--- a/service-front/module/Application/view/application/pages/vouching/confirm_donors.twig
+++ b/service-front/module/Application/view/application/pages/vouching/confirm_donors.twig
@@ -39,9 +39,7 @@
                             {% for index, datum in lpa_details %}
                                 <div class="govuk-summary-list__row">
                                     <dd class="govuk-summary-list__value">
-                                        <span class="app-type-text-colour--{{ datum['type'] }}">
-                                            {{ datum['type'] }}
-                                        </span>
+                                        <span id="lpaType" class="app-type-text-colour--{{ datum['type'] }}">{{ datum['type'] }}</span>
                                         <span id="lpaId">{{ index }}</span>
                                     </dd>
                                     <dd class="govuk-summary-list__value">


### PR DESCRIPTION
## Purpose

Make sure to fallback to `opg.poas.sirius` when `opg.poas.lpastore` is not available on the vouching route - specifically the confirm-donor and add-donor pages.
