### PR TITLE
Remove auth bypass

### DIFF
--- a/docker/sirius/data/currentUser.json
+++ b/docker/sirius/data/currentUser.json
@@ -1,0 +1,3 @@
+{
+  "email": "some.user@opgtest.com"
+}

--- a/docker/sirius/openapi.yml
+++ b/docker/sirius/openapi.yml
@@ -146,7 +146,7 @@ paths:
       operationId: postCreateDocumentRequest
       summary: Send letter data
       description: Send data to create letter
-      tags: [ poa ]
+      tags: [poa]
       requestBody:
         description: Sirius LPA document data
         content:
@@ -218,7 +218,7 @@ components:
     User:
       type: object
       properties:
-        id: int
+        email: string
     CombinedLpa:
       type: object
       required:

--- a/docker/sirius/sirius-config.yaml
+++ b/docker/sirius/sirius-config.yaml
@@ -10,6 +10,12 @@ resources:
       statusCode: 200
       file: data/addressResponse.json
 
+  - path: "/api/v1/users/current"
+    method: get
+    response:
+      statusCode: 200
+      file: data/currentUser.json
+
   - path: "/api/v1/reference-data/country"
     method: get
     response:

--- a/service-front/docker-compose.env
+++ b/service-front/docker-compose.env
@@ -1,4 +1,3 @@
-DISABLE_AUTH_LISTENER=1
 API_BASE_URI=http://api-web
 SIRIUS_BASE_URL=http://sirius-mock:8080 # http://host.docker.internal:8080 for real Sirius
 SIRIUS_PUBLIC_URL=http://localhost:8080

--- a/service-front/module/Application/src/Services/SiriusApiService.php
+++ b/service-front/module/Application/src/Services/SiriusApiService.php
@@ -119,10 +119,6 @@ class SiriusApiService
         try {
             $headers = $this->getAuthHeaders($request);
 
-            if ($headers === null) {
-                return false;
-            }
-
             $this->client->get('/api/v1/users/current', [
                 'headers' => $headers,
             ]);

--- a/service-front/module/Application/test/Unit/Services/SiriusApiServiceTest.php
+++ b/service-front/module/Application/test/Unit/Services/SiriusApiServiceTest.php
@@ -49,39 +49,6 @@ class SiriusApiServiceTest extends TestCase
         $this->assertTrue($ret);
     }
 
-    public function testCheckAuthFailureNoCookie(): void
-    {
-        $clientMock = $this->createMock(Client::class);
-        $loggerMock = $this->createMock(LoggerInterface::class);
-
-        $sut = new SiriusApiService($clientMock, $loggerMock);
-
-
-        $request = new Request();
-        $headers = $request->getHeaders();
-        assert($headers instanceof Headers);
-
-        $ret = $sut->checkAuth($request);
-        $this->assertFalse($ret);
-    }
-
-    public function testCheckAuthFailureNoXSRF(): void
-    {
-        $clientMock = $this->createMock(Client::class);
-        $loggerMock = $this->createMock(LoggerInterface::class);
-
-        $sut = new SiriusApiService($clientMock, $loggerMock);
-
-
-        $request = new Request();
-        $headers = $request->getHeaders();
-        assert($headers instanceof Headers);
-        $headers->addHeaderLine("cookie", "mycookie=1");
-
-        $ret = $sut->checkAuth($request);
-        $this->assertFalse($ret);
-    }
-
     public function testCheckAuthFailureNotAuthed(): void
     {
         $clientMock = $this->createMock(Client::class);


### PR DESCRIPTION
## Purpose

Instead of bypassing Sirius auth locally, use a fixed endpoint on the mock to ensure it always returns 200.

Fixes ID-535 #patch

## Approach

Don't check if headers exist first, to more easily enable local development and Cypress tests.