### PR TITLE
id-537 remove redundant code #patch

### DIFF
--- a/service-front/module/Application/config/module.config.php
+++ b/service-front/module/Application/config/module.config.php
@@ -171,7 +171,7 @@ return [
                         'options' => [
                             'route' => '/:uuid/identity-check-failed',
                             'defaults' => [
-                                'controller' => Controller\DonorFlowController::class,
+                                'controller' => Controller\KbvController::class,
                                 'action' => 'identityCheckFailed',
                             ],
                         ],
@@ -313,16 +313,6 @@ return [
                             'defaults' => [
                                 'controller' => Controller\CPFlowController::class,
                                 'action' => 'identityCheckPassed',
-                            ],
-                        ],
-                    ],
-                    'cp_identity_check_failed' => [
-                        'type' => Segment::class,
-                        'options' => [
-                            'route' => '/:uuid/cp/identity-check-failed',
-                            'defaults' => [
-                                'controller' => Controller\CPFlowController::class,
-                                'action' => 'identityCheckFailed',
                             ],
                         ],
                     ],
@@ -523,16 +513,6 @@ return [
                             'defaults' => [
                                 'controller' => Controller\VouchingFlowController::class,
                                 'action' => 'identityCheckPassed',
-                            ],
-                        ],
-                    ],
-                    'voucher_identity_check_failed' => [
-                        'type' => Segment::class,
-                        'options' => [
-                            'route' => '/:uuid/vouching/identity-check-failed',
-                            'defaults' => [
-                                'controller' => Controller\VouchingFlowController::class,
-                                'action' => 'identityCheckFailed',
                             ],
                         ],
                     ],

--- a/service-front/module/Application/src/Controller/CPFlowController.php
+++ b/service-front/module/Application/src/Controller/CPFlowController.php
@@ -278,31 +278,6 @@ class CPFlowController extends AbstractActionController
         return $view->setTemplate('application/pages/cp/identity_check_passed');
     }
 
-    public function identityCheckFailedAction(): ViewModel
-    {
-        $uuid = $this->params()->fromRoute("uuid");
-        $detailsData = $this->opgApiService->getDetailsData($uuid);
-        $lpaDetails = [];
-        foreach ($detailsData['lpas'] as $lpa) {
-            $lpasData = $this->siriusApiService->getLpaByUid($lpa, $this->request);
-            /**
-             * @psalm-suppress PossiblyNullArrayAccess
-             */
-            $lpaDetails[$lpa] = $lpasData['opg.poas.lpastore']['donor']['firstNames'] . " " .
-                /**
-                 * @psalm-suppress PossiblyNullArrayAccess
-                 */
-                $lpasData['opg.poas.lpastore']['donor']['lastName'];
-        }
-
-        $view = new ViewModel();
-
-        $view->setVariable('lpas_data', $lpaDetails);
-        $view->setVariable('details_data', $detailsData);
-
-        return $view->setTemplate('application/pages/identity_check_failed');
-    }
-
     public function enterPostcodeAction(): ViewModel|Response
     {
         $uuid = $this->params()->fromRoute("uuid");

--- a/service-front/module/Application/src/Controller/DonorFlowController.php
+++ b/service-front/module/Application/src/Controller/DonorFlowController.php
@@ -169,28 +169,6 @@ class DonorFlowController extends AbstractActionController
         return $view->setTemplate('application/pages/identity_check_passed');
     }
 
-    public function identityCheckFailedAction(): ViewModel
-    {
-        $uuid = $this->params()->fromRoute("uuid");
-        $detailsData = $this->opgApiService->getDetailsData($uuid);
-        $lpaDetails = [];
-        foreach ($detailsData['lpas'] as $lpa) {
-            $lpasData = $this->siriusApiService->getLpaByUid($lpa, $this->request);
-            /**
-             * @psalm-suppress PossiblyNullArrayAccess
-             */
-            $lpaDetails[$lpa] = $lpasData['opg.poas.lpastore']['donor']['firstNames'] . " " .
-                $lpasData['opg.poas.lpastore']['donor']['lastName'];
-        }
-
-        $view = new ViewModel();
-
-        $view->setVariable('lpas_data', $lpaDetails);
-        $view->setVariable('details_data', $detailsData);
-
-        return $view->setTemplate('application/pages/identity_check_failed');
-    }
-
     public function thinFileFailureAction(): ViewModel
     {
         $uuid = $this->params()->fromRoute("uuid");

--- a/service-front/module/Application/src/Controller/KbvController.php
+++ b/service-front/module/Application/src/Controller/KbvController.php
@@ -38,16 +38,12 @@ class KbvController extends AbstractActionController
             return $view->setTemplate('application/pages/cannot_start');
         }
 
-        if ($detailsData['personType'] == 'certificateProvider') {
-            $passRoute = "root/cp_identity_check_passed";
-            $failRoute = "root/cp_identity_check_failed";
-        } elseif ($detailsData['personType'] == 'voucher') {
-            $passRoute = "root/voucher_identity_check_passed";
-            $failRoute = "root/voucher_identity_check_failed";
-        } else {
-            $passRoute = "root/identity_check_passed";
-            $failRoute = "root/identity_check_failed";
-        }
+        $failRoute = "root/identity_check_failed";
+        $passRoute = [
+            'donor' => "root/identity_check_passed",
+            'certificateProvider' => "root/cp_identity_check_passed",
+            'voucher' => "root/voucher_identity_check_passed"
+        ];
         $view->setVariable('details_data', $detailsData);
 
         $questionsData = $this->opgApiService->getIdCheckQuestions($uuid);
@@ -95,7 +91,7 @@ class KbvController extends AbstractActionController
                     ];
                     $this->opgApiService->updateCaseProgress($uuid, $caseProgressData);
 
-                    return $this->redirect()->toRoute($passRoute, ['uuid' => $uuid]);
+                    return $this->redirect()->toRoute($passRoute[$detailsData['personType']], ['uuid' => $uuid]);
                 }
 
                 return $this->redirect()->toRoute($failRoute, ['uuid' => $uuid]);
@@ -121,5 +117,16 @@ class KbvController extends AbstractActionController
         }
 
         return null;
+    }
+
+    public function identityCheckFailedAction(): ViewModel
+    {
+        $uuid = $this->params()->fromRoute("uuid");
+        $detailsData = $this->opgApiService->getDetailsData($uuid);
+
+        $view = new ViewModel();
+        $view->setVariable('details_data', $detailsData);
+
+        return $view->setTemplate('application/pages/identity_check_failed');
     }
 }

--- a/service-front/module/Application/src/Controller/VouchingFlowController.php
+++ b/service-front/module/Application/src/Controller/VouchingFlowController.php
@@ -458,15 +458,4 @@ class VouchingFlowController extends AbstractActionController
 
         return $view->setTemplate('application/pages/vouching/identity_check_passed');
     }
-
-    public function identityCheckFailedAction(): ViewModel
-    {
-        $uuid = $this->params()->fromRoute("uuid");
-        $detailsData = $this->opgApiService->getDetailsData($uuid);
-
-        $view = new ViewModel();
-        $view->setVariable('details_data', $detailsData);
-
-        return $view->setTemplate('application/pages/identity_check_failed');
-    }
 }

--- a/service-front/module/Application/test/Feature/Controller/DonorFlowControllerTest.php
+++ b/service-front/module/Application/test/Feature/Controller/DonorFlowControllerTest.php
@@ -86,32 +86,6 @@ class DonorFlowControllerTest extends AbstractHttpControllerTestCase
         $this->assertMatchedRouteName('root/identity_check_passed');
     }
 
-    public function testIdentityCheckFailedPage(): void
-    {
-        $mockResponseDataIdDetails = $this->returnOpgResponseData();
-        $siriusResponse = $this->returnSiriusLpaResponse();
-
-        $this
-            ->opgApiServiceMock
-            ->expects(self::once())
-            ->method('getDetailsData')
-            ->with($this->uuid)
-            ->willReturn($mockResponseDataIdDetails);
-
-        $this
-            ->siriusApiService
-            ->expects(self::once())
-            ->method('getLpaByUid')
-            ->willReturn($siriusResponse);
-
-        $this->dispatch("/$this->uuid/identity-check-failed", 'GET');
-        $this->assertResponseStatusCode(200);
-        $this->assertModuleName('application');
-        $this->assertControllerName(DonorFlowController::class);
-        $this->assertControllerClass('DonorFlowController');
-        $this->assertMatchedRouteName('root/identity_check_failed');
-    }
-
     public function testThinFileFailurePage(): void
     {
         $this->dispatch("/$this->uuid/thin-file-failure", 'GET');

--- a/service-front/module/Application/test/Feature/Controller/KbvControllerTest.php
+++ b/service-front/module/Application/test/Feature/Controller/KbvControllerTest.php
@@ -210,13 +210,40 @@ class KbvControllerTest extends AbstractHttpControllerTestCase
             [
                 'personType' => 'certificateProvider',
                 'outcome' => ['complete' => true, 'passed' => false],
-                'expectedRedirect' => '/%s/cp/identity-check-failed',
+                'expectedRedirect' => '/%s/identity-check-failed',
             ],
             [
                 'personType' => 'certificateProvider',
                 'outcome' => ['complete' => true, 'passed' => true],
                 'expectedRedirect' => '/%s/cp/identity-check-passed',
             ],
+            [
+                'personType' => 'voucher',
+                'outcome' => ['complete' => true, 'passed' => true],
+                'expectedRedirect' => '/%s/vouching/identity-check-passed',
+            ],
         ];
+    }
+
+    public function testIdentityCheckFailedPage(): void
+    {
+        $uuid = '1b6b45ca-7f20-4110-afd4-1d6794423d3c';
+
+        $this
+            ->opgApiServiceMock
+            ->expects(self::once())
+            ->method('getDetailsData')
+            ->with($uuid)
+            ->willReturn([
+                'id' => $uuid,
+                'personType' => 'donor'
+            ]);
+
+        $this->dispatch("/$uuid/identity-check-failed", 'GET');
+        $this->assertResponseStatusCode(200);
+        $this->assertModuleName('application');
+        $this->assertControllerName(KbvController::class);
+        $this->assertControllerClass('KbvController');
+        $this->assertMatchedRouteName('root/identity_check_failed');
     }
 }


### PR DESCRIPTION
## Purpose

remove redundant code as we no longer show info on the LPAs in the id-check-failed pages so don't need to retrieve that info from sirius.

Fixes [id-537](https://opgtransform.atlassian.net/browse/ID-537)

## Approach

remove redundant code and move action to KBVController so it is not duplicated across personTypes

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
