### PR TITLE
Make mock secret values clearer

### DIFF
--- a/docker/dwp/data/tokenResponse.json
+++ b/docker/dwp/data/tokenResponse.json
@@ -1,5 +1,5 @@
 {
   "expires_in": "3600",
   "token_type": "Bearer",
-  "access_token": "583rue8vj4597834ygg892038wiff7d81uf9v538h4rje82901"
+  "access_token": "mock-access-token"
 }

--- a/docker/experian-crosscore-auth/openapi.yml
+++ b/docker/experian-crosscore-auth/openapi.yml
@@ -49,16 +49,12 @@ paths:
               properties:
                 username:
                   type: string
-                  example: "SYSTEM.UATAPI@publicguardian.com"
                 password:
                   type: string
-                  example: "58ehgvb74uh8812uw89i329gijv9ekk"
                 client_id:
                   type: string
-                  example: "o0mdjhtybndu73jertoijsogfkidk3i"
                 client_secret:
                   type: string
-                  example: "1ffg85rb7du83wvre"
       responses:
         200:
           description: "HTTP Status 200"

--- a/service-api/module/Application/test/ApplicationTest/Unit/Services/Experian/AuthApi/ExperianCrosscoreAuthApiServiceTest.php
+++ b/service-api/module/Application/test/ApplicationTest/Unit/Services/Experian/AuthApi/ExperianCrosscoreAuthApiServiceTest.php
@@ -92,15 +92,8 @@ class ExperianCrosscoreAuthApiServiceTest extends TestCase
             "issued_at" => "1724856638",
             "expires_in" => "1800",
             "token_type" => "Bearer",
-            "access_token" => "eyJraWQiOiJJSmpTMXJQQjdJODBHWjgybmNsSlZPQkF3V3B3ZTVYblNKZUdSZHdpc
-                EY5IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJTWVNURU0uVUFUQVBJQHB1YmxpY2d1YXJ
-                kaWFuLmNvbSIsIkVtYWlsIjpudWxsLCJGaXJzdE5hbWUiOm51bGwsImlzcyI6IkVYUEVSSUFOIiwiTGFzdE5hb
-                WUiOm51bGwsImV4cCI6MTcyNDg1ODQzOCwiaWF0IjoxNzI0ODU2NjM4LCJqdGkiOiIzNGJlODg5Ny1kYmYyLT
-                QwOTctODZlMS02NTQ3ZDc1YzAwYmMifQ.oqA5HWPnyssBrfCLxQqJmFHEXpD_bRV6hX3hu5DzI4azqrGnFn_q
-                27j6nsd6Urh3DdpAaETCgB3Nn074yTAKX02qIfNROpEiof8oWRbXZp89JJcI7by4mSyiXzhhzO_lTDRFnYIumz
-                RlEgwyGdtq16-5GSw3m7dN0TUReXnSZdSNB1uuCkwVM9VwdPrJhAF8Uq6ECG9rft2WUXuguUA08s5bdFIAOJfOm
-                6uFu5oskaCg79IO3ASdkVlOpWm8-csNCWeXLyq0ShV3jjO7XfZATiVL7zCxZF-ec",
-            "refresh_token" => "6Vx6yOMXQwupKggjueitrwotnFA0o3"
+            "access_token" => "mock-access-token",
+            "refresh_token" => "mock-refresh-token"
         ];
 
         $successMock = new MockHandler([


### PR DESCRIPTION
Having realistic-looking mock secrets means they can easily be mistaken for real secrets and confuse our tooling.

Replace the values to make it clearer that they're mocks.

In the case of `experian-crosscore-auth/openapi.yml`, remove the example values completely because they're unnecessary.

#patch
