### PR TITLE
Add JWT auth between frontend and API

### DIFF
--- a/docker/sirius/data/currentUser.json
+++ b/docker/sirius/data/currentUser.json
@@ -1,3 +1,3 @@
 {
-  "email": "some.user@opgtest.com"
+  "email": "some.user@opg.example"
 }

--- a/service-api/composer.json
+++ b/service-api/composer.json
@@ -28,6 +28,7 @@
         "laminas/laminas-mvc": "^3.7.0",
         "laminas/laminas-skeleton-installer": "^1.3.0",
         "lcobucci/clock": "^3.3",
+        "lcobucci/jwt": "^5.5",
         "monolog/monolog": "^3.5",
         "open-telemetry/contrib-aws": "^1.0@beta",
         "open-telemetry/exporter-otlp": "^1.0",

--- a/service-api/composer.lock
+++ b/service-api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0428c967932879aa7ead06b054cebece",
+    "content-hash": "a8c2dcb5675ec0a79d09ba69027ba0e0",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2538,6 +2538,79 @@
                 }
             ],
             "time": "2024-09-24T20:45:14+00:00"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "5.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "a835af59b030d3f2967725697cf88300f579088e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/a835af59b030d3f2967725697cf88300f579088e",
+                "reference": "a835af59b030d3f2967725697cf88300f579088e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-sodium": "*",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29",
+                "lcobucci/clock": "^3.2",
+                "lcobucci/coding-standard": "^11.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.10",
+                "phpstan/phpstan-strict-rules": "^1.5.0",
+                "phpunit/phpunit": "^11.1"
+            },
+            "suggest": {
+                "lcobucci/clock": ">= 3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/5.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-01-26T21:29:45+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/service-api/docker-compose.env
+++ b/service-api/docker-compose.env
@@ -1,3 +1,4 @@
+API_JWT_KEY=aninternalsigningkeythatissecret
 AWS_ACCESS_KEY_ID=localstack
 AWS_DYNAMODB_ENDPOINT=http://localstack:4566
 AWS_DYNAMODB_TABLE_NAME=identity-verify

--- a/service-api/module/Application/config/module.config.php
+++ b/service-api/module/Application/config/module.config.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Application;
 
+use Application\Auth\Listener as AuthListener;
+use Application\Auth\ListenerFactory as AuthListenerFactory;
 use Application\Aws\DynamoDbClientFactory;
 use Application\Aws\EventBridgeClientFactory;
 use Application\Aws\Secrets\AwsSecretsCache;
@@ -99,16 +101,6 @@ return [
                     'defaults' => [
                         'controller' => Controller\IdentityController::class,
                         'action' => 'details',
-                    ],
-                ],
-            ],
-            'testdata' => [
-                'type' => Literal::class,
-                'options' => [
-                    'route' => '/identity/testdata',
-                    'defaults' => [
-                        'controller' => Controller\IdentityController::class,
-                        'action' => 'testdata',
                     ],
                 ],
             ],
@@ -529,8 +521,12 @@ return [
             AuthManager::class => AuthManagerFactory::class,
             ClockInterface::class => fn () => SystemClock::fromSystemTimezone(),
             DwpAuthApiService::class => DwpAuthApiServiceFactory::class,
-            DwpApiService::class => DwpApiServiceFactory::class
+            DwpApiService::class => DwpApiServiceFactory::class,
+            AuthListener::class => AuthListenerFactory::class,
         ],
+    ],
+    'listeners' => [
+        AuthListener::class,
     ],
     'view_manager' => [
         'template_map' => [

--- a/service-api/module/Application/src/Auth/Listener.php
+++ b/service-api/module/Application/src/Auth/Listener.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Auth;
+
+use Application\Model\Entity\Problem;
+use Laminas\EventManager\AbstractListenerAggregate;
+use Laminas\EventManager\EventManagerInterface;
+use Laminas\Http\Header\HeaderInterface;
+use Laminas\Http\Request;
+use Laminas\Http\Response;
+use Laminas\Mvc\MvcEvent;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Token\Parser;
+use Lcobucci\JWT\UnencryptedToken;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Lcobucci\JWT\Validation\Constraint\StrictValidAt;
+use Lcobucci\JWT\Validation\Validator;
+use Psr\Clock\ClockInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+class Listener extends AbstractListenerAggregate
+{
+    /**
+     * @var string[]
+     */
+    public const ALLOW_LIST = [
+        '/health-check',
+        '/health-check/service',
+        '/health-check/dependencies',
+    ];
+
+    /**
+     * @param non-empty-string $passphrase
+     */
+    public function __construct(
+        private readonly ClockInterface $clock,
+        private readonly LoggerInterface $logger,
+        private readonly string $passphrase,
+    ) {
+    }
+
+    /**
+     * @param int $priority
+     */
+    public function attach(EventManagerInterface $events, $priority = 100): void
+    {
+        $this->listeners[] = $events->attach(
+            MvcEvent::EVENT_ROUTE,
+            [$this, 'checkAuth'],
+            $priority
+        );
+    }
+
+    public function detach(EventManagerInterface $events): void
+    {
+        $events->detach(
+            [$this, 'checkAuth'],
+            MvcEvent::EVENT_ROUTE
+        );
+    }
+
+    public function checkAuth(MvcEvent $e): ?Response
+    {
+        /** @var Request $request */
+        $request = $e->getRequest();
+
+        /** @var Response $response */
+        $response = $e->getResponse();
+
+        if (in_array($request->getUri()->getPath(), self::ALLOW_LIST)) {
+            return null;
+        }
+
+        if (! $this->isAuthed($request)) {
+            $problem = new Problem('Unauthorized', '', 401);
+
+            $response->setContent(json_encode($problem));
+            $response->setStatusCode(Response::STATUS_CODE_401);
+
+            return $response;
+        }
+
+        return null;
+    }
+
+    private function isAuthed(Request $request): bool
+    {
+        $authorization = $request->getHeader("Authorization");
+
+        if (! ($authorization instanceof HeaderInterface)) {
+            return false;
+        }
+
+        $token = str_replace('Bearer ', '', $authorization->getFieldValue());
+        if (empty($token)) {
+            return false;
+        }
+
+        $parser = new Parser(new JoseEncoder());
+
+        try {
+            $token = $parser->parse($token);
+        } catch (Throwable) {
+            return false;
+        }
+
+        if (! ($token instanceof UnencryptedToken)) {
+            return false;
+        }
+
+        $validator = new Validator();
+
+        try {
+            $validator->assert(
+                $token,
+                new StrictValidAt($this->clock),
+                new SignedWith(new Sha256(), InMemory::plainText($this->passphrase)),
+            );
+        } catch (Throwable $e) {
+            $this->logger->warning('Authorization failed', [
+                'message' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/service-api/module/Application/src/Auth/ListenerFactory.php
+++ b/service-api/module/Application/src/Auth/ListenerFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Auth;
+
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Clock\ClockInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+class ListenerFactory implements FactoryInterface
+{
+    /**
+     * @param string $requestedName
+     * @param null|array<mixed> $options
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null): Listener
+    {
+        $apiJwtKey = getenv("API_JWT_KEY");
+
+        if (! is_string($apiJwtKey) || $apiJwtKey === '') {
+            throw new RuntimeException('API_JWT_KEY must be set');
+        }
+
+        return new Listener(
+            $container->get(ClockInterface::class),
+            $container->get(LoggerInterface::class),
+            $apiJwtKey,
+        );
+    }
+}

--- a/service-api/module/Application/test/ApplicationTest/Feature/Auth/ListenerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Feature/Auth/ListenerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Feature\Controller;
+
+use DateInterval;
+use DateTimeImmutable;
+use Laminas\Http\Headers;
+use Laminas\Http\Request;
+use Laminas\Test\PHPUnit\Controller\AbstractControllerTestCase;
+use Lcobucci\JWT\Builder as JWTBuilder;
+use Lcobucci\JWT\Encoding\ChainedFormatter;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Token\Builder;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class ListenerTest extends AbstractControllerTestCase
+{
+    private Builder $builder;
+
+    public function setUp(): void
+    {
+        $this->builder = new Builder(new JoseEncoder(), ChainedFormatter::default());
+
+        $this->setApplicationConfig(include __DIR__ . '/../../../../../../config/application.config.php');
+
+        parent::setUp();
+    }
+
+    public function testFailsWithoutHeader(): void
+    {
+        $this->dispatch('/some-url');
+
+        $this->assertResponseStatusCode(401);
+    }
+
+    public function testAllowlist(): void
+    {
+        $this->dispatch('/health-check');
+
+        $this->assertResponseStatusCode(200);
+    }
+
+    private function addSignedTokenHeader(JWTBuilder $tokenBuilder): void
+    {
+        /** @var non-empty-string $secret */
+        $secret = getenv('API_JWT_KEY');
+
+        $signer = new Sha256();
+        $signingKey = InMemory::plainText($secret);
+
+        $token = $tokenBuilder
+            ->getToken($signer, $signingKey)
+            ->toString();
+
+        /** @var Request $request */
+        $request = $this->getRequest();
+
+        /** @var Headers $headers */
+        $headers = $request->getHeaders();
+
+        $headers->addHeaderLine('Authorization', "Bearer {$token}");
+    }
+
+    public function testValidJwt(): void
+    {
+        $now = new DateTimeImmutable();
+
+        $token = $this->builder
+            ->canOnlyBeUsedAfter($now->sub(new DateInterval('PT1S')))
+            ->issuedAt($now->sub(new DateInterval('PT10S')))
+            ->expiresAt($now->add(new DateInterval('PT10S')))
+            ->relatedTo('user14@opg.example');
+
+        $this->addSignedTokenHeader($token);
+
+        $this->dispatch('/no-exist', 'GET');
+
+        $this->assertResponseStatusCode(404);
+    }
+
+    /**
+     * @return array<string, array{?DateTimeImmutable, ?DateTimeImmutable}>
+     */
+    public static function invalidJwtProvider(): array
+    {
+        $now = new DateTimeImmutable();
+
+        return [
+            'missing iat' => [null, $now->add(new DateInterval('PT5M'))],
+            'missing exp' => [$now->sub(new DateInterval('PT5M')), null],
+            'expired' => [$now->sub(new DateInterval('PT5M')), $now->sub(new DateInterval('PT5M'))],
+            'not yet valid' => [$now->add(new DateInterval('PT5M')), $now->add(new DateInterval('PT5M'))],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidJwtProvider
+     */
+    public function testInvalidJwts(?DateTimeImmutable $issuedAt, ?DateTimeImmutable $expiresAt): void
+    {
+        $token = $this->builder->relatedTo('system.admin@opg.example');
+
+        if ($issuedAt) {
+            $token = $token->issuedAt($issuedAt);
+        }
+
+        if ($expiresAt) {
+            $token = $token->expiresAt($expiresAt);
+        }
+
+        $this->addSignedTokenHeader($token);
+
+        $this->dispatch('/no-exist', 'GET');
+
+        $this->assertResponseStatusCode(401);
+    }
+}

--- a/service-api/module/Application/test/ApplicationTest/Feature/Auth/ListenerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Feature/Auth/ListenerTest.php
@@ -15,7 +15,6 @@ use Lcobucci\JWT\Encoding\JoseEncoder;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Token\Builder;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 class ListenerTest extends AbstractControllerTestCase
 {

--- a/service-api/module/Application/test/ApplicationTest/Feature/Aws/Secrets/AwsSecretTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Feature/Aws/Secrets/AwsSecretTest.php
@@ -7,7 +7,6 @@ namespace ApplicationTest\Feature\Aws\Secrets;
 use Application\Aws\Secrets\AwsSecret;
 use Application\Aws\Secrets\AwsSecretsCache;
 use ApplicationTest\TestCase;
-use RuntimeException;
 
 class AwsSecretTest extends TestCase
 {
@@ -21,14 +20,6 @@ class AwsSecretTest extends TestCase
     public function testGetName(): void
     {
         self::assertEquals('test', $this->sut->getName());
-    }
-
-    public function testGetValueThrowsExceptionIfCacheNotInstantiated(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('SecretsCache has not been initialised');
-
-        $this->sut->getValue();
     }
 
     public function testGetValueReturnsValueFromCache(): void

--- a/service-api/module/Application/test/TestCase.php
+++ b/service-api/module/Application/test/TestCase.php
@@ -4,12 +4,21 @@ declare(strict_types=1);
 
 namespace ApplicationTest;
 
+use Application\Auth\Listener;
 use Laminas\Http\Headers;
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
 
 abstract class TestCase extends AbstractHttpControllerTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $listener = $this->getApplicationServiceLocator()->get(Listener::class);
+        $listener->detach($this->getApplication()->getEventManager());
+    }
+
     public function dispatchJSON(string $path, string $method, mixed $data = null): void
     {
         $headers = new Headers();

--- a/service-front/composer.json
+++ b/service-front/composer.json
@@ -25,6 +25,8 @@
         "laminas/laminas-mvc-plugins": "^1.2.0",
         "laminas/laminas-session": "^2.16.0",
         "laminas/laminas-skeleton-installer": "^1.3.0",
+        "lcobucci/clock": "^3.3",
+        "lcobucci/jwt": "^5.5",
         "monolog/monolog": "^3.5",
         "open-telemetry/contrib-aws": "^1.0@beta",
         "open-telemetry/exporter-otlp": "^1.0",

--- a/service-front/composer.lock
+++ b/service-front/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3fe931490f0a537f7975b50f495f04dc",
+    "content-hash": "a1014b391393bf3416cd4da9d78a3700",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3644,6 +3644,143 @@
             "time": "2024-11-21T17:42:20+00:00"
         },
         {
+            "name": "lcobucci/clock",
+            "version": "3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/clock.git",
+                "reference": "db3713a61addfffd615b79bf0bc22f0ccc61b86b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/db3713a61addfffd615b79bf0bc22f0ccc61b86b",
+                "reference": "db3713a61addfffd615b79bf0bc22f0ccc61b86b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/clock": "^1.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29",
+                "lcobucci/coding-standard": "^11.1.0",
+                "phpstan/extension-installer": "^1.3.1",
+                "phpstan/phpstan": "^1.10.25",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.13",
+                "phpstan/phpstan-strict-rules": "^1.5.1",
+                "phpunit/phpunit": "^11.3.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\Clock\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com"
+                }
+            ],
+            "description": "Yet another clock abstraction",
+            "support": {
+                "issues": "https://github.com/lcobucci/clock/issues",
+                "source": "https://github.com/lcobucci/clock/tree/3.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2024-09-24T20:45:14+00:00"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "5.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "a835af59b030d3f2967725697cf88300f579088e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/a835af59b030d3f2967725697cf88300f579088e",
+                "reference": "a835af59b030d3f2967725697cf88300f579088e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-sodium": "*",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "psr/clock": "^1.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.29",
+                "lcobucci/clock": "^3.2",
+                "lcobucci/coding-standard": "^11.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan": "^1.10.7",
+                "phpstan/phpstan-deprecation-rules": "^1.1.3",
+                "phpstan/phpstan-phpunit": "^1.3.10",
+                "phpstan/phpstan-strict-rules": "^1.5.0",
+                "phpunit/phpunit": "^11.1"
+            },
+            "suggest": {
+                "lcobucci/clock": ">= 3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/5.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-01-26T21:29:45+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "3.8.1",
             "source": {
@@ -4592,6 +4729,54 @@
                 "source": "https://github.com/php-fig/cache/tree/3.0.0"
             },
             "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
         },
         {
             "name": "psr/container",

--- a/service-front/docker-compose.env
+++ b/service-front/docker-compose.env
@@ -1,4 +1,5 @@
 API_BASE_URI=http://api-web
+API_JWT_KEY=aninternalsigningkeythatissecret
 SIRIUS_BASE_URL=http://sirius-mock:8080 # http://host.docker.internal:8080 for real Sirius
 SIRIUS_PUBLIC_URL=http://localhost:8080
 APP_DEBUG=1

--- a/service-front/module/Application/config/module.config.php
+++ b/service-front/module/Application/config/module.config.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Application;
 
+use Application\Auth\JwtGenerator;
+use Application\Auth\JwtGeneratorFactory;
 use Application\Auth\Listener as AuthListener;
 use Application\Auth\ListenerFactory as AuthListenerFactory;
 use Application\Controller\Factory\CourtOfProtectionFlowControllerFactory;
 use Application\Controller\Factory\CPFlowControllerFactory;
+use Application\Controller\Factory\DocumentCheckControllerFactory;
 use Application\Controller\Factory\DonorFlowControllerFactory;
 use Application\Controller\Factory\HowConfirmControllerFactory;
 use Application\Controller\Factory\IndexControllerFactory;
-use Application\Controller\Factory\DocumentCheckControllerFactory;
 use Application\Controller\Factory\PostOfficeFlowControllerFactory;
 use Application\Controller\Factory\VouchingFlowControllerFactory;
 use Application\Enums\IdMethod;
@@ -24,9 +26,12 @@ use Application\Services\OpgApiService;
 use Application\Services\SiriusApiService;
 use Application\Views\TwigExtension;
 use Application\Views\TwigExtensionFactory;
+use Exception;
 use Laminas\Mvc\Controller\LazyControllerAbstractFactory;
 use Laminas\Router\Http\Literal;
 use Laminas\Router\Http\Segment;
+use Lcobucci\Clock\SystemClock;
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 use Twig\Extension\DebugExtension;
 
@@ -579,6 +584,8 @@ return [
         ],
         'factories' => [
             AuthListener::class => AuthListenerFactory::class,
+            ClockInterface::class => fn () => SystemClock::fromSystemTimezone(),
+            JwtGenerator::class => JwtGeneratorFactory::class,
             LoggerInterface::class => LoggerFactory::class,
             OpgApiService::class => OpgApiServiceFactory::class,
             SiriusApiService::class => SiriusApiServiceFactory::class,
@@ -630,7 +637,7 @@ return [
             IdMethod::NationalInsuranceNumber->value,
             IdMethod::PassportNumber->value,
             IdMethod::DrivingLicenseNumber->value,
-            IdMethod::PostOffice->value
+            IdMethod::PostOffice->value,
         ],
         'template_options' => [
             'NATIONAL_INSURANCE_NUMBER' => [
@@ -638,21 +645,21 @@ return [
                 'success' => 'application/pages/document_success',
                 'fail' => 'application/pages/national_insurance_number_fail',
                 'thin_file' => 'application/pages/thin_file_failure',
-                'fraud' => 'application/pages/fraud_failure'
+                'fraud' => 'application/pages/fraud_failure',
             ],
             'PASSPORT' => [
                 'default' => 'application/pages/passport_number',
                 'success' => 'application/pages/document_success',
                 'fail' => 'application/pages/passport_number_fail',
                 'thin_file' => 'application/pages/thin_file_failure',
-                'fraud' => 'application/pages/fraud_failure'
+                'fraud' => 'application/pages/fraud_failure',
             ],
             'DRIVING_LICENCE' => [
                 'default' => 'application/pages/driving_licence_number',
                 'success' => 'application/pages/document_success',
                 'fail' => 'application/pages/driving_licence_number_fail',
                 'thin_file' => 'application/pages/thin_file_failure',
-                'fraud' => 'application/pages/fraud_failure'
+                'fraud' => 'application/pages/fraud_failure',
             ],
         ],
         'yoti_supported_documents' => json_decode(

--- a/service-front/module/Application/src/Auth/JwtGenerator.php
+++ b/service-front/module/Application/src/Auth/JwtGenerator.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Application\Auth;
+
+use DateMalformedStringException;
+use Lcobucci\JWT\Encoding\CannotEncodeContent;
+use Lcobucci\JWT\Encoding\ChainedFormatter;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Signer\CannotSignPayload;
+use Lcobucci\JWT\Signer\Ecdsa\ConversionFailed;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\InvalidKeyProvided;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Token\Builder;
+use Psr\Clock\ClockInterface;
+use RuntimeException;
+
+class JwtGenerator
+{
+    private string $sub = '';
+
+    /**
+     * @param non-empty-string $passphrase
+     */
+    public function __construct(private readonly ClockInterface $clock, private readonly string $passphrase)
+    {
+    }
+
+    public function setSub(string $sub): void
+    {
+        $this->sub = $sub;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function issueToken(): string
+    {
+        $tokenBuilder = Builder::new(new JoseEncoder(), ChainedFormatter::default());
+        $algorithm = new Sha256();
+        $signingKey = InMemory::plainText($this->passphrase);
+
+        if ($this->sub === '') {
+            throw new RuntimeException('Could not determine user sub');
+        }
+
+        $now = $this->clock->now();
+        $token = $tokenBuilder
+            ->relatedTo($this->sub)
+            ->canOnlyBeUsedAfter($now->modify('-1 second'))
+            ->issuedAt($now)
+            ->expiresAt($now->modify('+30 seconds'))
+            ->getToken($algorithm, $signingKey);
+
+        return $token->toString();
+    }
+}

--- a/service-front/module/Application/src/Auth/JwtGeneratorFactory.php
+++ b/service-front/module/Application/src/Auth/JwtGeneratorFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Auth;
+
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Clock\ClockInterface;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+class JwtGeneratorFactory implements FactoryInterface
+{
+    public function __invoke(
+        ContainerInterface $container,
+        $requestedName,
+        ?array $options = null
+    ) {
+        $apiJwtKey = getenv("API_JWT_KEY");
+
+        if (! is_string($apiJwtKey) || $apiJwtKey === '') {
+            throw new RuntimeException('API_JWT_KEY must be set');
+        }
+
+        return new JwtGenerator(
+            $container->get(ClockInterface::class),
+            $apiJwtKey,
+        );
+    }
+}

--- a/service-front/module/Application/src/Factories/OpgApiServiceFactory.php
+++ b/service-front/module/Application/src/Factories/OpgApiServiceFactory.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Application\Factories;
 
+use Application\Auth\JwtGenerator;
+use Application\Services\OpgApiService;
 use GuzzleHttp\Client;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
-use Application\Services\OpgApiService;
 use RuntimeException;
 
 class OpgApiServiceFactory implements FactoryInterface
@@ -26,6 +27,9 @@ class OpgApiServiceFactory implements FactoryInterface
 
         $guzzleClient = new Client(['base_uri' => $baseUri]);
 
-        return new OpgApiService($guzzleClient);
+        return new OpgApiService(
+            $guzzleClient,
+            $container->get(JwtGenerator::class),
+        );
     }
 }

--- a/service-front/module/Application/src/Factories/SiriusApiServiceFactory.php
+++ b/service-front/module/Application/src/Factories/SiriusApiServiceFactory.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Application\Factories;
 
+use Application\Auth\JwtGenerator;
 use Application\Services\SiriusApiService;
 use GuzzleHttp\Client;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
-use RuntimeException;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 class SiriusApiServiceFactory implements FactoryInterface
 {
@@ -26,11 +27,11 @@ class SiriusApiServiceFactory implements FactoryInterface
         }
 
         $client = new Client(['base_uri' => $baseUri]);
-        $logger = $container->get(LoggerInterface::class);
 
         return new SiriusApiService(
             $client,
-            $logger
+            $container->get(LoggerInterface::class),
+            $container->get(JwtGenerator::class)
         );
     }
 }

--- a/service-front/module/Application/test/Unit/Auth/JwtGeneratorTest.php
+++ b/service-front/module/Application/test/Unit/Auth/JwtGeneratorTest.php
@@ -34,4 +34,15 @@ class JwtGeneratorTest extends TestCase
         $this->assertEquals('2022-06-18T10:28:45+00:00', $token->claims()->get('iat')->format('c'));
         $this->assertEquals('2022-06-18T10:29:15+00:00', $token->claims()->get('exp')->format('c'));
     }
+
+    public function testWillNotIssueWithoutSub(): void
+    {
+        $clock = new FrozenClock(new DateTimeImmutable('2022-06-18T10:28:45Z'));
+
+        $generator = new JwtGenerator($clock, 'alongstringthatcouldbeusedasapassphrase');
+
+        $this->expectExceptionMessage('Could not determine user sub');
+
+        $generator->issueToken();
+    }
 }

--- a/service-front/module/Application/test/Unit/Auth/JwtGeneratorTest.php
+++ b/service-front/module/Application/test/Unit/Auth/JwtGeneratorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ApplicationTest\Unit\Auth;
+
+use Application\Auth\JwtGenerator;
+use DateTimeImmutable;
+use Lcobucci\Clock\FrozenClock;
+use Lcobucci\JWT\Encoding\JoseEncoder;
+use Lcobucci\JWT\Token\Parser;
+use Lcobucci\JWT\UnencryptedToken;
+use PHPUnit\Framework\TestCase;
+
+class JwtGeneratorTest extends TestCase
+{
+    public function testIssueToken(): void
+    {
+        $clock = new FrozenClock(new DateTimeImmutable('2022-06-18T10:28:45Z'));
+
+        $generator = new JwtGenerator($clock, 'alongstringthatcouldbeusedasapassphrase');
+        $generator->setSub('my-identity');
+
+        $tokenString = $generator->issueToken();
+
+        $parser = new Parser(new JoseEncoder());
+        $token = $parser->parse($tokenString);
+
+        $this->assertInstanceOf(UnencryptedToken::class, $token);
+        assert($token instanceof UnencryptedToken);
+
+        $this->assertEquals('my-identity', $token->claims()->get('sub'));
+        $this->assertEquals('2022-06-18T10:28:44+00:00', $token->claims()->get('nbf')->format('c'));
+        $this->assertEquals('2022-06-18T10:28:45+00:00', $token->claims()->get('iat')->format('c'));
+        $this->assertEquals('2022-06-18T10:29:15+00:00', $token->claims()->get('exp')->format('c'));
+    }
+}

--- a/service-front/module/Application/test/Unit/Services/OpgApiServiceTest.php
+++ b/service-front/module/Application/test/Unit/Services/OpgApiServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ApplicationTest\Unit\Services;
 
+use Application\Auth\JwtGenerator;
 use Application\Enums\IdMethod;
 use Application\Exceptions\HttpException;
 use Application\Exceptions\OpgApiException;
@@ -13,11 +14,41 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Throwable;
 
 class OpgApiServiceTest extends TestCase
 {
+    private JwtGenerator&MockObject $jwtGenerator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->jwtGenerator = $this->createMock(JwtGenerator::class);
+    }
+
+    public function testAuthorizationHeaderApplied(): void
+    {
+        $client = $this->createMock(Client::class);
+
+        $this->jwtGenerator->expects($this->once())
+            ->method('issueToken')
+            ->willReturn('abcd');
+
+        $client->expects($this->once())
+            ->method('request')
+            ->with($this->anything(), $this->anything(), $this->callback(function (array $options) {
+                return $options['headers']['Authorization'] === 'Bearer abcd';
+            }))
+            ->willReturn(new Response(200, [], ''));
+
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+
+        $this->assertTrue($opgApiService->healthCheck());
+    }
+
     /**
      * @dataProvider detailsData
      * @param class-string<Throwable>|null $expectedException
@@ -31,7 +62,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectException($expectedException);
         }
 
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $response = $opgApiService->getDetailsData('uuid');
 
@@ -182,7 +213,7 @@ class OpgApiServiceTest extends TestCase
      */
     public function testValidateNino(string $nino, Client $client, array $responseData): void
     {
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $response = $opgApiService->checkNinoValidity('uuid', $nino);
 
@@ -225,17 +256,17 @@ class OpgApiServiceTest extends TestCase
                 $successClient,
                 [
                     'result' => 'PASS',
-                    'nino' => $validNino
-                ]
+                    'nino' => $validNino,
+                ],
             ],
             [
                 $invalidNino,
                 $failClient,
                 [
                     'result' => 'NO_MATCH',
-                    'nino' => $validNino
-                ]
-            ]
+                    'nino' => $validNino,
+                ],
+            ],
         ];
     }
 
@@ -248,7 +279,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectException(OpgApiException::class);
         }
 
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $response = $opgApiService->checkDlnValidity($dln);
 
@@ -331,7 +362,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectException(OpgApiException::class);
         }
 
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $response = $opgApiService->checkPassportValidity($passport);
 
@@ -459,7 +490,7 @@ class OpgApiServiceTest extends TestCase
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(['handler' => $handlerStack]);
 
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $response = $opgApiService->getIdCheckQuestions($uuid);
 
@@ -477,7 +508,7 @@ class OpgApiServiceTest extends TestCase
         }
         $uuid = '49895f88-501b-4491-8381-e8aeeaef177d';
 
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $response = $opgApiService->checkIdCheckAnswers($uuid, $answers);
 
@@ -547,7 +578,7 @@ class OpgApiServiceTest extends TestCase
         if ($exception) {
             $this->expectException(OpgApiException::class);
         }
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $response = $opgApiService->createCase(
             $postData['FirstName'],
@@ -636,7 +667,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $opgApiService->updateIdMethod($data['uuid'], $data['method']);
     }
@@ -688,7 +719,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $opgApiService->updateCaseSetDocumentComplete($data['uuid'], IdMethod::NationalInsuranceNumber->value);
     }
@@ -740,7 +771,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $opgApiService->updateCaseSetDob($data['uuid'], $data['dob']);
     }
@@ -793,7 +824,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $opgApiService->updateCaseProgress($data['uuid'], $data);
     }
@@ -841,7 +872,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectException(OpgApiException::class);
         }
 
-        $opgApiService = new OpgApiService($client);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
 
         $this->assertEquals($expected, $opgApiService->getServiceAvailability());
     }
@@ -907,7 +938,7 @@ class OpgApiServiceTest extends TestCase
 
         $client = new Client(['handler' => HandlerStack::create($successMock)]);
 
-        $sut = new OpgApiService($client);
+        $sut = new OpgApiService($client, $this->jwtGenerator);
 
         $sut->abandonFlow('case-uuid');
     }
@@ -925,7 +956,7 @@ class OpgApiServiceTest extends TestCase
 
         $client = new Client(['handler' => HandlerStack::create($successMock)]);
 
-        $sut = new OpgApiService($client);
+        $sut = new OpgApiService($client, $this->jwtGenerator);
 
         $this->expectException(OpgApiException::class);
 

--- a/service-front/module/Application/test/Unit/Services/SiriusApiServicePactTest.php
+++ b/service-front/module/Application/test/Unit/Services/SiriusApiServicePactTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ApplicationTest\Unit\Services;
 
+use Application\Auth\JwtGenerator;
 use Application\Enums\SiriusDocument;
 use Application\Services\SiriusApiService;
 use GuzzleHttp\Client;
@@ -39,9 +40,11 @@ class SiriusApiServicePactTest extends TestCase
     private function buildService(): SiriusApiService
     {
         $this->loggerMock = $this->createMock(LoggerInterface::class);
+        $jwtGeneratorMock = $this->createMock(JwtGenerator::class);
+
         $client = new Client(['base_uri' => $this->pactConfig->getBaseUri()]);
 
-        return new SiriusApiService($client, $this->loggerMock);
+        return new SiriusApiService($client, $this->loggerMock, $jwtGeneratorMock);
     }
 
     public function tearDown(): void
@@ -197,7 +200,7 @@ trailer\n<<\n/Root 3 0 R\n>>\n
         $details["lpas"][0] = "M-1234-9876-4567";
         $details["vouchingFor"] = [
             "firstName" => 'Jane',
-            "lastName" => 'Doe'
+            "lastName" => 'Doe',
         ];
 
         $suffix = base64_encode($this->getMinimalPdf());
@@ -238,8 +241,9 @@ trailer\n<<\n/Root 3 0 R\n>>\n
 
         $client = new Client(['base_uri' => $this->pactConfig->getBaseUri()]);
         $loggerMock = $this->createMock(LoggerInterface::class);
+        $jwtGeneratorMock = $this->createMock(JwtGenerator::class);
 
-        $service = new class ($client, $loggerMock) extends SiriusApiService {
+        $service = new class ($client, $loggerMock, $jwtGeneratorMock) extends SiriusApiService {
             /**
              * @return Lpa
              */
@@ -256,7 +260,7 @@ trailer\n<<\n/Root 3 0 R\n>>\n
                         'addressLine1' => 'Vandammeplein 8',
                         'town' => 'Hernezele',
                         'country' => 'BE',
-                    ]
+                    ],
                 ], 'opg.poas.lpastore' => null];
             }
         };

--- a/service-front/module/Application/test/Unit/Services/SiriusApiServiceTest.php
+++ b/service-front/module/Application/test/Unit/Services/SiriusApiServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ApplicationTest\Unit\Services;
 
+use Application\Auth\JwtGenerator;
 use Application\Exceptions\PostcodeInvalidException;
 use Application\Exceptions\UidInvalidException;
 use Application\Services\SiriusApiService;
@@ -27,8 +28,9 @@ class SiriusApiServiceTest extends TestCase
     {
         $clientMock = $this->createMock(Client::class);
         $loggerMock = $this->createMock(LoggerInterface::class);
+        $jwtGeneratorMock = $this->createMock(JwtGenerator::class);
 
-        $sut = new SiriusApiService($clientMock, $loggerMock);
+        $sut = new SiriusApiService($clientMock, $loggerMock, $jwtGeneratorMock);
 
         $request = new Request();
         $headers = $request->getHeaders();
@@ -43,7 +45,13 @@ class SiriusApiServiceTest extends TestCase
                     'Cookie' => 'mycookie=1; XSRF-TOKEN=abcd',
                     'X-XSRF-TOKEN' => 'abcd',
                 ],
-            ]);
+            ])
+            ->willReturn(new Response(200, [], '{"email":"myemail@opg.example"}'));
+
+        $jwtGeneratorMock
+            ->expects($this->once())
+            ->method('setSub')
+            ->with('myemail@opg.example');
 
         $ret = $sut->checkAuth($request);
         $this->assertTrue($ret);
@@ -53,8 +61,9 @@ class SiriusApiServiceTest extends TestCase
     {
         $clientMock = $this->createMock(Client::class);
         $loggerMock = $this->createMock(LoggerInterface::class);
+        $jwtGeneratorMock = $this->createMock(JwtGenerator::class);
 
-        $sut = new SiriusApiService($clientMock, $loggerMock);
+        $sut = new SiriusApiService($clientMock, $loggerMock, $jwtGeneratorMock);
 
 
         $request = new Request();
@@ -83,8 +92,9 @@ class SiriusApiServiceTest extends TestCase
     {
         $clientMock = $this->createMock(Client::class);
         $loggerMock = $this->createMock(LoggerInterface::class);
+        $jwtGeneratorMock = $this->createMock(JwtGenerator::class);
 
-        $sut = new SiriusApiService($clientMock, $loggerMock);
+        $sut = new SiriusApiService($clientMock, $loggerMock, $jwtGeneratorMock);
 
 
         $request = new Request();
@@ -123,8 +133,9 @@ class SiriusApiServiceTest extends TestCase
     {
         $clientMock = $this->createMock(Client::class);
         $loggerMock = $this->createMock(LoggerInterface::class);
+        $jwtGeneratorMock = $this->createMock(JwtGenerator::class);
 
-        $sut = new SiriusApiService($clientMock, $loggerMock);
+        $sut = new SiriusApiService($clientMock, $loggerMock, $jwtGeneratorMock);
 
 
         $request = new Request();
@@ -156,8 +167,9 @@ class SiriusApiServiceTest extends TestCase
     {
         $clientMock = $this->createMock(Client::class);
         $loggerMock = $this->createMock(LoggerInterface::class);
+        $jwtGeneratorMock = $this->createMock(JwtGenerator::class);
 
-        $sut = new SiriusApiService($clientMock, $loggerMock);
+        $sut = new SiriusApiService($clientMock, $loggerMock, $jwtGeneratorMock);
 
 
         $request = new Request();
@@ -189,8 +201,9 @@ class SiriusApiServiceTest extends TestCase
 
         $clientMock = $this->createMock(Client::class);
         $loggerMock = $this->createMock(LoggerInterface::class);
+        $jwtGeneratorMock = $this->createMock(JwtGenerator::class);
 
-        $sut = new SiriusApiService($clientMock, $loggerMock);
+        $sut = new SiriusApiService($clientMock, $loggerMock, $jwtGeneratorMock);
 
         $request = new Request();
         $headers = $request->getHeaders();
@@ -219,8 +232,9 @@ class SiriusApiServiceTest extends TestCase
 
         $clientMock = $this->createMock(Client::class);
         $loggerMock = $this->createMock(LoggerInterface::class);
+        $jwtGeneratorMock = $this->createMock(JwtGenerator::class);
 
-        $sut = new SiriusApiService($clientMock, $loggerMock);
+        $sut = new SiriusApiService($clientMock, $loggerMock, $jwtGeneratorMock);
 
         $request = new Request();
 
@@ -236,9 +250,9 @@ class SiriusApiServiceTest extends TestCase
                 'opg.poas.sirius' => [
                     'linkedDigitalLpas' => [
                         ['uId' => 'M-0000-0000-0001'],
-                        ['uId' => 'M-0000-0000-0002']
-                    ]
-                ]
+                        ['uId' => 'M-0000-0000-0002'],
+                    ],
+                ],
             ],
             'M-0000-0000-0001' => ['lpa1'],
             'M-0000-0000-0002' => ['lpa2'],
@@ -246,8 +260,9 @@ class SiriusApiServiceTest extends TestCase
 
         $clientMock = $this->createMock(Client::class);
         $loggerMock = $this->createMock(LoggerInterface::class);
+        $jwtGeneratorMock = $this->createMock(JwtGenerator::class);
 
-        $sut = new SiriusApiService($clientMock, $loggerMock);
+        $sut = new SiriusApiService($clientMock, $loggerMock, $jwtGeneratorMock);
 
         $request = new Request();
         $headers = $request->getHeaders();
@@ -282,7 +297,8 @@ class SiriusApiServiceTest extends TestCase
     {
         $clientMock = $this->createMock(Client::class);
         $loggerMock = $this->createMock(LoggerInterface::class);
-        $sut = new SiriusApiService($clientMock, $loggerMock);
+        $jwtGeneratorMock = $this->createMock(JwtGenerator::class);
+        $sut = new SiriusApiService($clientMock, $loggerMock, $jwtGeneratorMock);
 
         $request = new Request();
         $uid = 'M-0000-0000-0000';
@@ -294,7 +310,7 @@ class SiriusApiServiceTest extends TestCase
             'opg.poas.sirius' => [
                 'id' => 1234,
                 'donor' => ['id' => 5678],
-            ]
+            ],
         ];
 
         /** @psalm-suppress PossiblyFalseArgument */
@@ -315,7 +331,7 @@ class SiriusApiServiceTest extends TestCase
                         'name' => $name,
                         'type' => $type,
                         'description' => $description,
-                    ]
+                    ],
                 ]
             )
             ->willReturn(new Response(201));

--- a/service-front/phpunit.xml
+++ b/service-front/phpunit.xml
@@ -33,6 +33,7 @@
 
     <php>
         <env name="API_BASE_URI" value="API_BASE_URI" />
+        <env name="API_JWT_KEY" value="API_JWT_KEY" />
         <env name="SIRIUS_BASE_URL" value="SIRIUS_BASE_URL" />
         <env name="SIRIUS_PUBLIC_URL" value="SIRIUS_PUBLIC_URL" />
         <env name="DISABLE_AUTH_LISTENER" value="1"/>


### PR DESCRIPTION
## Purpose

Ensure calls to the API are authenticated so a rogue actor could not make requests.

Fixes ID-390 #minor

## Approach

When making calls to the internal API, generate a JWT and attach it as an Authorization header.

We need to scrape the user's email address of their auth-to-Sirius request to use as the `sub`.

Verify that token in the API, ensuring it has all required fields and they have valid values.

## Learning

I prefer this method of bypassing the listener, I'll backport it to the frontend too (rather than using an env var)

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * N/A
