### PR TITLE
id-560 + id-561 log errors only when needed #minor

### DIFF
--- a/service-api/module/Application/src/Controller/Factory/HealthcheckControllerFactory.php
+++ b/service-api/module/Application/src/Controller/Factory/HealthcheckControllerFactory.php
@@ -7,13 +7,8 @@ namespace Application\Controller\Factory;
 use Application\Aws\SsmHandler;
 use Application\Controller\HealthcheckController;
 use Application\Fixtures\DataQueryHandler;
-use Application\Services\Logging\OpgFormatter;
 use Laminas\ServiceManager\Factory\FactoryInterface;
-use Monolog\Handler\StreamHandler;
-use Monolog\Logger;
 use Psr\Container\ContainerInterface;
-use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 
 class HealthcheckControllerFactory implements FactoryInterface
 {
@@ -30,7 +25,6 @@ class HealthcheckControllerFactory implements FactoryInterface
         /** @var string $siriusBaseUrl */
         $ssmRouteAvailability = getenv("AWS_SSM_SERVICE_AVAILABILITY");
         $config = $container->get('Config');
-        $logger = $container->get(LoggerInterface::class);
         /**
          * @psalm-suppress PossiblyFalseArgument
          */
@@ -38,7 +32,6 @@ class HealthcheckControllerFactory implements FactoryInterface
             $container->get(DataQueryHandler::class),
             $container->get(SsmHandler::class),
             $ssmRouteAvailability,
-            $logger,
             $config
         );
     }

--- a/service-api/module/Application/src/Controller/HealthcheckController.php
+++ b/service-api/module/Application/src/Controller/HealthcheckController.php
@@ -9,7 +9,6 @@ use Application\Fixtures\DataQueryHandler;
 use Application\View\JsonModel;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
-use Psr\Log\LoggerInterface;
 use Application\Helpers\RouteAvailabilityHelper;
 use Application\Model\Entity\Problem;
 use Exception;
@@ -26,7 +25,6 @@ class HealthcheckController extends AbstractActionController
         private readonly DataQueryHandler $dataQuery,
         private readonly SsmHandler $ssmHandler,
         private string $ssmRouteAvailability,
-        private readonly LoggerInterface $logger,
         private array $config = []
     ) {
     }

--- a/service-api/module/Application/src/Controller/KbvController.php
+++ b/service-api/module/Application/src/Controller/KbvController.php
@@ -42,12 +42,8 @@ class KbvController extends AbstractActionController
         $case = $this->dataQueryHandler->getCaseByUUID($uuid);
 
         if (is_null($case?->caseProgress?->docCheck) || $case?->caseProgress?->docCheck?->state === false) {
-            $this->getResponse()->setStatusCode(Response::STATUS_CODE_200);
-            $response = [
-                "error" => "Document checks incomplete or unable to locate case",
-            ];
-
-            return new JsonModel($response);
+            $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
+            return new JsonModel(new Problem('Document checks incomplete or unable to locate case'));
         }
 
         $this->getResponse()->setStatusCode(Response::STATUS_CODE_200);

--- a/service-api/module/Application/src/Controller/YotiController.php
+++ b/service-api/module/Application/src/Controller/YotiController.php
@@ -76,12 +76,8 @@ class YotiController extends AbstractActionController
         $response = [];
 
         if (! $case) {
-            $status = Response::STATUS_CODE_400;
-            $this->getResponse()->setStatusCode($status);
-            $response = [
-                "error" => "Unable to locate case"
-            ];
-            return new JsonModel($response);
+            $this->getResponse()->setStatusCode(Response::STATUS_CODE_400);
+            return new JsonModel(new Problem("Unable to locate case"));
         }
 
         //start Yoti process

--- a/service-api/module/Application/src/DWP/DwpApi/DwpApiService.php
+++ b/service-api/module/Application/src/DWP/DwpApi/DwpApiService.php
@@ -60,30 +60,25 @@ class DwpApiService
     {
         $this->correlationUuid = $correlationUuid;
 
-        try {
-            $matchResponseDTO = $this->makeCitizenMatchRequest(
-                new CitizenRequestDTO($caseData, $nino)
-            );
+        $matchResponseDTO = $this->makeCitizenMatchRequest(
+            new CitizenRequestDTO($caseData, $nino)
+        );
 
-            if ($matchResponseDTO instanceof AmbiguousCitizenResponseDTO) {
-                return "MULTIPLE_MATCH";
-            }
-
-            $detailsResponseDTO = $this->makeCitizenDetailsRequest(
-                new DetailsRequestDTO($matchResponseDTO->id()),
-                $nino
-            );
-
-            return $this->compareRecords(
-                $caseData,
-                $detailsResponseDTO,
-                $matchResponseDTO,
-                $nino
-            ) ? "PASS" : "NO_MATCH";
-        } catch (\Exception $exception) {
-            $this->logger->error('DwpApiException: ' . "($this->correlationUuid) " . $exception->getMessage());
-            throw new DwpApiException($exception->getMessage());
+        if ($matchResponseDTO instanceof AmbiguousCitizenResponseDTO) {
+            return "MULTIPLE_MATCH";
         }
+
+        $detailsResponseDTO = $this->makeCitizenDetailsRequest(
+            new DetailsRequestDTO($matchResponseDTO->id()),
+            $nino
+        );
+
+        return $this->compareRecords(
+            $caseData,
+            $detailsResponseDTO,
+            $matchResponseDTO,
+            $nino
+        ) ? "PASS" : "NO_MATCH";
     }
 
     public function compareRecords(
@@ -163,6 +158,7 @@ class DwpApiService
                 throw $clientException;
             }
         } catch (\Exception $exception) {
+            $this->logger->error('DwpApiException : ' . $exception->getMessage(), ['exception' => $exception]);
             throw new DwpApiException($exception->getMessage());
         }
         return new CitizenResponseDTO(
@@ -201,7 +197,7 @@ class DwpApiService
                 throw $clientException;
             }
         } catch (\Exception $exception) {
-            $this->logger->error("DwpApiException: " . $exception->getMessage());
+            $this->logger->error('DwpApiException : ' . $exception->getMessage(), ['exception' => $exception]);
             throw new DwpApiException("DwpApiException: " . $exception->getMessage());
         }
 

--- a/service-api/module/Application/src/Experian/Crosscore/FraudApi/FraudApiService.php
+++ b/service-api/module/Application/src/Experian/Crosscore/FraudApi/FraudApiService.php
@@ -92,6 +92,7 @@ class FraudApiService
                 throw $clientException;
             }
         } catch (\Exception $exception) {
+            $this->logger->error('FraudApiException: ' . $exception->getMessage(), ['exception' => $exception]);
             throw new FraudApiException($exception->getMessage());
         }
     }

--- a/service-api/module/Application/src/Fixtures/DataWriteHandler.php
+++ b/service-api/module/Application/src/Fixtures/DataWriteHandler.php
@@ -41,6 +41,7 @@ class DataWriteHandler
             $this->logger->error('Unable to save data [' . $e->getMessage() . '] to ' . $this->tableName, [
                 'data' => $item,
             ]);
+            throw $e;
         }
     }
 
@@ -108,6 +109,7 @@ class DataWriteHandler
             $this->logger->error('Unable to update data [' . $e->getMessage() . '] for case' . $uuid, [
                 'data' => [$attrName => $attrValue],
             ]);
+            throw $e;
         }
     }
 
@@ -146,6 +148,7 @@ class DataWriteHandler
             ]);
         } catch (AwsException $e) {
             $this->logger->error('Unable to set ttl [' . $e->getMessage() . '] for case' . $uuid);
+            throw $e;
         }
     }
 
@@ -171,6 +174,7 @@ class DataWriteHandler
             ]);
         } catch (AwsException $e) {
             $this->logger->error('Unable to unset ttl [' . $e->getMessage() . '] for case' . $uuid);
+            throw $e;
         }
     }
 }

--- a/service-api/module/Application/test/ApplicationTest/Feature/Controller/KbvControllerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Feature/Controller/KbvControllerTest.php
@@ -216,7 +216,7 @@ class KbvControllerTest extends TestCase
      */
     public function testKBVQuestionsWithUnVerifiedDocsCase(): void
     {
-        $response = '{"error":"Document checks incomplete or unable to locate case"}';
+        $response = '{"title":"Document checks incomplete or unable to locate case"}';
         $caseData = CaseData::fromArray([
             'personType' => '',
             'claimedIdentity' => [
@@ -233,7 +233,7 @@ class KbvControllerTest extends TestCase
             ->willReturn($caseData);
 
         $this->dispatch('/cases/a9bc8ab8-389c-4367-8a9b-762ab3050999/kbv-questions', 'GET');
-        $this->assertResponseStatusCode(200);
+        $this->assertResponseStatusCode(400);
         $this->assertEquals($response, $this->getResponse()->getContent());
         $this->assertModuleName('application');
         $this->assertControllerName(KbvController::class);

--- a/service-api/module/Application/test/ApplicationTest/Unit/Fixtures/DataWriteHandlerTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Unit/Fixtures/DataWriteHandlerTest.php
@@ -135,6 +135,8 @@ class DataWriteHandlerTest extends TestCase
                 })
             );
 
+        $this->expectException(AwsException::class);
+
         // Call the insertData method with test data
         $this->sut->insertUpdateData($caseData);
     }

--- a/service-front/module/Application/src/Controller/CPFlowController.php
+++ b/service-front/module/Application/src/Controller/CPFlowController.php
@@ -23,7 +23,6 @@ use Application\Services\SiriusApiService;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
-use Psr\Log\LoggerInterface;
 use Application\Controller\Trait\DobOver100WarningTrait;
 use Application\Enums\DocumentType;
 use Application\Enums\IdRoute;
@@ -45,7 +44,6 @@ class CPFlowController extends AbstractActionController
         private readonly array $config,
         private readonly string $siriusPublicUrl,
         private readonly SiriusDataProcessorHelper $siriusDataProcessorHelper,
-        private readonly LoggerInterface $logger
     ) {
     }
 
@@ -53,11 +51,7 @@ class CPFlowController extends AbstractActionController
     {
         $uuid = $this->params()->fromRoute("uuid");
 
-        try {
-            $this->siriusDataProcessorHelper->updatePaperIdCaseFromSirius($uuid, $this->getRequest());
-        } catch (\Exception $e) {
-            $this->logger->error('Unable to update paper id case from Sirius', ['exception' => $e]);
-        }
+        $this->siriusDataProcessorHelper->updatePaperIdCaseFromSirius($uuid, $this->getRequest());
 
         $optionsdata = $this->config['opg_settings']['identity_documents'];
         $detailsData = $this->opgApiService->getDetailsData($uuid);

--- a/service-front/module/Application/src/Controller/DonorFlowController.php
+++ b/service-front/module/Application/src/Controller/DonorFlowController.php
@@ -16,7 +16,6 @@ use Application\Helpers\SiriusDataProcessorHelper;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
-use Psr\Log\LoggerInterface;
 
 class DonorFlowController extends AbstractActionController
 {
@@ -29,7 +28,6 @@ class DonorFlowController extends AbstractActionController
         private readonly string $siriusPublicUrl,
         private readonly SendSiriusNoteHelper $sendNoteHelper,
         private readonly SiriusDataProcessorHelper $siriusDataProcessorHelper,
-        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -74,11 +72,7 @@ class DonorFlowController extends AbstractActionController
     {
         $uuid = $this->params()->fromRoute("uuid");
 
-        try {
-            $this->siriusDataProcessorHelper->updatePaperIdCaseFromSirius($uuid, $this->getRequest());
-        } catch (\Exception $e) {
-            $this->logger->error('Unable to update paper id case from Sirius', ['exception' => $e]);
-        }
+        $this->siriusDataProcessorHelper->updatePaperIdCaseFromSirius($uuid, $this->getRequest());
 
         $detailsData = $this->opgApiService->getDetailsData($uuid);
 

--- a/service-front/module/Application/src/Controller/Factory/CPFlowControllerFactory.php
+++ b/service-front/module/Application/src/Controller/Factory/CPFlowControllerFactory.php
@@ -13,7 +13,6 @@ use Application\Helpers\SiriusDataProcessorHelper;
 use Application\Services\SiriusApiService;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
-use Psr\Log\LoggerInterface;
 
 class CPFlowControllerFactory implements FactoryInterface
 {
@@ -37,7 +36,6 @@ class CPFlowControllerFactory implements FactoryInterface
             $config,
             $siriusPublicUrl,
             $container->get(SiriusDataProcessorHelper::class),
-            $container->get(LoggerInterface::class)
         );
     }
 }

--- a/service-front/module/Application/src/Controller/Factory/DonorFlowControllerFactory.php
+++ b/service-front/module/Application/src/Controller/Factory/DonorFlowControllerFactory.php
@@ -10,7 +10,6 @@ use Application\Helpers\SendSiriusNoteHelper;
 use Application\Helpers\SiriusDataProcessorHelper;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
-use Psr\Log\LoggerInterface;
 
 class DonorFlowControllerFactory implements FactoryInterface
 {
@@ -29,7 +28,6 @@ class DonorFlowControllerFactory implements FactoryInterface
             $siriusPublicUrl,
             $container->get(SendSiriusNoteHelper::class),
             $container->get(SiriusDataProcessorHelper::class),
-            $container->get(LoggerInterface::class)
         );
     }
 }

--- a/service-front/module/Application/src/Factories/OpgApiServiceFactory.php
+++ b/service-front/module/Application/src/Factories/OpgApiServiceFactory.php
@@ -9,6 +9,7 @@ use Application\Services\OpgApiService;
 use GuzzleHttp\Client;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 class OpgApiServiceFactory implements FactoryInterface
@@ -30,6 +31,7 @@ class OpgApiServiceFactory implements FactoryInterface
         return new OpgApiService(
             $guzzleClient,
             $container->get(JwtGenerator::class),
+            $container->get(LoggerInterface::class),
         );
     }
 }

--- a/service-front/module/Application/src/Helpers/SiriusDataProcessorHelper.php
+++ b/service-front/module/Application/src/Helpers/SiriusDataProcessorHelper.php
@@ -62,13 +62,22 @@ class SiriusDataProcessorHelper
         }
         $processedData = $this->processLpaResponse($detailsData['personType'], $lpaData);
 
-        $this->opgApiService->updateCaseSetName(
-            $uuid,
-            $processedData['first_name'],
-            $processedData['last_name']
-        );
-        $this->opgApiService->updateCaseSetDob($uuid, $processedData['dob']);
-        $this->opgApiService->updateCaseAddress($uuid, $processedData['address']);
+        if (
+            $processedData['first_name'] !== $detailsData['firstName'] ||
+            $processedData['last_name'] !== $detailsData['lastName']
+        ) {
+                $this->opgApiService->updateCaseSetName(
+                    $uuid,
+                    $processedData['first_name'],
+                    $processedData['last_name']
+                );
+        }
+        if ($processedData['dob'] !== $detailsData['dob']) {
+            $this->opgApiService->updateCaseSetDob($uuid, $processedData['dob']);
+        }
+        if ($processedData['address'] !== $detailsData['address']) {
+            $this->opgApiService->updateCaseAddress($uuid, $processedData['address']);
+        }
     }
 
     /**

--- a/service-front/module/Application/src/Services/OpgApiService.php
+++ b/service-front/module/Application/src/Services/OpgApiService.php
@@ -12,6 +12,7 @@ use Application\Helpers\AddressProcessorHelper;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use Laminas\Http\Response;
+use Psr\Log\LoggerInterface;
 
 /**
  * @psalm-import-type CaseData from OpgApiServiceInterface
@@ -34,6 +35,7 @@ class OpgApiService implements OpgApiServiceInterface
     public function __construct(
         private Client $httpClient,
         private JwtGenerator $jwtGenerator,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -71,6 +73,7 @@ class OpgApiService implements OpgApiServiceInterface
 
             return $this->responseData;
         } catch (\GuzzleHttp\Exception\BadResponseException $exception) {
+            $this->logger->error('opg api request failed', ['exception' => $exception]);
             throw new OpgApiException($exception->getMessage(), 0, $exception);
         }
     }

--- a/service-front/module/Application/test/Unit/Services/OpgApiServiceTest.php
+++ b/service-front/module/Application/test/Unit/Services/OpgApiServiceTest.php
@@ -18,17 +18,20 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 class OpgApiServiceTest extends TestCase
 {
     private JwtGenerator&MockObject $jwtGenerator;
+    private LoggerInterface&MockObject $mockLogger;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->jwtGenerator = $this->createMock(JwtGenerator::class);
+        $this->mockLogger = $this->createMock(LoggerInterface::class);
     }
 
     public function testAuthorizationHeaderApplied(): void
@@ -46,7 +49,7 @@ class OpgApiServiceTest extends TestCase
             }))
             ->willReturn(new Response(200, [], ''));
 
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $this->assertTrue($opgApiService->healthCheck());
     }
@@ -64,7 +67,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectException($expectedException);
         }
 
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $response = $opgApiService->getDetailsData('uuid');
 
@@ -213,7 +216,7 @@ class OpgApiServiceTest extends TestCase
     #[DataProvider('ninoData')]
     public function testValidateNino(string $nino, Client $client, array $responseData): void
     {
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $response = $opgApiService->checkNinoValidity('uuid', $nino);
 
@@ -277,7 +280,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectException(OpgApiException::class);
         }
 
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $response = $opgApiService->checkDlnValidity($dln);
 
@@ -358,7 +361,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectException(OpgApiException::class);
         }
 
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $response = $opgApiService->checkPassportValidity($passport);
 
@@ -486,7 +489,7 @@ class OpgApiServiceTest extends TestCase
         $handlerStack = HandlerStack::create($mock);
         $client = new Client(['handler' => $handlerStack]);
 
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $response = $opgApiService->getIdCheckQuestions($uuid);
 
@@ -501,7 +504,7 @@ class OpgApiServiceTest extends TestCase
         }
         $uuid = '49895f88-501b-4491-8381-e8aeeaef177d';
 
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $response = $opgApiService->checkIdCheckAnswers($uuid, $answers);
 
@@ -569,7 +572,7 @@ class OpgApiServiceTest extends TestCase
         if ($exception) {
             $this->expectException(OpgApiException::class);
         }
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $response = $opgApiService->createCase(
             $postData['FirstName'],
@@ -655,7 +658,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $opgApiService->updateIdMethod($data['uuid'], $data['method']);
     }
@@ -704,7 +707,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $opgApiService->updateCaseSetDocumentComplete($data['uuid'], DocumentType::NationalInsuranceNumber->value);
     }
@@ -753,7 +756,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $opgApiService->updateCaseSetDob($data['uuid'], $data['dob']);
     }
@@ -803,7 +806,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectNotToPerformAssertions();
         }
 
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $opgApiService->updateCaseProgress($data['uuid'], $data);
     }
@@ -849,7 +852,7 @@ class OpgApiServiceTest extends TestCase
             $this->expectException(OpgApiException::class);
         }
 
-        $opgApiService = new OpgApiService($client, $this->jwtGenerator);
+        $opgApiService = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $this->assertEquals($expected, $opgApiService->getRouteAvailability());
     }
@@ -915,7 +918,7 @@ class OpgApiServiceTest extends TestCase
 
         $client = new Client(['handler' => HandlerStack::create($successMock)]);
 
-        $sut = new OpgApiService($client, $this->jwtGenerator);
+        $sut = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $sut->sendIdentityCheck('case-uuid');
     }
@@ -933,7 +936,7 @@ class OpgApiServiceTest extends TestCase
 
         $client = new Client(['handler' => HandlerStack::create($successMock)]);
 
-        $sut = new OpgApiService($client, $this->jwtGenerator);
+        $sut = new OpgApiService($client, $this->jwtGenerator, $this->mockLogger);
 
         $this->expectException(OpgApiException::class);
 


### PR DESCRIPTION
## Purpose

ensure we log errors wherever we would want to be alerted to an issue and not for any expected behaviour in the application.

fixes [id-560](https://opgtransform.atlassian.net/browse/ID-560) and [id-561](https://opgtransform.atlassian.net/browse/ID-561)

## Approach

there is a combination of added error logs where they were missing and removing some which were logging behaviour we would expect in the application.

I have also removed a number of redundant try/catch blocks which were obscuring the true cause of errors and resulting in multiple error logs which would make debugging more difficult.
## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] I have run an accessibility tool against the changes and applied fixes
* [ ] The team have tested these changes
