### PR TITLE
Prevent value being lost from Passport in date on form submission

### DIFF
--- a/e2e-tests/cypress/e2e/certificate_provider/certificate-provider-journey.cy.ts
+++ b/e2e-tests/cypress/e2e/certificate_provider/certificate-provider-journey.cy.ts
@@ -144,7 +144,7 @@ describe("Identify a Certificate Provider", () => {
         cy.contains("The passport needs to be no more than 18 months out of date");
 
         cy.get("#passport").clear();
-        cy.contains("Yes").click();
+        cy.get(".govuk-radios__label").contains("Yes").click();
         cy.get(".govuk-button").contains("Continue").click();
         cy.contains("Enter the passport number.");
 

--- a/e2e-tests/cypress/e2e/donor/donor-journey.cy.ts
+++ b/e2e-tests/cypress/e2e/donor/donor-journey.cy.ts
@@ -113,7 +113,7 @@ describe("Identify a Donor", () => {
     cy.contains("Enter passport expiry date. For example, 31 03 2012");
 
     cy.get("#passport").type("123456781", {force: true});
-    cy.contains("Yes").click();
+    cy.get(".govuk-radios__label").contains("Yes").click();
     cy.get(".govuk-button").contains("Continue").click();
 
     cy.contains("Identity document verified");
@@ -151,7 +151,7 @@ describe("Identify a Donor", () => {
     cy.contains("Enter the Driving licence number.");
 
     cy.get("#dln").type("MORGA657054SM9IJ", {force: true});
-    cy.contains("Yes").click();
+    cy.get(".govuk-radios__label").contains("Yes").click();
     cy.get(".govuk-button").contains("Continue").click();
 
     cy.contains("Identity document verified");

--- a/service-front/module/Application/view/application/pages/how_will_you_confirm.twig
+++ b/service-front/module/Application/view/application/pages/how_will_you_confirm.twig
@@ -103,6 +103,7 @@
                                 name="id_method"
                                 type="radio"
                                 value="NATIONAL_INSURANCE_NUMBER"
+                                {{ (form.get('id_method').value == 'NATIONAL_INSURANCE_NUMBER') ? 'checked' : '' }}
                             >
                             <label class="govuk-label govuk-radios__label" for="NATIONAL_INSURANCE_NUMBER">
                                 National insurance number
@@ -116,6 +117,7 @@
                                 name="id_method"
                                 type="radio"
                                 value="PASSPORT"
+                                {{ (form.get('id_method').value == 'PASSPORT') ? 'checked' : '' }}
                             >
                             <label class="govuk-label govuk-radios__label" for="PASSPORT">
                                 UK Passport (current or expired in the last 18 months)
@@ -245,6 +247,7 @@
                                 name="id_method"
                                 type="radio"
                                 value="DRIVING_LICENCE"
+                                {{ (form.get('id_method').value == 'DRIVING_LICENCE') ? 'checked' : '' }}
                             >
                             <label class="govuk-label govuk-radios__label" for="DRIVING_LICENCE">
                                 UK driving licence (must be current)
@@ -274,6 +277,7 @@
                                     name="id_method"
                                     type="radio"
                                     value="POST_OFFICE"
+                                    {{ (form.get('id_method').value == 'POST_OFFICE') ? 'checked' : '' }}
                                 >
                                 <label class="govuk-label govuk-radios__label" for="PostOffice">
                                     Post Office
@@ -325,6 +329,7 @@
                                         name="id_method"
                                         type="radio"
                                         value="OnBehalf"
+                                        {{ (form.get('id_method').value == 'OnBehalf') ? 'checked' : '' }}
                                     >
                                     <label class="govuk-label govuk-radios__label" for="OnBehalf">
                                         Have someone vouch for the identity of the donor
@@ -339,6 +344,7 @@
                                         name="id_method"
                                         type="radio"
                                         value="cpr"
+                                        {{ (form.get('id_method').value == 'cpr') ? 'checked' : '' }}
                                     >
                                     <label class="govuk-label govuk-radios__label" for="CourtOfProtection">
                                         The donor cannot do any of the above (Court of Protection)</label>

--- a/service-front/module/Application/view/application/pages/passport_number.twig
+++ b/service-front/module/Application/view/application/pages/passport_number.twig
@@ -171,12 +171,12 @@
                 <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="inDateTrue" name="inDate" type="radio"
-                                value="yes">
+                                value="yes" {{ (form.get('inDate').value == 'yes') ? 'checked' : '' }}>
                         <label class="govuk-label govuk-radios__label" for="inDateTrue">Yes</label>
                     </div>
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="inDateFalse" name="inDate" type="radio"
-                                value="no">
+                                value="no" {{ (form.get('inDate').value == 'no') ? 'checked' : '' }}>
                         <label class="govuk-label govuk-radios__label" for="inDateFalse">No</label>
                     </div>
                 </div>

--- a/service-front/module/Application/view/application/pages/post_office/post_office_documents.twig
+++ b/service-front/module/Application/view/application/pages/post_office/post_office_documents.twig
@@ -63,7 +63,7 @@
                 <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="PASSPORT" name="id_method" type="radio"
-                               value="PASSPORT">
+                               value="PASSPORT" {{ (form.get('id_method').value == 'PASSPORT') ? 'checked' : '' }}>
                         <label class="govuk-label govuk-radios__label" for="PASSPORT">UK passport (up to 18 months expired)
 
                             <details
@@ -164,20 +164,20 @@
                     </div>
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="DRIVING_LICENCE" name="id_method" type="radio"
-                               value="DRIVING_LICENCE">
+                               value="DRIVING_LICENCE" {{ (form.get('id_method').value == 'DRIVING_LICENCE') ? 'checked' : '' }}>
                         <label class="govuk-label govuk-radios__label" for="DRIVING_LICENCE">UK photocard driving
                             licence (must be current)</label>
                     </div>
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="RESIDENCE_PERMIT" name="id_method" type="radio"
-                               value="RESIDENCE_PERMIT">
+                               value="RESIDENCE_PERMIT" {{ (form.get('id_method').value == 'RESIDENCE_PERMIT') ? 'checked' : '' }}>
                         <label class="govuk-label govuk-radios__label" for="RESIDENCE_PERMIT">
                             UK biometric residence card (BRP)
                         </label>
                     </div>
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input" id="NONUKID" name="id_method" type="radio"
-                               value="NONUKID">
+                               value="NONUKID" {{ (form.get('id_method').value == 'NONUKID') ? 'checked' : '' }}>
                         <label class="govuk-label govuk-radios__label" for="NONUKID">
                             ID from another country
                         </label>


### PR DESCRIPTION
## Purpose

To recreate - start an ID check, and on that page select the passport option and open the reveal and enter a date and click check. The page refreshes and the passport option is unchecked. 

This is frustrating because each user after they had checked would scroll down to the continue button and then get the error and then have to select the radio button again. 

Can this radio button stay as checked after the passport date has been checked please. 

Fixes https://opgtransform.atlassian.net/browse/ID-467

## Approach

`<input class="govuk-radios__input" id="inDateFalse" name="inDate" type="radio"
                                value="no" {{ (form.get('inDate').value == 'no') ? 'checked' : '' }}>`