### PR TITLE
Add `trace_id` and `request` to log messages

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -14,7 +14,22 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    map "$time_iso8601 # $msec" $time_iso8601_ms {
+      "~(^[^+]+)(\+[0-9:]+) # \d+\.(\d+)$" $1.$3$2;
+    }
+
+    map "$http_x_amzn_trace_id" $trace_id {
+      "~Root=1-([0-9A-Fa-f]{8})-([0-9A-Fa-f]{24})(;|$)" $1$2;
+    }
+
     log_format main escape=json '{'
+                             '"time": "$time_iso8601_ms", '
+                             '"level": "INFO", '
+                             '"trace_id": "$trace_id", '
+                             '"request": {'
+                               '"method": "$request_method", '
+                               '"path": "$request_uri"'
+                             '},'
                              '"timestamp_msec": "$msec", '
                              '"remote_addr": "$remote_addr", '
                              '"real_ip": "$http_x_real_ip", '
@@ -25,7 +40,6 @@ http {
                              '"request_time": $request_time, '
                              '"request_uri": "$request_uri", '
                              '"status": $status, '
-                             '"request": "$request", '
                              '"request_method": "$request_method", '
                              '"http_referrer": "$http_referer", '
                              '"http_user_agent": "$http_user_agent", '

--- a/service-api/Dockerfile
+++ b/service-api/Dockerfile
@@ -42,7 +42,7 @@ ENV OTEL_SERVICE_NAME=api.lpa-identity-check.local
 ENV OTEL_TRACES_EXPORTER=none
 ENV OTEL_METRICS_EXPORTER=none
 ENV OTEL_LOGS_EXPORTER=none
-ENV OTEL_PROPAGATORS=xray
+ENV OTEL_PROPAGATORS=tracecontext,xray
 
 COPY --chown=www-data:www-data --chmod=755 --from=composer /usr/bin/composer /usr/bin/
 COPY --chown=www-data:www-data --chmod=755 composer.json composer.json

--- a/service-api/module/Application/src/Factories/LoggerFactory.php
+++ b/service-api/module/Application/src/Factories/LoggerFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Factories;
 
 use Application\Services\Logging\OpgFormatter;
+use Laminas\Http\Request as HttpRequest;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 use Monolog\Handler\StreamHandler;
@@ -21,8 +22,15 @@ class LoggerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LoggerInterface
     {
+        $formatter = new OpgFormatter();
+
+        $request = $container->get('Request');
+        if ($request instanceof HttpRequest) {
+            $formatter->setRequest($request);
+        }
+
         $streamHandler = new StreamHandler('php://stderr', LogLevel::INFO);
-        $streamHandler->setFormatter(new OpgFormatter());
+        $streamHandler->setFormatter($formatter);
 
         return new Logger('opg-paper-identity/api', [$streamHandler]);
     }

--- a/service-api/module/Application/src/Services/Logging/OpgFormatter.php
+++ b/service-api/module/Application/src/Services/Logging/OpgFormatter.php
@@ -4,11 +4,19 @@ declare(strict_types=1);
 
 namespace Application\Services\Logging;
 
+use Laminas\Http\Request as HttpRequest;
 use Monolog\Formatter\NormalizerFormatter;
 use Monolog\LogRecord;
 
 class OpgFormatter extends NormalizerFormatter
 {
+    private ?HttpRequest $request = null;
+
+    public function setRequest(?HttpRequest $request): void
+    {
+        $this->request = $request;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -22,6 +30,18 @@ class OpgFormatter extends NormalizerFormatter
             'msg' => $original['message'],
             'service_name' => $original['channel'],
         ];
+
+        if (isset($original['context']['trace_id'])) {
+            $record['trace_id'] = $original['context']['trace_id'];
+            unset($original['context']['trace_id']);
+        }
+
+        if ($this->request !== null) {
+            $record['request'] = [
+                'method' => $this->request->getMethod(),
+                'path' => $this->request->getUri()->getPath(),
+            ];
+        }
 
         unset($original['datetime']);
         unset($original['level_name']);

--- a/service-api/module/Telemetry/Instrumentation/Logger.php
+++ b/service-api/module/Telemetry/Instrumentation/Logger.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telemetry\Instrumentation;
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\Context\Context;
+use Psr\Log\LoggerInterface;
+use Telemetry\Propagation\LoggingFormatter;
+
+use function OpenTelemetry\Instrumentation\hook;
+
+class Logger
+{
+    public static function register(): void
+    {
+        $pre = static function (LoggerInterface $object, array $params, string $class, string $function): array {
+            $context = Context::getCurrent();
+            $span = Span::fromContext($context)->getContext();
+
+            if (! $span->isValid()) {
+                return $params;
+            }
+
+            $ctxIdx = $function === 'log' ? 2 : 1;
+            $params[$ctxIdx] ??= [];
+
+            Globals::propagator()->inject($params[$ctxIdx], LoggingFormatter::instance());
+
+            return $params;
+        };
+
+        foreach (['log', 'emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'] as $f) {
+            /** @psalm-suppress UnusedFunctionCall */
+            hook(class: LoggerInterface::class, function: $f, pre: $pre);
+        }
+    }
+}

--- a/service-api/module/Telemetry/Propagation/LoggingFormatter.php
+++ b/service-api/module/Telemetry/Propagation/LoggingFormatter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telemetry\Propagation;
+
+use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
+use OpenTelemetry\Context\Propagation\PropagationSetterInterface;
+
+class LoggingFormatter implements PropagationSetterInterface
+{
+    public const LOG_ENTRY_FIELD_NAME = 'trace_id';
+
+    public static function instance(): self
+    {
+        static $instance;
+
+        return $instance ??= new self();
+    }
+
+    /**
+     * @param mixed $carrier
+     */
+    public function set(&$carrier, string $key, string $value): void
+    {
+        if (strtolower($key) === TraceContextPropagator::TRACEPARENT) {
+            $carrier[self::LOG_ENTRY_FIELD_NAME] = explode('-', $value)[1];
+        }
+    }
+}

--- a/service-api/module/Telemetry/Tracer.php
+++ b/service-api/module/Telemetry/Tracer.php
@@ -13,6 +13,7 @@ use OpenTelemetry\SDK\Registry;
 use Telemetry\Instrumentation\Aws;
 use Telemetry\Instrumentation\Guzzle;
 use Telemetry\Instrumentation\Laminas;
+use Telemetry\Instrumentation\Logger;
 use Telemetry\Instrumentation\Soap;
 
 /**
@@ -28,6 +29,7 @@ class Tracer
         Aws::register();
         Guzzle::register();
         Laminas::register();
+        Logger::register();
         Soap::register();
     }
 }

--- a/service-front/Dockerfile
+++ b/service-front/Dockerfile
@@ -46,7 +46,7 @@ ENV OTEL_SERVICE_NAME=front.lpa-identity-check.local
 ENV OTEL_TRACES_EXPORTER=none
 ENV OTEL_METRICS_EXPORTER=none
 ENV OTEL_LOGS_EXPORTER=none
-ENV OTEL_PROPAGATORS=xray
+ENV OTEL_PROPAGATORS=tracecontext,xray
 
 COPY --chown=www-data:www-data --chmod=755  --from=composer /usr/bin/composer /usr/bin/
 COPY --chown=www-data:www-data --chmod=755  composer.json composer.json

--- a/service-front/module/Application/src/Factories/LoggerFactory.php
+++ b/service-front/module/Application/src/Factories/LoggerFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Application\Factories;
 
 use Application\Services\Logging\OpgFormatter;
+use Laminas\Http\Request as HttpRequest;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
 use Monolog\Handler\StreamHandler;
@@ -21,8 +22,15 @@ class LoggerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null): LoggerInterface
     {
+        $formatter = new OpgFormatter();
+
+        $request = $container->get('Request');
+        if ($request instanceof HttpRequest) {
+            $formatter->setRequest($request);
+        }
+
         $streamHandler = new StreamHandler('php://stderr', LogLevel::INFO);
-        $streamHandler->setFormatter(new OpgFormatter());
+        $streamHandler->setFormatter($formatter);
 
         return new Logger('opg-paper-identity/front', [$streamHandler]);
     }

--- a/service-front/module/Application/src/Services/Logging/OpgFormatter.php
+++ b/service-front/module/Application/src/Services/Logging/OpgFormatter.php
@@ -4,11 +4,19 @@ declare(strict_types=1);
 
 namespace Application\Services\Logging;
 
+use Laminas\Http\Request as HttpRequest;
 use Monolog\Formatter\NormalizerFormatter;
 use Monolog\LogRecord;
 
 class OpgFormatter extends NormalizerFormatter
 {
+    private ?HttpRequest $request = null;
+
+    public function setRequest(?HttpRequest $request): void
+    {
+        $this->request = $request;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -22,6 +30,18 @@ class OpgFormatter extends NormalizerFormatter
             'msg' => $original['message'],
             'service_name' => $original['channel'],
         ];
+
+        if (isset($original['context']['trace_id'])) {
+            $record['trace_id'] = $original['context']['trace_id'];
+            unset($original['context']['trace_id']);
+        }
+
+        if ($this->request !== null) {
+            $record['request'] = [
+                'method' => $this->request->getMethod(),
+                'path' => $this->request->getUri()->getPath(),
+            ];
+        }
 
         unset($original['datetime']);
         unset($original['level_name']);

--- a/service-front/module/Telemetry/Instrumentation/Logger.php
+++ b/service-front/module/Telemetry/Instrumentation/Logger.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telemetry\Instrumentation;
+
+use OpenTelemetry\API\Globals;
+use OpenTelemetry\API\Trace\Span;
+use OpenTelemetry\Context\Context;
+use Psr\Log\LoggerInterface;
+use Telemetry\Propagation\LoggingFormatter;
+
+use function OpenTelemetry\Instrumentation\hook;
+
+class Logger
+{
+    public static function register(): void
+    {
+        $pre = static function (LoggerInterface $object, array $params, string $class, string $function): array {
+            $context = Context::getCurrent();
+            $span = Span::fromContext($context)->getContext();
+
+            if (! $span->isValid()) {
+                return $params;
+            }
+
+            $ctxIdx = $function === 'log' ? 2 : 1;
+            $params[$ctxIdx] ??= [];
+
+            Globals::propagator()->inject($params[$ctxIdx], LoggingFormatter::instance());
+
+            return $params;
+        };
+
+        foreach (['log', 'emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'] as $f) {
+            /** @psalm-suppress UnusedFunctionCall */
+            hook(class: LoggerInterface::class, function: $f, pre: $pre);
+        }
+    }
+}

--- a/service-front/module/Telemetry/Propagation/LoggingFormatter.php
+++ b/service-front/module/Telemetry/Propagation/LoggingFormatter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telemetry\Propagation;
+
+use OpenTelemetry\API\Trace\Propagation\TraceContextPropagator;
+use OpenTelemetry\Context\Propagation\PropagationSetterInterface;
+
+class LoggingFormatter implements PropagationSetterInterface
+{
+    public const LOG_ENTRY_FIELD_NAME = 'trace_id';
+
+    public static function instance(): self
+    {
+        static $instance;
+
+        return $instance ??= new self();
+    }
+
+    /**
+     * @param mixed $carrier
+     */
+    public function set(&$carrier, string $key, string $value): void
+    {
+        if (strtolower($key) === TraceContextPropagator::TRACEPARENT) {
+            $carrier[self::LOG_ENTRY_FIELD_NAME] = explode('-', $value)[1];
+        }
+    }
+}

--- a/service-front/module/Telemetry/Tracer.php
+++ b/service-front/module/Telemetry/Tracer.php
@@ -12,6 +12,7 @@ use OpenTelemetry\Aws\Xray\Propagator;
 use OpenTelemetry\SDK\Registry;
 use Telemetry\Instrumentation\Guzzle;
 use Telemetry\Instrumentation\Laminas;
+use Telemetry\Instrumentation\Logger;
 
 /**
  * @psalm-suppress UnusedClass
@@ -25,5 +26,6 @@ class Tracer
 
         Guzzle::register();
         Laminas::register();
+        Logger::register();
     }
 }


### PR DESCRIPTION
## Purpose

Log messages in nginx and PHP now include the `trace_id` and `request` fields.

Fixes ID-562 #patch

## Approach

An OpenTelemetry hook injects the information from the tracecontext propagator. Request information is retrieved from the `Request` service.

The OpgFormatter needed modifications to populate request info and make `trace_id` a top-level field.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * N/A
* [x] I have run an accessibility tool against the changes and applied fixes
  * N/A
* [x] The team have tested these changes
  * I tested on a popup environment
