### PR TITLE
Always return redirects immediately

### DIFF
--- a/service-front/module/Application/src/Controller/PostOfficeFlowController.php
+++ b/service-front/module/Application/src/Controller/PostOfficeFlowController.php
@@ -89,7 +89,7 @@ class PostOfficeFlowController extends AbstractActionController
                                 break;
                         }
                     }
-                    $this->redirect()->toRoute($redirect, ['uuid' => $uuid]);
+                    return $this->redirect()->toRoute($redirect, ['uuid' => $uuid]);
                 }
             }
         }

--- a/service-front/module/Application/src/Controller/VouchingFlowController.php
+++ b/service-front/module/Application/src/Controller/VouchingFlowController.php
@@ -224,7 +224,7 @@ class VouchingFlowController extends AbstractActionController
         }
         $view->setVariable(
             'warning_message',
-            'By continuing, you confirm that the person vouching is more than 100 years old. 
+            'By continuing, you confirm that the person vouching is more than 100 years old.
             If not, please change the date.'
         );
         return $view->setTemplate('application/pages/confirm_dob');
@@ -452,13 +452,13 @@ class VouchingFlowController extends AbstractActionController
         return $this->redirect()->toRoute($this->routes["confirm_donors"], ['uuid' => $uuid]);
     }
 
-    public function identityCheckPassedAction(): ViewModel
+    public function identityCheckPassedAction(): ViewModel|Response
     {
         $uuid = $this->params()->fromRoute("uuid");
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 
         if ($this->getRequest()->isPost()) {
-            $this->redirect()->toUrl($this->siriusPublicUrl . '/lpa/frontend/lpa/' . $detailsData["lpas"][0]);
+            return $this->redirect()->toUrl($this->siriusPublicUrl . '/lpa/frontend/lpa/' . $detailsData["lpas"][0]);
         }
 
         $view = new ViewModel();


### PR DESCRIPTION
## Purpose

Otherwise the code after the redirect is still executed, and we return a body payload to the browser that is unnecessary.

Fixes ID-574 #patch

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
