### PR TITLE
Remove memory_limit ini files

### DIFF
--- a/service-api/Dockerfile
+++ b/service-api/Dockerfile
@@ -17,7 +17,6 @@ RUN chmod 0644 /etc/ssl/cert.pem
 WORKDIR /var/www/
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
-COPY docker/php/memory_limit.ini /usr/local/etc/php/conf.d/memory-limit.ini
 COPY docker/php/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY docker/php/www.conf /usr/local/etc/php-fpm.d/www.conf
 COPY docker/php/apcu.ini /usr/local/etc/php/conf.d/apcu.ini

--- a/service-api/docker/php/memory_limit.ini
+++ b/service-api/docker/php/memory_limit.ini
@@ -1,1 +1,0 @@
-memory_limit = 4096M

--- a/service-front/Dockerfile
+++ b/service-front/Dockerfile
@@ -28,7 +28,6 @@ RUN apk upgrade --no-cache openssl curl libcurl
 WORKDIR /var/www
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
-COPY docker/php/memory_limit.ini /usr/local/etc/php/conf.d/memory-limit.ini
 COPY docker/php/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY docker/php/www.conf /usr/local/etc/php-fpm.d/www.conf
 

--- a/service-front/docker/php/memory_limit.ini
+++ b/service-front/docker/php/memory_limit.ini
@@ -1,1 +1,0 @@
-memory_limit = 4096M


### PR DESCRIPTION
## Purpose

GitHub Actions warned us that setting memory_limit to 4GB is higher than permissible. Also, that number is overridden in the container by PHP FPM config.

Fixes ID-534 #patch

## Approach

Remove memory_limit ini files.

## Learning

- FPM config > INI config
- `php-fpm -i` isn't reliable
