### PR TITLE
Fix `for` attributes

### DIFF
--- a/service-front/module/Application/view/application/pages/how_will_you_confirm.twig
+++ b/service-front/module/Application/view/application/pages/how_will_you_confirm.twig
@@ -279,7 +279,7 @@
                                     value="POST_OFFICE"
                                     {{ (form.get('id_method').value == 'POST_OFFICE') ? 'checked' : '' }}
                                 >
-                                <label class="govuk-label govuk-radios__label" for="PostOffice">
+                                <label class="govuk-label govuk-radios__label" for="POST_OFFICE">
                                     Post Office
                                     <details class="govuk-details govuk-!-margin-top-4 govuk-!-margin-bottom-0">
                                         <summary class="govuk-details__summary">
@@ -331,7 +331,7 @@
                                         value="OnBehalf"
                                         {{ (form.get('id_method').value == 'OnBehalf') ? 'checked' : '' }}
                                     >
-                                    <label class="govuk-label govuk-radios__label" for="OnBehalf">
+                                    <label class="govuk-label govuk-radios__label" for="ON_BEHALF">
                                         Have someone vouch for the identity of the donor
                                     </label>
                                 </div>
@@ -346,7 +346,7 @@
                                         value="cpr"
                                         {{ (form.get('id_method').value == 'cpr') ? 'checked' : '' }}
                                     >
-                                    <label class="govuk-label govuk-radios__label" for="CourtOfProtection">
+                                    <label class="govuk-label govuk-radios__label" for="COURT_OF_PROTECTION">
                                         The donor cannot do any of the above (Court of Protection)</label>
                                 </div>
                             {% endif %}

--- a/service-front/module/Application/view/application/pages/post_office/find_post_office_branch.twig
+++ b/service-front/module/Application/view/application/pages/post_office/find_post_office_branch.twig
@@ -50,7 +50,7 @@
                             value="{{ item|json_encode }}"
                             data-aria-controls="default"
                         >
-                        <label class="govuk-label govuk-radios__label" for="{{ fad }}">
+                        <label class="govuk-label govuk-radios__label" for="postoffice-{{ fad }}">
                             {{ item.name }}<br>
                             <span id="poAddress-{{ fad }}">{{ item.address }}, {{ item.post_code }}</span>
                         </label>

--- a/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
+++ b/service-front/module/Application/view/application/pages/vouching/confirm_vouching.twig
@@ -35,7 +35,7 @@
                     <div class="govuk-checkboxes__item">
                         <input class="govuk-checkboxes__input" id="eligibility_confirmed" name="eligibility" type="checkbox" value="eligibility_confirmed"
                         {% if form.get('eligibility').value == "eligibility_confirmed" %}checked{% endif %}>
-                        <label class="govuk-label govuk-checkboxes__label" for="eligibility">
+                        <label class="govuk-label govuk-checkboxes__label" for="eligibility_confirmed">
                         They are not:
                         <ul class="govuk-list govuk-list--bullet">
                             <li>under the age of 18</li>
@@ -67,7 +67,7 @@
                     <div class="govuk-checkboxes__item">
                         <input class="govuk-checkboxes__input" id="declaration_confirmed" name="declaration" type="checkbox" value="declaration_confirmed"
                         {% if form.get('declaration').value == "declaration_confirmed" %}checked{% endif %}>
-                        <label class="govuk-label govuk-checkboxes__label" for="declaration">
+                        <label class="govuk-label govuk-checkboxes__label" for="declaration_confirmed">
                         To the best of your knowledge, the person who asked you to vouch for them is {{ details_data.vouchingFor.firstName }} {{ details_data.vouchingFor.lastName }}
                         and you have known them for at least 2 years.
                         </label>

--- a/service-front/module/Application/view/application/pages/vouching/vouch_for_another_donor.twig
+++ b/service-front/module/Application/view/application/pages/vouching/vouch_for_another_donor.twig
@@ -41,7 +41,7 @@
     <form method="POST">
         <div class="govuk-form-group govuk-!-width-two-thirds {% if form.get('lpa').messages %}govuk-form-group--error{% endif %}">
             <h1 class="govuk-label-wrapper">
-                <label class="govuk-label govuk-label--l" for="event-name">
+                <label class="govuk-label govuk-label--l" for="lpa-number">
                 What is the LPA number?
                 </label>
             </h1>
@@ -163,7 +163,7 @@
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="declaration_confirmed" name="declaration" type="checkbox" value="declaration_confirmed"
                                 {% if form.get('declaration').value == "declaration_confirmed" %}checked{% endif %}>
-                                <label class="govuk-label govuk-checkboxes__label" for="declaration">
+                                <label class="govuk-label govuk-checkboxes__label" for="declaration_confirmed">
                                 To the best of your knowledge, the person who asked you to vouch for them is {{ lpa_response['donorName'] }} and you have known them for at least 2 years.
                                 </label>
                             </div>


### PR DESCRIPTION
## Purpose

They need to match the `id` of the input they relate to

Fixes ID-522 #patch

## Approach

I searched templates for `for="` and checked they matched the inputs

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * N/A
* [x] I have run an accessibility tool against the changes and applied fixes
* [x] The team have tested these changes
  * N/A
