### PR TITLE
Add boundary assertions to LpaUidValidator

### DIFF
--- a/service-api/module/Application/src/Validators/LpaUidValidator.php
+++ b/service-api/module/Application/src/Validators/LpaUidValidator.php
@@ -27,6 +27,6 @@ class LpaUidValidator extends AbstractValidator
             return true;
         }
 
-        return 1 === preg_match('/M(-([0-9A-Z]){4}){3}/', $lpa);
+        return 1 === preg_match('/^M(-([0-9A-Z]){4}){3}$/', $lpa);
     }
 }

--- a/service-api/module/Application/test/ApplicationTest/Validators/LpaUidValidatorTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Validators/LpaUidValidatorTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Validators;
+
+use Application\Validators\LpaUidValidator;
+use PHPUnit\Framework\TestCase;
+
+class LpaUidValidatorTest extends TestCase
+{
+    protected LpaUidValidator $lpaValidator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->lpaValidator = new LpaUidValidator();
+    }
+
+    /**
+     * @dataProvider lpaData
+     */
+    public function testValidator(string $lpa, bool $valid): void
+    {
+        $this->assertEquals($valid, $this->lpaValidator->isValid($lpa));
+    }
+
+    public static function lpaData(): array
+    {
+        return [
+            ['M-0000-0000-0000', true],
+            ['M-0000-0000-1234', true],
+            ['M-0000-0000-000t', false],
+            ['M-0000-0000-123', false],
+            ['T-0000-0000-1234', false],
+            ['M-0-00-0000-1234', false],
+            ['-0-00-0000-1234', false],
+            ['M-0000-0000-1234-1234', false],
+            ['PREFIX-M-0000-0000-1234', false],
+        ];
+    }
+}

--- a/service-front/module/Application/src/Validators/LpaUidValidator.php
+++ b/service-front/module/Application/src/Validators/LpaUidValidator.php
@@ -23,7 +23,7 @@ class LpaUidValidator extends AbstractValidator
             return false;
         }
 
-        $this->setValue(strtoupper($value));
+        $this->setValue($value);
 
         if (! $this->lpaValidity()) {
             $this->error(self::LPA);
@@ -35,6 +35,6 @@ class LpaUidValidator extends AbstractValidator
 
     private function lpaValidity(): bool
     {
-        return 1 === preg_match('/M(-([0-9A-Z]){4}){3}/', $this->value);
+        return 1 === preg_match('/^M(-([0-9A-Z]){4}){3}$/', $this->value);
     }
 }

--- a/service-front/module/Application/test/Validators/LpaUidValidatorTest.php
+++ b/service-front/module/Application/test/Validators/LpaUidValidatorTest.php
@@ -7,7 +7,7 @@ namespace ApplicationTest\Validators;
 use Application\Validators\LpaUidValidator;
 use PHPUnit\Framework\TestCase;
 
-class LpaValidatorTest extends TestCase
+class LpaUidValidatorTest extends TestCase
 {
     protected LpaUidValidator $lpaValidator;
 
@@ -30,12 +30,14 @@ class LpaValidatorTest extends TestCase
     {
         return [
             ['M-0000-0000-0000', true],
-            ['M-0000-0000-000t', true],
             ['M-0000-0000-1234', true],
+            ['M-0000-0000-000t', false],
             ['M-0000-0000-123', false],
             ['T-0000-0000-1234', false],
             ['M-0-00-0000-1234', false],
             ['-0-00-0000-1234', false],
+            ['M-0000-0000-1234-1234', false],
+            ['PREFIX-M-0000-0000-1234', false],
         ];
     }
 }


### PR DESCRIPTION
## Purpose

Ensure LpaUidValidator requires strings to *be* UIDs not *contain* UIDs.

Fixes ID-521 #patch

## Approach

Added `^` and `$` to regex pattern.

Renamed LpaValidatorTest to LpaUidValidatorTest

Removed `strtoupper` because we shouldn't manipulate input in validators. If we wantt o make things upper case, we need to do so in a filter.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [ ] The team have tested these changes
