### PR TITLE
Display error if identity check complete

### DIFF
--- a/docker/sirius/data/donor.json
+++ b/docker/sirius/data/donor.json
@@ -50,10 +50,6 @@
       "dateOfBirth": "1986-09-03",
       "email": "lee.manthrope@example.com",
       "firstNames": "Lee",
-      "identityCheck": {
-        "checkedAt": "1913-11-28T02:04:34.0Z",
-        "type": "one-login"
-      },
       "lastName": "Manthrope",
       "uid": "20cd4c3b-76e2-6582-27c4-428eb9ca1f9c"
     },

--- a/docker/sirius/data/donorNoDecision.json
+++ b/docker/sirius/data/donorNoDecision.json
@@ -50,10 +50,6 @@
       "dateOfBirth": "1986-09-03",
       "email": "lee.nodec@example.com",
       "firstNames": "Lee",
-      "identityCheck": {
-        "checkedAt": "1913-11-28T02:04:34.0Z",
-        "type": "one-login"
-      },
       "lastName": "Nodec",
       "uid": "20cd4c3b-76e2-6582-27c4-428eb9ca1f9c"
     },

--- a/docker/sirius/data/donorNoDecisionKBV.json
+++ b/docker/sirius/data/donorNoDecisionKBV.json
@@ -50,10 +50,6 @@
       "dateOfBirth": "1986-09-03",
       "email": "lee.thinfile@example.com",
       "firstNames": "Lee",
-      "identityCheck": {
-        "checkedAt": "1913-11-28T02:04:34.0Z",
-        "type": "one-login"
-      },
       "lastName": "Thinfile",
       "uid": "20cd4c3b-76e2-6582-27c4-428eb9ca1f9c"
     },

--- a/docker/sirius/data/donorRefer.json
+++ b/docker/sirius/data/donorRefer.json
@@ -50,10 +50,6 @@
       "dateOfBirth": "1986-09-03",
       "email": "lee.refer@example.com",
       "firstNames": "Lee",
-      "identityCheck": {
-        "checkedAt": "1913-11-28T02:04:34.0Z",
-        "type": "one-login"
-      },
       "lastName": "Refer",
       "uid": "20cd4c3b-76e2-6582-27c4-428eb9ca1f9c"
     },

--- a/docker/sirius/data/donorStop.json
+++ b/docker/sirius/data/donorStop.json
@@ -50,10 +50,6 @@
       "dateOfBirth": "1986-09-03",
       "email": "lee.nohope@example.com",
       "firstNames": "Lee",
-      "identityCheck": {
-        "checkedAt": "1913-11-28T02:04:34.0Z",
-        "type": "one-login"
-      },
       "lastName": "Nohope",
       "uid": "20cd4c3b-76e2-6582-27c4-428eb9ca1f9c"
     },

--- a/service-front/module/Application/src/Controller/IndexController.php
+++ b/service-front/module/Application/src/Controller/IndexController.php
@@ -91,8 +91,10 @@ class IndexController extends AbstractActionController
             throw new HttpException(400, "ID check has already been completed");
         }
 
-        if ($type === 'certificateProvider'
-            && isset($lpaData['opg.poas.lpastore']['certificateProvider']['identityCheck'])) {
+        if (
+            $type === 'certificateProvider'
+            && isset($lpaData['opg.poas.lpastore']['certificateProvider']['identityCheck'])
+        ) {
             throw new HttpException(400, "ID check has already been completed");
         }
     }

--- a/service-front/module/Application/src/Controller/IndexController.php
+++ b/service-front/module/Application/src/Controller/IndexController.php
@@ -69,6 +69,8 @@ class IndexController extends AbstractActionController
             throw new HttpException(400, "These LPAs are for different {$personTypeDescription[$type]}");
         }
 
+        $this->ensureIdentityCheckHasNotAlreadyBeenPerformed($type, $lpas[0]);
+
         $case = $this->siriusDataProcessorHelper->createPaperIdCase($type, $lpasQuery, $lpas[0]);
 
         if ($type === 'voucher') {

--- a/service-front/module/Application/src/Controller/IndexController.php
+++ b/service-front/module/Application/src/Controller/IndexController.php
@@ -79,6 +79,24 @@ class IndexController extends AbstractActionController
         return $this->redirect()->toRoute($redirect, ['uuid' => $case['uuid']]);
     }
 
+    /**
+     * @param string $type
+     * @psalm-param Lpa $lpaData
+     * @return void
+     * @throws HttpException
+     */
+    private function ensureIdentityCheckHasNotAlreadyBeenPerformed(string $type, array $lpaData): void
+    {
+        if ($type === 'donor' && isset($lpaData['opg.poas.lpastore']['donor']['identityCheck'])) {
+            throw new HttpException(400, "ID check has already been completed");
+        }
+
+        if ($type === 'certificateProvider'
+            && isset($lpaData['opg.poas.lpastore']['certificateProvider']['identityCheck'])) {
+            throw new HttpException(400, "ID check has already been completed");
+        }
+    }
+
     public function abandonFlowAction(): ViewModel|Response
     {
         $view = new ViewModel();

--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -54,7 +54,7 @@ use Psr\Log\LoggerInterface;
  *      addressLine3?: string,
  *      town?: string,
  *      postcode?: string,
- *      country: string,
+ *      country: string
  *    },
  *    linkedDigitalLpas?: LinkedLpa[]
  *  },
@@ -65,12 +65,20 @@ use Psr\Log\LoggerInterface;
  *      lastName: string,
  *      dateOfBirth: string,
  *      address: Address,
+ *      identityCheck?: array{
+ *        checkedAt: string,
+ *        type: string
+ *      },
  *    },
  *    certificateProvider: array{
  *      firstNames: string,
  *      lastName: string,
  *      dateOfBirth: string,
  *      address: Address,
+ *      identityCheck?: array{
+ *        checkedAt: string,
+ *        type: string
+ *      },
  *    },
  *    attorneys: Attorney[],
  *  },


### PR DESCRIPTION
When starting the journey, when we fetch the data from Sirius: if there is already a valid ID check against the actor, do not allow them to start the process and show an error page explaining that the ID check is already complete.
<img width="1089" alt="image" src="https://github.com/user-attachments/assets/46236d4f-825a-49eb-addb-ee7b601103d1" />