### PR TITLE
Id 586 deploy paper id mock

### DIFF
--- a/.github/workflows/build-scan.yml
+++ b/.github/workflows/build-scan.yml
@@ -63,6 +63,9 @@ jobs:
             - ecr_repository: paper-identity/experian-iiq-mock
               service_name: experian-iiq-mock
               context: docker/experian-iiq
+            - ecr_repository: paper-identity/hmpo-mock
+              service_name: hmpo-mock
+              context: docker/hmpo
             - ecr_repository: paper-identity/yoti-mock
               service_name: yoti-mock
               context: docker/yoti
@@ -97,6 +100,8 @@ jobs:
             service_name: experian-crosscore-mock
           - ecr_repository: paper-identity/experian-iiq-mock
             service_name: experian-iiq-mock
+          - ecr_repository: paper-identity/hmpo-mock
+            service_name: hmpo-mock
           - ecr_repository: paper-identity/yoti-mock
             service_name: yoti-mock
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,10 @@ jobs:
           path: /tmp/images
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          name: hmpo-mock-multi-arch
+          path: /tmp/images
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
           name: yoti-mock-multi-arch
           path: /tmp/images
       - name: Load Images
@@ -151,6 +155,7 @@ jobs:
           docker load -i /tmp/images/experian-crosscore-auth-mock-multi-arch.tar
           docker load -i /tmp/images/experian-crosscore-mock-multi-arch.tar
           docker load -i /tmp/images/experian-iiq-mock-multi-arch.tar
+          docker load -i /tmp/images/hmpo-mock-multi-arch.tar
           docker load -i /tmp/images/yoti-mock-multi-arch.tar
       - name: Run cypress
         run: make cypress

--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -67,6 +67,8 @@ jobs:
             service_name: experian-crosscore-mock
           - ecr_repository: paper-identity/experian-iiq-mock
             service_name: experian-iiq-mock
+          - ecr_repository: paper-identity/hmpo-mock
+            service_name: hmpo-mock
           - ecr_repository: paper-identity/yoti-mock
             service_name: yoti-mock
     steps:

--- a/docker/hmpo/data/notAuthorisedResponse.json
+++ b/docker/hmpo/data/notAuthorisedResponse.json
@@ -1,0 +1,13 @@
+{
+  "errors": [
+    {
+      "message": "Action Requested not allowed by current profile",
+      "locations": [],
+      "extensions": {
+        "errorCode": "DVAD_400_001",
+        "classification": "INTERNAL_ERROR"
+      }
+    }
+  ],
+  "data": {}
+}

--- a/docker/hmpo/hmpo-config.yaml
+++ b/docker/hmpo/hmpo-config.yaml
@@ -14,11 +14,21 @@ resources:
   - path: "/auth/token"
     method: post
     requestBody:
-      jsonPath: $.clientId
       value: client-id
+      operator: contains
     response:
       statusCode: 200
       file: data/tokenResponse.json
+
+  - path: "/graphql"
+    method: post
+    requestHeaders:
+      Authorization:
+        value: Bearer some-big-long-bearer-token
+        operator: NotEqualTo
+    response:
+      statusCode: 400
+      file: data/notAuthorisedResponse.json
 
   - path: "/graphql"
     method: post

--- a/docker/hmpo/openapi.yml
+++ b/docker/hmpo/openapi.yml
@@ -30,7 +30,7 @@ paths:
         - $ref: '#/components/parameters/User-Agent'
       requestBody:
         content:
-          application/json:
+          application/x-www-form-urlencoded:
             schema:
               type: object
               required:

--- a/service-api/docker-compose.env
+++ b/service-api/docker-compose.env
@@ -32,3 +32,5 @@ EXPERIAN_CROSSCORE_AUTH_URL=http://experian-crosscore-auth-mock:8080/oauth2/expe
 # DWP_SUPPRESS_CERTIFICATE flag is used to prevent mounting of certificate in dev environments
 DWP_SUPPRESS_CERTIFICATE=true
 DWP_BASE_URI=http://dwp-mock:8080
+
+HMPO_BASE_URI=http://hmpo-mock:8080


### PR DESCRIPTION
## Purpose

deploy new hmpo-mock service in github pipeline

Fixes [ID-586](https://opgtransform.atlassian.net/browse/ID-586)

## Approach

i unashamedly copied from what was their for the  dwp-mock


[ID-586]: https://opgtransform.atlassian.net/browse/ID-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ