### PR TITLE
Add Content-Security-Policy header to requests

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -16,6 +16,8 @@ server {
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
+    add_header Content-Security-Policy "default-src 'self'; form-action 'self'; frame-ancestors 'none'";
+    add_header Cache-Control "no-store";
 
     # Simple health check for nginx containers
     location /nginx-health {


### PR DESCRIPTION
## Purpose

Fixes ID-573 #patch

## Approach

Start with basic default-src header

## Learning

Zap also wanted us to add "form-action" and "frame-ancestors" because they don't inherit from default-src

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
