### PR TITLE
Security improvements

### DIFF
--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -1079,9 +1079,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/service-api/Dockerfile
+++ b/service-api/Dockerfile
@@ -73,6 +73,10 @@ CMD ["php-fpm"]
 FROM app AS development
 USER "root"
 RUN apk add git
+
+# Update vulnerable packages
+RUN apk upgrade --no-cache sqlite-libs
+
 RUN pecl install pcov && docker-php-ext-enable pcov;
 
 RUN composer install --prefer-dist --no-interaction --no-scripts &&\

--- a/service-front/Dockerfile
+++ b/service-front/Dockerfile
@@ -78,6 +78,10 @@ STOPSIGNAL SIGQUIT
 FROM app AS development
 USER "root"
 RUN apk add git
+
+# Update vulnerable packages
+RUN apk upgrade --no-cache sqlite-libs
+
 RUN pecl install pcov && docker-php-ext-enable pcov;
 
 RUN composer install --prefer-dist --no-interaction --no-scripts &&\


### PR DESCRIPTION
- ~~Use the distroless version of imposter, which comes with far fewer dependencies and 231 fewer vulnerabilities~~
  - Fewer vulns, but more crits, and has trouble starting up in GHA
- Bump cross-spawn to non-vulnerable version
- Update sqlite to non-vulnerable version

#patch