### PR TITLE
Use `identity-check-updated` event

### DIFF
--- a/service-api/module/Application/src/Controller/IdentityController.php
+++ b/service-api/module/Application/src/Controller/IdentityController.php
@@ -23,6 +23,7 @@ use Application\Model\Entity\Problem;
 use Application\Nino\ValidatorInterface;
 use Application\Passport\ValidatorInterface as PassportValidator;
 use Application\Sirius\EventSender;
+use Application\Sirius\UpdateStatus;
 use Application\View\JsonModel;
 use GuzzleHttp\Exception\GuzzleException;
 use Laminas\Form\Annotation\AttributeBuilder;
@@ -802,12 +803,12 @@ class IdentityController extends AbstractActionController
             return new JsonModel(new Problem('Case not found'));
         }
 
-        $this->eventSender->send("identity-check-resolved", [
+        $this->eventSender->send("identity-check-updated", [
             "reference" => "opg:" . $caseData->id,
             "actorType" => $caseData->personType,
-            "lpaIds" => $caseData->lpas,
+            "lpaUids" => $caseData->lpas,
             "time" => $this->clock->now()->format('c'),
-            "outcome" => "exit",
+            "state" => UpdateStatus::Exit->value,
         ]);
 
         return new JsonModel();

--- a/service-api/module/Application/src/Helpers/CaseOutcomeCalculator.php
+++ b/service-api/module/Application/src/Helpers/CaseOutcomeCalculator.php
@@ -7,6 +7,7 @@ namespace Application\Helpers;
 use Application\Model\Entity\CaseData;
 use Application\Fixtures\DataWriteHandler;
 use Application\Sirius\EventSender;
+use Application\Sirius\UpdateStatus;
 use Psr\Log\LoggerInterface;
 
 class CaseOutcomeCalculator
@@ -25,12 +26,12 @@ class CaseOutcomeCalculator
         // add to logs
         $this->logger->info("Update for CaseId " . $caseData->id . "- Result: " . $caseData->identityCheckPassed);
 
-        $this->eventSender->send("identity-check-resolved", [
+        $this->eventSender->send("identity-check-updated", [
             "reference" => "opg:" . $caseData->id,
             "actorType" => $caseData->personType,
-            "lpaIds" => $caseData->lpas,
+            "lpaUids" => $caseData->lpas,
             "time" => $time,
-            "outcome" => $caseData->identityCheckPassed ? 'success' : 'failure',
+            "state" => ($caseData->identityCheckPassed ? UpdateStatus::Success : UpdateStatus::Failure)->value,
         ]);
     }
 }

--- a/service-api/module/Application/src/Sirius/UpdateStatus.php
+++ b/service-api/module/Application/src/Sirius/UpdateStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Sirius;
+
+enum UpdateStatus: string
+{
+    case CopStarted = "COP_STARTED";
+    case CounterServiceStarted = "COUNTER_SERVICE_STARTED";
+    case Exit = "EXIT";
+    case Failure = "FAILURE";
+    case Success = "SUCCESS";
+    case VouchStarted = "VOUCH_STARTED";
+}

--- a/service-api/module/Application/test/ApplicationTest/Helpers/CaseOutcomeCalculatorTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Helpers/CaseOutcomeCalculatorTest.php
@@ -9,8 +9,6 @@ use Application\Fixtures\DataWriteHandler;
 use Application\Sirius\EventSender;
 use ApplicationTest\TestCase;
 use Application\Helpers\CaseOutcomeCalculator;
-use Laminas\Stdlib\ArrayUtils;
-use PhpParser\Node\Stmt\Case_;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -52,7 +50,9 @@ class CaseOutcomeCalculatorTest extends TestCase
                 'state' => '',
                 'result' => false
             ],
-            'lpas' => [],
+            'lpas' => [
+                'M-9387-2843-3891'
+            ],
             'identityCheckPassed' => true,
         ]);
 
@@ -66,12 +66,12 @@ class CaseOutcomeCalculatorTest extends TestCase
 
         $this->eventSenderMock->expects($this->once())
             ->method('send')
-            ->with("identity-check-resolved", [
+            ->with("identity-check-updated", [
                 "reference" => "opg:2b45a8c1-dd35-47ef-a00e-c7b6264bf1cc",
                 "actorType" => "donor",
-                "lpaIds" => [],
+                "lpaUids" => ['M-9387-2843-3891'],
                 "time" => 'some timestamp',
-                "outcome" => 'success',
+                "state" => 'SUCCESS',
             ]);
 
         $this->sut->updateSendIdentityCheck($caseData, 'some timestamp');

--- a/service-api/module/Application/test/Controller/IdentityControllerTest.php
+++ b/service-api/module/Application/test/Controller/IdentityControllerTest.php
@@ -949,13 +949,13 @@ class IdentityControllerTest extends TestCase
             ->expects($this->once())
             ->method('send')
             ->with(
-                'identity-check-resolved',
+                'identity-check-updated',
                 [
                     'reference' => 'opg:' . $caseData->id,
                     'actorType' => $caseData->personType,
-                    'lpaIds' => $caseData->lpas,
+                    'lpaUids' => $caseData->lpas,
                     'time' => '2024-05-12T13:45:56+00:00',
-                    'outcome' => 'exit',
+                    'state' => 'EXIT',
                 ]
             );
 


### PR DESCRIPTION
## Purpose

The `identity-check-resolved` event has been replaced by `identity-check-updated`, which has a wider scope and introduces some syntax changes.

Fixes ID-500 #major

## Approach

- Rename event
- `outcome` becomes `state` and use an enum for the values
- `lpaIds` becomes `lpaUids`

## Learning

N/A

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * See ministryofjustice/opg-event-store#126
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
