### PR TITLE
Fix link to update details on Sirius

### DIFF
--- a/e2e-tests/cypress/e2e/certificate_provider/certificate-provider-journey.cy.ts
+++ b/e2e-tests/cypress/e2e/certificate_provider/certificate-provider-journey.cy.ts
@@ -7,7 +7,7 @@ describe("Identify a Certificate Provider", () => {
         cy.get(".govuk-button").contains("Continue").click();
 
         cy.contains("Does the name match the ID?");
-        cy.contains("Edit the certificate provider's details in Sirius").should('have.attr', 'href').and('include', 'lpa_details')
+        cy.contains("Edit the certificate provider's details in Sirius").should('have.attr', 'href').and('include', 'lpa-details')
         cy.get(".govuk-button").contains("Continue").click();
 
         cy.contains("LPAs included in the identity check");

--- a/e2e-tests/cypress/e2e/donor/donor-journey.cy.ts
+++ b/e2e-tests/cypress/e2e/donor/donor-journey.cy.ts
@@ -8,7 +8,7 @@ describe("Identify a Donor", () => {
 
     cy.contains("Do the details match the ID document?");
 
-    cy.contains("Edit the donor's details in Sirius").should('have.attr', 'href').and('include', 'lpa_details')
+    cy.contains("Edit the donor's details in Sirius").should('have.attr', 'href').and('include', 'lpa-details')
     cy.get(".govuk-button").contains("Continue").click();
 
     cy.contains("LPAs included in this identity check");

--- a/service-front/module/Application/view/application/pages/cp/cp_id_check.twig
+++ b/service-front/module/Application/view/application/pages/cp/cp_id_check.twig
@@ -21,7 +21,7 @@
         <p class="govuk-body">
             {{ details_data.firstName }} {{ details_data.lastName }}
         </p>
-        <a href="{{ sirius_edit_url }}/lpa_details" class="govuk-link" target="_blank">Edit the certificate provider's details in Sirius</a> (Opens in a new window)<br><br>
+        <a href="{{ sirius_edit_url }}/lpa-details" class="govuk-link" target="_blank">Edit the certificate provider's details in Sirius</a> (Opens in a new window)<br><br>
 
         <a href="./name-match-check" class="govuk-link">Update this page</a> (if you've changed the record in Sirius)
     </div>

--- a/service-front/module/Application/view/application/pages/donor_details_match_check.twig
+++ b/service-front/module/Application/view/application/pages/donor_details_match_check.twig
@@ -41,7 +41,7 @@
                 {% endfor %}
             </p>
 
-            <a href="{{ sirius_edit_url }}/lpa_details" class="govuk-link" target="_blank">Edit the donor's details in Sirius</a> (Opens in a new window)<br><br>
+            <a href="{{ sirius_edit_url }}/lpa-details" class="govuk-link" target="_blank">Edit the donor's details in Sirius</a> (Opens in a new window)<br><br>
 
             <a href="./donor-details-match-check" class="govuk-link">Update this page</a> (if you've changed the record
             in Sirius)


### PR DESCRIPTION
Got on a call with @jrattle and found that the link wasn't quite right to update the donor and cert provider details on Sirius. This PR fixes that.